### PR TITLE
feat: add flow export / import for cross-machine task and project handoff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 # running the CLI with a relative FLOW_ROOT.
 /projects/
 /tasks/
+docs/superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,3 +100,19 @@ flow/
 - `hookCommand` in `internal/app/skill.go` is the exact string matched in `~/.claude/settings.json`. Changing it orphans existing installations.
 - `do.go` uses `openConcurrentDB` with `busy_timeout(30000)` and `_txlock=immediate` for safe concurrent access.
 - Tests override `$HOME` — any code that calls `os.UserHomeDir()` will see the test's temp dir, not the real home.
+
+## Export / import security
+
+`flow export` masks sensitive values in all markdown files (briefs, updates, KB files) before they enter the bundle. The masking uses deterministic regex patterns defined in `internal/app/sanitize.go`:
+
+- Connection strings: `proto://user:pass@host` → `proto://<sensitive>@host`
+- PEM private key blocks → `<sensitive>`
+- AWS access key IDs (`AKIA…`) → `<sensitive>`
+- GitHub personal access tokens (`ghp_…`, `github_pat_…`) → `<sensitive>`
+- Slack tokens (`xoxb-…`) → `<sensitive>`
+- Stripe API keys (`sk_live_…`) → `<sensitive>`
+- Generic `key = <value>` assignments for field names like `password`, `api_key`, `secret`, `token`, `client_secret` (value must be ≥12 chars) → `key = <sensitive>`
+
+A warning is printed to stderr for each file where masking occurred. JSON metadata files (`task.json`, `project.json`, `manifest.json`) are NOT scanned — their fields are controlled by the export schema which never captures session IDs, session timestamps, or credentials.
+
+To add or update patterns, edit `sensitiveRules` in `internal/app/sanitize.go`.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -49,6 +49,10 @@ func Run(args []string) int {
 		return cmdTranscript(rest)
 	case "hook":
 		return cmdHook(rest)
+	case "export":
+		return cmdExport(rest)
+	case "import":
+		return cmdImport(rest)
 	case "-h", "--help", "help":
 		printUsage()
 		return 0
@@ -96,5 +100,11 @@ Workdirs:
   flow workdir list
   flow workdir add <path> [--name <nickname>]
   flow workdir remove <path>
-  flow workdir scan [<root>] [--add]`)
+  flow workdir scan [<root>] [--add]
+
+Share / handoff:
+  flow export task    <slug> [--output <dir>]
+  flow export project <slug> [--output <dir>]
+  flow export all           [--output <dir>]
+  flow import <file> [--force]`)
 }

--- a/internal/app/export.go
+++ b/internal/app/export.go
@@ -292,10 +292,116 @@ func writeTaskBundle(task *flowdb.Task, root, outDir, home string) (string, erro
 	return outPath, nil
 }
 
-// Stubs for Tasks 2 and 3 — replaced in subsequent tasks.
-func exportProjectCmd(_ []string) int {
-	fmt.Fprintln(os.Stderr, "error: export project not yet implemented")
-	return 1
+func exportProjectCmd(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "error: export project requires a slug")
+		return 2
+	}
+	slug := args[0]
+	fs := flagSet("export project")
+	outDir := fs.String("output", ".", "directory to write bundle")
+	if err := fs.Parse(args[1:]); err != nil {
+		return 2
+	}
+
+	dbPath, err := flowDBPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	db, err := flowdb.OpenDB(dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: open db: %v\n", err)
+		return 1
+	}
+	defer db.Close()
+
+	project, err := flowdb.GetProject(db, slug)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: project %q not found\n", slug)
+		return 1
+	}
+
+	tasks, err := flowdb.ListTasks(db, flowdb.TaskFilter{Project: slug, IncludeArchived: true})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: list tasks: %v\n", err)
+		return 1
+	}
+
+	root, err := flowRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	home, _ := os.UserHomeDir()
+
+	outPath, err := writeProjectBundle(project, tasks, root, *outDir, home)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	fmt.Println(outPath)
+	return 0
+}
+
+func writeProjectBundle(project *flowdb.Project, tasks []*flowdb.Task, root, outDir, home string) (string, error) {
+	filename := fmt.Sprintf("flow-project-%s-%s.tar", project.Slug, time.Now().Format("20060102"))
+	ok := false
+	outPath, tw, cleanup, err := newTarFile(outDir, filename)
+	if err != nil {
+		return "", err
+	}
+	defer cleanup(&ok)
+
+	mf := bundleManifest{Type: "project", Version: "1", ExportedAt: time.Now().Format(time.RFC3339), Slug: project.Slug}
+	b, err := marshalJSON(mf)
+	if err != nil {
+		return "", fmt.Errorf("marshal manifest: %w", err)
+	}
+	if err := addBytesToTar(tw, "manifest.json", b); err != nil {
+		return "", fmt.Errorf("write manifest: %w", err)
+	}
+
+	bp := projectFromDB(project, home)
+	b, err = marshalJSON(bp)
+	if err != nil {
+		return "", fmt.Errorf("marshal project: %w", err)
+	}
+	if err := addBytesToTar(tw, "project.json", b); err != nil {
+		return "", fmt.Errorf("write project.json: %w", err)
+	}
+
+	projRoot := filepath.Join(root, "projects", project.Slug)
+	briefPath := filepath.Join(projRoot, "brief.md")
+	if err := addFileToTar(tw, briefPath, "brief.md"); err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("project brief.md: %w", err)
+	}
+	if err := addUpdatesTar(tw, filepath.Join(projRoot, "updates"), "."); err != nil {
+		return "", err
+	}
+
+	for _, task := range tasks {
+		prefix := path.Join("tasks", task.Slug)
+		bt := taskFromDB(task, home)
+		b, err := marshalJSON(bt)
+		if err != nil {
+			return "", fmt.Errorf("marshal task %s: %w", task.Slug, err)
+		}
+		if err := addBytesToTar(tw, path.Join(prefix, "task.json"), b); err != nil {
+			return "", fmt.Errorf("write task %s: %w", task.Slug, err)
+		}
+		taskBriefPath := filepath.Join(root, "tasks", task.Slug, "brief.md")
+		if err := addFileToTar(tw, taskBriefPath, path.Join(prefix, "brief.md")); err != nil && !os.IsNotExist(err) {
+			return "", fmt.Errorf("task %s brief.md: %w", task.Slug, err)
+		}
+		taskUpdatesDir := filepath.Join(root, "tasks", task.Slug, "updates")
+		if err := addUpdatesTar(tw, taskUpdatesDir, prefix); err != nil {
+			return "", err
+		}
+	}
+
+	ok = true
+	return outPath, nil
 }
 
 func exportAllCmd(_ []string) int {

--- a/internal/app/export.go
+++ b/internal/app/export.go
@@ -1,0 +1,295 @@
+package app
+
+import (
+	"archive/tar"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"flow/internal/flowdb"
+)
+
+// ---------- bundle types ----------
+
+type bundleManifest struct {
+	Type       string `json:"type"`
+	Version    string `json:"version"`
+	ExportedAt string `json:"exported_at"`
+	Slug       string `json:"slug,omitempty"`
+}
+
+type bundledTask struct {
+	Slug            string `json:"slug"`
+	Name            string `json:"name"`
+	ProjectSlug     string `json:"project_slug,omitempty"`
+	Status          string `json:"status"`
+	Priority        string `json:"priority"`
+	WorkDir         string `json:"work_dir"`
+	WaitingOn       string `json:"waiting_on,omitempty"`
+	DueDate         string `json:"due_date,omitempty"`
+	StatusChangedAt string `json:"status_changed_at,omitempty"`
+	CreatedAt       string `json:"created_at"`
+	UpdatedAt       string `json:"updated_at"`
+	ArchivedAt      string `json:"archived_at,omitempty"`
+}
+
+type bundledProject struct {
+	Slug       string `json:"slug"`
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+	Priority   string `json:"priority"`
+	WorkDir    string `json:"work_dir"`
+	CreatedAt  string `json:"created_at"`
+	UpdatedAt  string `json:"updated_at"`
+	ArchivedAt string `json:"archived_at,omitempty"`
+}
+
+// ---------- home-dir masking ----------
+
+func maskHome(p, home string) string {
+	if home != "" && strings.HasPrefix(p, home) {
+		return "<HOME>" + p[len(home):]
+	}
+	return p
+}
+
+func expandHome(p, home string) string {
+	if strings.HasPrefix(p, "<HOME>") {
+		return home + p[len("<HOME>"):]
+	}
+	return p
+}
+
+// ---------- DB → bundle conversions ----------
+
+func taskFromDB(t *flowdb.Task, home string) bundledTask {
+	return bundledTask{
+		Slug:            t.Slug,
+		Name:            t.Name,
+		ProjectSlug:     t.ProjectSlug.String,
+		Status:          t.Status,
+		Priority:        t.Priority,
+		WorkDir:         maskHome(t.WorkDir, home),
+		WaitingOn:       t.WaitingOn.String,
+		DueDate:         t.DueDate.String,
+		StatusChangedAt: t.StatusChangedAt.String,
+		CreatedAt:       t.CreatedAt,
+		UpdatedAt:       t.UpdatedAt,
+		ArchivedAt:      t.ArchivedAt.String,
+	}
+}
+
+func projectFromDB(p *flowdb.Project, home string) bundledProject {
+	return bundledProject{
+		Slug:       p.Slug,
+		Name:       p.Name,
+		Status:     p.Status,
+		Priority:   p.Priority,
+		WorkDir:    maskHome(p.WorkDir, home),
+		CreatedAt:  p.CreatedAt,
+		UpdatedAt:  p.UpdatedAt,
+		ArchivedAt: p.ArchivedAt.String,
+	}
+}
+
+// ---------- tar write helpers ----------
+
+func addBytesToTar(tw *tar.Writer, name string, data []byte) error {
+	hdr := &tar.Header{Name: name, Mode: 0o644, Size: int64(len(data))}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return err
+	}
+	_, err := tw.Write(data)
+	return err
+}
+
+func addFileToTar(tw *tar.Writer, srcPath, tarName string) error {
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		return err
+	}
+	return addBytesToTar(tw, tarName, data)
+}
+
+// addUpdatesTar writes all *.md files from updatesDir into tw under tarPrefix/updates/.
+func addUpdatesTar(tw *tar.Writer, updatesDir, tarPrefix string) error {
+	entries, _ := os.ReadDir(updatesDir)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		src := filepath.Join(updatesDir, e.Name())
+		dst := path.Join(tarPrefix, "updates", e.Name())
+		if err := addFileToTar(tw, src, dst); err != nil {
+			return fmt.Errorf("add update %s: %w", e.Name(), err)
+		}
+	}
+	return nil
+}
+
+func marshalJSON(v any) ([]byte, error) {
+	return json.MarshalIndent(v, "", "  ")
+}
+
+// newTarFile creates the output file and returns (outPath, tarWriter, cleanup, error).
+// cleanup(&ok) must be deferred: it closes writers and removes the file if ok==false.
+func newTarFile(outDir, filename string) (string, *tar.Writer, func(ok *bool), error) {
+	outPath, err := filepath.Abs(filepath.Join(outDir, filename))
+	if err != nil {
+		return "", nil, nil, err
+	}
+	f, err := os.Create(outPath)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("create bundle: %w", err)
+	}
+	tw := tar.NewWriter(f)
+	cleanup := func(ok *bool) {
+		tw.Close()
+		f.Close()
+		if !*ok {
+			os.Remove(outPath)
+		}
+	}
+	return outPath, tw, cleanup, nil
+}
+
+// readTarFiles reads all entries of a tar into a name→data map.
+// Used by import.go (same package).
+func readTarFiles(tarPath string) (map[string][]byte, error) {
+	f, err := os.Open(tarPath)
+	if err != nil {
+		return nil, fmt.Errorf("open bundle: %w", err)
+	}
+	defer f.Close()
+	tr := tar.NewReader(f)
+	files := map[string][]byte{}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("tar: %w", err)
+		}
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			return nil, err
+		}
+		files[hdr.Name] = data
+	}
+	return files, nil
+}
+
+// ---------- dispatcher ----------
+
+func cmdExport(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "error: export requires 'task', 'project', or 'all'")
+		return 2
+	}
+	switch args[0] {
+	case "task":
+		return exportTaskCmd(args[1:])
+	case "project":
+		return exportProjectCmd(args[1:])
+	case "all":
+		return exportAllCmd(args[1:])
+	}
+	fmt.Fprintf(os.Stderr, "error: unknown export subcommand %q (want task|project|all)\n", args[0])
+	return 2
+}
+
+// ---------- flow export task ----------
+
+func exportTaskCmd(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "error: export task requires a slug")
+		return 2
+	}
+	slug := args[0]
+	fs := flagSet("export task")
+	outDir := fs.String("output", ".", "directory to write bundle")
+	if err := fs.Parse(args[1:]); err != nil {
+		return 2
+	}
+
+	dbPath, err := flowDBPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	db, err := flowdb.OpenDB(dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: open db: %v\n", err)
+		return 1
+	}
+	defer db.Close()
+
+	task, rc := findTask(db, slug)
+	if rc != 0 {
+		return rc
+	}
+	root, err := flowRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	home, _ := os.UserHomeDir()
+
+	outPath, err := writeTaskBundle(task, root, *outDir, home)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	fmt.Println(outPath)
+	return 0
+}
+
+func writeTaskBundle(task *flowdb.Task, root, outDir, home string) (string, error) {
+	filename := fmt.Sprintf("flow-task-%s-%s.tar", task.Slug, time.Now().Format("20060102"))
+	ok := false
+	outPath, tw, cleanup, err := newTarFile(outDir, filename)
+	if err != nil {
+		return "", err
+	}
+	defer cleanup(&ok)
+
+	mf := bundleManifest{Type: "task", Version: "1", ExportedAt: time.Now().Format(time.RFC3339), Slug: task.Slug}
+	if b, err := marshalJSON(mf); err == nil {
+		addBytesToTar(tw, "manifest.json", b)
+	}
+
+	bt := taskFromDB(task, home)
+	if b, err := marshalJSON(bt); err == nil {
+		addBytesToTar(tw, "task.json", b)
+	}
+
+	briefPath := filepath.Join(root, "tasks", task.Slug, "brief.md")
+	if err := addFileToTar(tw, briefPath, "brief.md"); err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("brief.md: %w", err)
+	}
+
+	updatesDir := filepath.Join(root, "tasks", task.Slug, "updates")
+	if err := addUpdatesTar(tw, updatesDir, "."); err != nil {
+		return "", err
+	}
+
+	ok = true
+	return outPath, nil
+}
+
+// Stubs for Tasks 2 and 3 — replaced in subsequent tasks.
+func exportProjectCmd(_ []string) int {
+	fmt.Fprintln(os.Stderr, "error: export project not yet implemented")
+	return 1
+}
+
+func exportAllCmd(_ []string) int {
+	fmt.Fprintln(os.Stderr, "error: export all not yet implemented")
+	return 1
+}

--- a/internal/app/export.go
+++ b/internal/app/export.go
@@ -116,6 +116,20 @@ func addFileToTar(tw *tar.Writer, srcPath, tarName string) error {
 	return addBytesToTar(tw, tarName, data)
 }
 
+// addSafeFileToTar reads a text file, masks sensitive content, and writes to tw.
+// It prints a warning to stderr if any masking occurred.
+func addSafeFileToTar(tw *tar.Writer, srcPath, tarName string) error {
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		return err
+	}
+	cleaned, masked := maskSensitiveContent(data)
+	if masked {
+		fmt.Fprintf(os.Stderr, "  ⚠ sensitive content masked in %s\n", tarName)
+	}
+	return addBytesToTar(tw, tarName, cleaned)
+}
+
 // addUpdatesTar writes all *.md files from updatesDir into tw under tarPrefix/updates/.
 func addUpdatesTar(tw *tar.Writer, updatesDir, tarPrefix string) error {
 	entries, _ := os.ReadDir(updatesDir)
@@ -125,7 +139,7 @@ func addUpdatesTar(tw *tar.Writer, updatesDir, tarPrefix string) error {
 		}
 		src := filepath.Join(updatesDir, e.Name())
 		dst := path.Join(tarPrefix, "updates", e.Name())
-		if err := addFileToTar(tw, src, dst); err != nil {
+		if err := addSafeFileToTar(tw, src, dst); err != nil {
 			return fmt.Errorf("add update %s: %w", e.Name(), err)
 		}
 	}
@@ -279,7 +293,7 @@ func writeTaskBundle(task *flowdb.Task, root, outDir, home string) (string, erro
 	}
 
 	briefPath := filepath.Join(root, "tasks", task.Slug, "brief.md")
-	if err := addFileToTar(tw, briefPath, "brief.md"); err != nil && !os.IsNotExist(err) {
+	if err := addSafeFileToTar(tw, briefPath, "brief.md"); err != nil && !os.IsNotExist(err) {
 		return "", fmt.Errorf("brief.md: %w", err)
 	}
 
@@ -373,7 +387,7 @@ func writeProjectBundle(project *flowdb.Project, tasks []*flowdb.Task, root, out
 
 	projRoot := filepath.Join(root, "projects", project.Slug)
 	briefPath := filepath.Join(projRoot, "brief.md")
-	if err := addFileToTar(tw, briefPath, "brief.md"); err != nil && !os.IsNotExist(err) {
+	if err := addSafeFileToTar(tw, briefPath, "brief.md"); err != nil && !os.IsNotExist(err) {
 		return "", fmt.Errorf("project brief.md: %w", err)
 	}
 	if err := addUpdatesTar(tw, filepath.Join(projRoot, "updates"), "."); err != nil {
@@ -391,7 +405,7 @@ func writeProjectBundle(project *flowdb.Project, tasks []*flowdb.Task, root, out
 			return "", fmt.Errorf("write task %s: %w", task.Slug, err)
 		}
 		taskBriefPath := filepath.Join(root, "tasks", task.Slug, "brief.md")
-		if err := addFileToTar(tw, taskBriefPath, path.Join(prefix, "brief.md")); err != nil && !os.IsNotExist(err) {
+		if err := addSafeFileToTar(tw, taskBriefPath, path.Join(prefix, "brief.md")); err != nil && !os.IsNotExist(err) {
 			return "", fmt.Errorf("task %s brief.md: %w", task.Slug, err)
 		}
 		taskUpdatesDir := filepath.Join(root, "tasks", task.Slug, "updates")
@@ -492,7 +506,7 @@ func writeAllBundle(projects []*flowdb.Project, tasks []*flowdb.Task, root, outD
 		}
 		projRoot := filepath.Join(root, "projects", project.Slug)
 		briefPath := filepath.Join(projRoot, "brief.md")
-		if err := addFileToTar(tw, briefPath, path.Join(prefix, "brief.md")); err != nil && !os.IsNotExist(err) {
+		if err := addSafeFileToTar(tw, briefPath, path.Join(prefix, "brief.md")); err != nil && !os.IsNotExist(err) {
 			return "", fmt.Errorf("project %s brief.md: %w", project.Slug, err)
 		}
 		if err := addUpdatesTar(tw, filepath.Join(projRoot, "updates"), prefix); err != nil {
@@ -510,7 +524,7 @@ func writeAllBundle(projects []*flowdb.Project, tasks []*flowdb.Task, root, outD
 				return "", fmt.Errorf("write task %s: %w", task.Slug, err)
 			}
 			taskBriefPath := filepath.Join(root, "tasks", task.Slug, "brief.md")
-			if err := addFileToTar(tw, taskBriefPath, path.Join(taskPrefix, "brief.md")); err != nil && !os.IsNotExist(err) {
+			if err := addSafeFileToTar(tw, taskBriefPath, path.Join(taskPrefix, "brief.md")); err != nil && !os.IsNotExist(err) {
 				return "", fmt.Errorf("task %s brief.md: %w", task.Slug, err)
 			}
 			if err := addUpdatesTar(tw, filepath.Join(root, "tasks", task.Slug, "updates"), taskPrefix); err != nil {
@@ -531,7 +545,7 @@ func writeAllBundle(projects []*flowdb.Project, tasks []*flowdb.Task, root, outD
 			return "", fmt.Errorf("write floating task %s: %w", task.Slug, err)
 		}
 		briefPath := filepath.Join(root, "tasks", task.Slug, "brief.md")
-		if err := addFileToTar(tw, briefPath, path.Join(prefix, "brief.md")); err != nil && !os.IsNotExist(err) {
+		if err := addSafeFileToTar(tw, briefPath, path.Join(prefix, "brief.md")); err != nil && !os.IsNotExist(err) {
 			return "", fmt.Errorf("floating task %s brief.md: %w", task.Slug, err)
 		}
 		if err := addUpdatesTar(tw, filepath.Join(root, "tasks", task.Slug, "updates"), prefix); err != nil {
@@ -542,7 +556,7 @@ func writeAllBundle(projects []*flowdb.Project, tasks []*flowdb.Task, root, outD
 	// KB files.
 	for _, kbFile := range kbFiles(root) {
 		name := filepath.Base(kbFile)
-		if err := addFileToTar(tw, kbFile, path.Join("kb", name)); err != nil && !os.IsNotExist(err) {
+		if err := addSafeFileToTar(tw, kbFile, path.Join("kb", name)); err != nil && !os.IsNotExist(err) {
 			return "", fmt.Errorf("kb/%s: %w", name, err)
 		}
 	}

--- a/internal/app/export.go
+++ b/internal/app/export.go
@@ -404,7 +404,149 @@ func writeProjectBundle(project *flowdb.Project, tasks []*flowdb.Task, root, out
 	return outPath, nil
 }
 
-func exportAllCmd(_ []string) int {
-	fmt.Fprintln(os.Stderr, "error: export all not yet implemented")
-	return 1
+func exportAllCmd(args []string) int {
+	fs := flagSet("export all")
+	outDir := fs.String("output", ".", "directory to write bundle")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	dbPath, err := flowDBPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	db, err := flowdb.OpenDB(dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: open db: %v\n", err)
+		return 1
+	}
+	defer db.Close()
+
+	projects, err := flowdb.ListProjects(db, flowdb.ProjectFilter{IncludeArchived: true})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: list projects: %v\n", err)
+		return 1
+	}
+	tasks, err := flowdb.ListTasks(db, flowdb.TaskFilter{IncludeArchived: true})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: list tasks: %v\n", err)
+		return 1
+	}
+
+	root, err := flowRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	home, _ := os.UserHomeDir()
+
+	outPath, err := writeAllBundle(projects, tasks, root, *outDir, home)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	fmt.Println(outPath)
+	return 0
+}
+
+func writeAllBundle(projects []*flowdb.Project, tasks []*flowdb.Task, root, outDir, home string) (string, error) {
+	filename := fmt.Sprintf("flow-all-%s.tar", time.Now().Format("20060102"))
+	ok := false
+	outPath, tw, cleanup, err := newTarFile(outDir, filename)
+	if err != nil {
+		return "", err
+	}
+	defer cleanup(&ok)
+
+	mf := bundleManifest{Type: "all", Version: "1", ExportedAt: time.Now().Format(time.RFC3339)}
+	b, err := marshalJSON(mf)
+	if err != nil {
+		return "", fmt.Errorf("marshal manifest: %w", err)
+	}
+	if err := addBytesToTar(tw, "manifest.json", b); err != nil {
+		return "", fmt.Errorf("write manifest: %w", err)
+	}
+
+	// Index tasks by project slug for easy lookup.
+	projTasks := map[string][]*flowdb.Task{}
+	var floaters []*flowdb.Task
+	for _, t := range tasks {
+		if t.ProjectSlug.Valid && t.ProjectSlug.String != "" {
+			projTasks[t.ProjectSlug.String] = append(projTasks[t.ProjectSlug.String], t)
+		} else {
+			floaters = append(floaters, t)
+		}
+	}
+
+	// Projects.
+	for _, project := range projects {
+		prefix := path.Join("projects", project.Slug)
+		bp := projectFromDB(project, home)
+		b, err := marshalJSON(bp)
+		if err != nil {
+			return "", fmt.Errorf("marshal project %s: %w", project.Slug, err)
+		}
+		if err := addBytesToTar(tw, path.Join(prefix, "project.json"), b); err != nil {
+			return "", fmt.Errorf("write project %s: %w", project.Slug, err)
+		}
+		projRoot := filepath.Join(root, "projects", project.Slug)
+		briefPath := filepath.Join(projRoot, "brief.md")
+		if err := addFileToTar(tw, briefPath, path.Join(prefix, "brief.md")); err != nil && !os.IsNotExist(err) {
+			return "", fmt.Errorf("project %s brief.md: %w", project.Slug, err)
+		}
+		if err := addUpdatesTar(tw, filepath.Join(projRoot, "updates"), prefix); err != nil {
+			return "", err
+		}
+
+		for _, task := range projTasks[project.Slug] {
+			taskPrefix := path.Join(prefix, "tasks", task.Slug)
+			bt := taskFromDB(task, home)
+			b, err := marshalJSON(bt)
+			if err != nil {
+				return "", fmt.Errorf("marshal task %s: %w", task.Slug, err)
+			}
+			if err := addBytesToTar(tw, path.Join(taskPrefix, "task.json"), b); err != nil {
+				return "", fmt.Errorf("write task %s: %w", task.Slug, err)
+			}
+			taskBriefPath := filepath.Join(root, "tasks", task.Slug, "brief.md")
+			if err := addFileToTar(tw, taskBriefPath, path.Join(taskPrefix, "brief.md")); err != nil && !os.IsNotExist(err) {
+				return "", fmt.Errorf("task %s brief.md: %w", task.Slug, err)
+			}
+			if err := addUpdatesTar(tw, filepath.Join(root, "tasks", task.Slug, "updates"), taskPrefix); err != nil {
+				return "", err
+			}
+		}
+	}
+
+	// Floating tasks (no project).
+	for _, task := range floaters {
+		prefix := path.Join("floating-tasks", task.Slug)
+		bt := taskFromDB(task, home)
+		b, err := marshalJSON(bt)
+		if err != nil {
+			return "", fmt.Errorf("marshal floating task %s: %w", task.Slug, err)
+		}
+		if err := addBytesToTar(tw, path.Join(prefix, "task.json"), b); err != nil {
+			return "", fmt.Errorf("write floating task %s: %w", task.Slug, err)
+		}
+		briefPath := filepath.Join(root, "tasks", task.Slug, "brief.md")
+		if err := addFileToTar(tw, briefPath, path.Join(prefix, "brief.md")); err != nil && !os.IsNotExist(err) {
+			return "", fmt.Errorf("floating task %s brief.md: %w", task.Slug, err)
+		}
+		if err := addUpdatesTar(tw, filepath.Join(root, "tasks", task.Slug, "updates"), prefix); err != nil {
+			return "", err
+		}
+	}
+
+	// KB files.
+	for _, kbFile := range kbFiles(root) {
+		name := filepath.Base(kbFile)
+		if err := addFileToTar(tw, kbFile, path.Join("kb", name)); err != nil && !os.IsNotExist(err) {
+			return "", fmt.Errorf("kb/%s: %w", name, err)
+		}
+	}
+
+	ok = true
+	return outPath, nil
 }

--- a/internal/app/export.go
+++ b/internal/app/export.go
@@ -230,9 +230,10 @@ func exportTaskCmd(args []string) int {
 	}
 	defer db.Close()
 
-	task, rc := findTask(db, slug)
-	if rc != 0 {
-		return rc
+	task, err := flowdb.GetTask(db, slug)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: task %q not found\n", slug)
+		return 1
 	}
 	root, err := flowRoot()
 	if err != nil {
@@ -260,13 +261,21 @@ func writeTaskBundle(task *flowdb.Task, root, outDir, home string) (string, erro
 	defer cleanup(&ok)
 
 	mf := bundleManifest{Type: "task", Version: "1", ExportedAt: time.Now().Format(time.RFC3339), Slug: task.Slug}
-	if b, err := marshalJSON(mf); err == nil {
-		addBytesToTar(tw, "manifest.json", b)
+	b, err := marshalJSON(mf)
+	if err != nil {
+		return "", fmt.Errorf("marshal manifest: %w", err)
+	}
+	if err := addBytesToTar(tw, "manifest.json", b); err != nil {
+		return "", fmt.Errorf("write manifest: %w", err)
 	}
 
 	bt := taskFromDB(task, home)
-	if b, err := marshalJSON(bt); err == nil {
-		addBytesToTar(tw, "task.json", b)
+	b, err = marshalJSON(bt)
+	if err != nil {
+		return "", fmt.Errorf("marshal task: %w", err)
+	}
+	if err := addBytesToTar(tw, "task.json", b); err != nil {
+		return "", fmt.Errorf("write task: %w", err)
 	}
 
 	briefPath := filepath.Join(root, "tasks", task.Slug, "brief.md")

--- a/internal/app/export_test.go
+++ b/internal/app/export_test.go
@@ -354,3 +354,95 @@ func TestExportProjectIncludesArchivedTasks(t *testing.T) {
 
 // Dummy reference to flowdb to avoid unused import if needed.
 var _ = flowdb.TaskFilter{}
+
+// ---------- export all tests ----------
+
+func TestExportAllCreatesBundle(t *testing.T) {
+	root, db := showListEditDB(t)
+	home := root
+	t.Setenv("HOME", home)
+
+	insertProject(t, db, "proj-a", "Project A", filepath.Join(home, "code"), "high")
+	insertTask(t, db, "task-proj", "Proj Task", "backlog", "high", filepath.Join(home, "code"), "proj-a")
+	insertTask(t, db, "floating", "Floating Task", "in-progress", "medium", filepath.Join(home, "other"), nil)
+
+	kbDir := filepath.Join(root, "kb")
+	os.MkdirAll(kbDir, 0o755)
+	os.WriteFile(filepath.Join(kbDir, "user.md"), []byte("# User"), 0o644)
+	os.WriteFile(filepath.Join(kbDir, "org.md"), []byte("# Org"), 0o644)
+
+	outDir := t.TempDir()
+	out := captureStdout(t, func() {
+		if rc := cmdExport([]string{"all", "--output", outDir}); rc != 0 {
+			t.Errorf("rc=%d", rc)
+		}
+	})
+
+	tarPath := strings.TrimSpace(out)
+	if _, err := os.Stat(tarPath); err != nil {
+		t.Fatalf("bundle missing: %v", err)
+	}
+
+	mfData := readTarEntry(t, tarPath, "manifest.json")
+	var mf bundleManifest
+	json.Unmarshal(mfData, &mf)
+	if mf.Type != "all" || mf.Slug != "" {
+		t.Errorf("manifest wrong: %+v", mf)
+	}
+
+	if !tarContains(t, tarPath, "projects/proj-a/project.json") {
+		t.Errorf("projects/proj-a/project.json missing")
+	}
+	if !tarContains(t, tarPath, "projects/proj-a/tasks/task-proj/task.json") {
+		t.Errorf("projects/proj-a/tasks/task-proj/task.json missing")
+	}
+	if !tarContains(t, tarPath, "floating-tasks/floating/task.json") {
+		t.Errorf("floating-tasks/floating/task.json missing")
+	}
+	if !tarContains(t, tarPath, "kb/user.md") {
+		t.Errorf("kb/user.md missing")
+	}
+	if !tarContains(t, tarPath, "kb/org.md") {
+		t.Errorf("kb/org.md missing")
+	}
+}
+
+func TestExportAllNoData(t *testing.T) {
+	_, _ = showListEditDB(t)
+	outDir := t.TempDir()
+	out := captureStdout(t, func() {
+		if rc := cmdExport([]string{"all", "--output", outDir}); rc != 0 {
+			t.Errorf("rc=%d", rc)
+		}
+	})
+	tarPath := strings.TrimSpace(out)
+	if _, err := os.Stat(tarPath); err != nil {
+		t.Errorf("bundle missing even with no data: %v", err)
+	}
+	if !tarContains(t, tarPath, "manifest.json") {
+		t.Errorf("manifest.json missing")
+	}
+}
+
+func TestExportAllIncludesArchivedEntities(t *testing.T) {
+	root, db := showListEditDB(t)
+	insertProject(t, db, "arch-all-proj", "Arch All Project", filepath.Join(root, "x"), "low")
+	insertTask(t, db, "arch-all-task", "Arch All Task", "done", "low", filepath.Join(root, "x"), "arch-all-proj")
+	now := flowdb.NowISO()
+	db.Exec(`UPDATE projects SET archived_at = ? WHERE slug = ?`, now, "arch-all-proj")
+	db.Exec(`UPDATE tasks SET archived_at = ? WHERE slug = ?`, now, "arch-all-task")
+
+	outDir := t.TempDir()
+	out := captureStdout(t, func() {
+		if rc := cmdExport([]string{"all", "--output", outDir}); rc != 0 {
+			t.Errorf("rc=%d", rc)
+		}
+	})
+	tarPath := strings.TrimSpace(out)
+	if !tarContains(t, tarPath, "projects/arch-all-proj/project.json") {
+		t.Errorf("archived project missing from all bundle")
+	}
+	if !tarContains(t, tarPath, "projects/arch-all-proj/tasks/arch-all-task/task.json") {
+		t.Errorf("archived task missing from all bundle")
+	}
+}

--- a/internal/app/export_test.go
+++ b/internal/app/export_test.go
@@ -221,5 +221,111 @@ func TestExpandHome(t *testing.T) {
 	}
 }
 
+// ---------- export project tests ----------
+
+func TestExportProjectCreatesBundle(t *testing.T) {
+	root, db := showListEditDB(t)
+	home := root
+	t.Setenv("HOME", home)
+
+	insertProject(t, db, "my-proj", "My Project", filepath.Join(home, "code", "proj"), "high")
+	insertTask(t, db, "task-a", "Task A", "in-progress", "high", filepath.Join(home, "code", "proj"), "my-proj")
+	insertTask(t, db, "task-b", "Task B", "backlog", "medium", filepath.Join(home, "code", "proj"), "my-proj")
+
+	projDir := filepath.Join(root, "projects", "my-proj")
+	os.MkdirAll(filepath.Join(projDir, "updates"), 0o755)
+	os.WriteFile(filepath.Join(projDir, "brief.md"), []byte("# My Project"), 0o644)
+
+	for _, slug := range []string{"task-a", "task-b"} {
+		td := filepath.Join(root, "tasks", slug)
+		os.MkdirAll(filepath.Join(td, "updates"), 0o755)
+		os.WriteFile(filepath.Join(td, "brief.md"), []byte("# "+slug), 0o644)
+	}
+	os.WriteFile(filepath.Join(root, "tasks", "task-a", "updates", "2026-04-23-note.md"), []byte("note"), 0o644)
+
+	outDir := t.TempDir()
+	out := captureStdout(t, func() {
+		if rc := cmdExport([]string{"project", "my-proj", "--output", outDir}); rc != 0 {
+			t.Errorf("rc=%d", rc)
+		}
+	})
+
+	tarPath := strings.TrimSpace(out)
+	if _, err := os.Stat(tarPath); err != nil {
+		t.Fatalf("bundle missing: %v", err)
+	}
+
+	mfData := readTarEntry(t, tarPath, "manifest.json")
+	var mf bundleManifest
+	json.Unmarshal(mfData, &mf)
+	if mf.Type != "project" || mf.Slug != "my-proj" {
+		t.Errorf("manifest wrong: %+v", mf)
+	}
+
+	pData := readTarEntry(t, tarPath, "project.json")
+	var bp bundledProject
+	json.Unmarshal(pData, &bp)
+	if bp.Slug != "my-proj" {
+		t.Errorf("project.json slug wrong: %q", bp.Slug)
+	}
+	if !strings.HasPrefix(bp.WorkDir, "<HOME>") {
+		t.Errorf("project work_dir not masked: %q", bp.WorkDir)
+	}
+
+	if !tarContains(t, tarPath, "tasks/task-a/task.json") {
+		t.Errorf("tasks/task-a/task.json missing")
+	}
+	if !tarContains(t, tarPath, "tasks/task-b/task.json") {
+		t.Errorf("tasks/task-b/task.json missing")
+	}
+	if !tarContains(t, tarPath, "tasks/task-a/brief.md") {
+		t.Errorf("tasks/task-a/brief.md missing")
+	}
+	if !tarContains(t, tarPath, "tasks/task-a/updates/2026-04-23-note.md") {
+		t.Errorf("task-a update file missing")
+	}
+	if !tarContains(t, tarPath, "brief.md") {
+		t.Errorf("project brief.md missing")
+	}
+}
+
+func TestExportProjectMissingSlugErrors(t *testing.T) {
+	_, _ = showListEditDB(t)
+	if rc := cmdExport([]string{"project"}); rc != 2 {
+		t.Errorf("rc=%d, want 2", rc)
+	}
+}
+
+func TestExportProjectUnknownSlugErrors(t *testing.T) {
+	_, _ = showListEditDB(t)
+	out := captureStdout(t, func() {
+		if rc := cmdExport([]string{"project", "ghost"}); rc != 1 {
+			t.Errorf("expected rc=1")
+		}
+	})
+	if !strings.Contains(out, "ghost") {
+		t.Errorf("expected slug in error; out=%q", out)
+	}
+}
+
+func TestExportProjectNoTasks(t *testing.T) {
+	root, db := showListEditDB(t)
+	insertProject(t, db, "empty-proj", "Empty", filepath.Join(root, "x"), "medium")
+
+	outDir := t.TempDir()
+	out := captureStdout(t, func() {
+		if rc := cmdExport([]string{"project", "empty-proj", "--output", outDir}); rc != 0 {
+			t.Errorf("rc=%d", rc)
+		}
+	})
+	tarPath := strings.TrimSpace(out)
+	if _, err := os.Stat(tarPath); err != nil {
+		t.Errorf("bundle missing: %v", err)
+	}
+	if !tarContains(t, tarPath, "project.json") {
+		t.Errorf("project.json missing")
+	}
+}
+
 // Dummy reference to flowdb to avoid unused import if needed.
 var _ = flowdb.TaskFilter{}

--- a/internal/app/export_test.go
+++ b/internal/app/export_test.go
@@ -327,5 +327,30 @@ func TestExportProjectNoTasks(t *testing.T) {
 	}
 }
 
+func TestExportProjectIncludesArchivedTasks(t *testing.T) {
+	root, db := showListEditDB(t)
+	insertProject(t, db, "arch-proj", "Arch Project", filepath.Join(root, "x"), "medium")
+	insertTask(t, db, "active-t", "Active", "backlog", "medium", filepath.Join(root, "x"), "arch-proj")
+	insertTask(t, db, "archived-t", "Archived", "done", "low", filepath.Join(root, "x"), "arch-proj")
+	// Archive the second task.
+	if _, err := db.Exec(`UPDATE tasks SET archived_at = ? WHERE slug = ?`, flowdb.NowISO(), "archived-t"); err != nil {
+		t.Fatalf("archive task: %v", err)
+	}
+
+	outDir := t.TempDir()
+	out := captureStdout(t, func() {
+		if rc := cmdExport([]string{"project", "arch-proj", "--output", outDir}); rc != 0 {
+			t.Errorf("rc=%d", rc)
+		}
+	})
+	tarPath := strings.TrimSpace(out)
+	if !tarContains(t, tarPath, "tasks/active-t/task.json") {
+		t.Errorf("active task missing from bundle")
+	}
+	if !tarContains(t, tarPath, "tasks/archived-t/task.json") {
+		t.Errorf("archived task missing from bundle — IncludeArchived must be true")
+	}
+}
+
 // Dummy reference to flowdb to avoid unused import if needed.
 var _ = flowdb.TaskFilter{}

--- a/internal/app/export_test.go
+++ b/internal/app/export_test.go
@@ -1,0 +1,225 @@
+package app
+
+import (
+	"archive/tar"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"flow/internal/flowdb"
+)
+
+// ---------- tar inspection helpers (shared with import_test.go) ----------
+
+func listTarEntries(t *testing.T, tarPath string) []string {
+	t.Helper()
+	f, err := os.Open(tarPath)
+	if err != nil {
+		t.Fatalf("open tar: %v", err)
+	}
+	defer f.Close()
+	tr := tar.NewReader(f)
+	var names []string
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar next: %v", err)
+		}
+		names = append(names, hdr.Name)
+	}
+	return names
+}
+
+func readTarEntry(t *testing.T, tarPath, entry string) []byte {
+	t.Helper()
+	f, err := os.Open(tarPath)
+	if err != nil {
+		t.Fatalf("open tar: %v", err)
+	}
+	defer f.Close()
+	tr := tar.NewReader(f)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar next: %v", err)
+		}
+		if hdr.Name == entry {
+			data, err := io.ReadAll(tr)
+			if err != nil {
+				t.Fatalf("read entry %s: %v", entry, err)
+			}
+			return data
+		}
+	}
+	t.Fatalf("entry %q not found in %s", entry, tarPath)
+	return nil
+}
+
+func tarContains(t *testing.T, tarPath, entry string) bool {
+	t.Helper()
+	for _, e := range listTarEntries(t, tarPath) {
+		if e == entry {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------- export task tests ----------
+
+func TestExportTaskCreatesBundle(t *testing.T) {
+	root, db := showListEditDB(t)
+	home := root // use root as fake home so maskHome is predictable
+	t.Setenv("HOME", home)
+
+	insertTask(t, db, "my-task", "My Task", "backlog", "high", filepath.Join(home, "code", "repo"), nil)
+
+	// Write brief and an update file.
+	taskDir := filepath.Join(root, "tasks", "my-task")
+	os.MkdirAll(filepath.Join(taskDir, "updates"), 0o755)
+	os.WriteFile(filepath.Join(taskDir, "brief.md"), []byte("# My Task\n\n## What\nDo the thing."), 0o644)
+	os.WriteFile(filepath.Join(taskDir, "updates", "2026-04-23-progress.md"), []byte("Progress note."), 0o644)
+
+	outDir := t.TempDir()
+	out := captureStdout(t, func() {
+		if rc := cmdExport([]string{"task", "my-task", "--output", outDir}); rc != 0 {
+			t.Errorf("rc=%d", rc)
+		}
+	})
+
+	tarPath := strings.TrimSpace(out)
+	if _, err := os.Stat(tarPath); err != nil {
+		t.Fatalf("bundle not found at %q: %v", tarPath, err)
+	}
+	if !strings.HasSuffix(tarPath, ".tar") {
+		t.Errorf("expected .tar extension, got %q", tarPath)
+	}
+
+	// Verify manifest.
+	mfData := readTarEntry(t, tarPath, "manifest.json")
+	var mf bundleManifest
+	if err := json.Unmarshal(mfData, &mf); err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	if mf.Type != "task" || mf.Slug != "my-task" || mf.Version != "1" {
+		t.Errorf("manifest wrong: %+v", mf)
+	}
+
+	// Verify task.json has correct fields and no session data.
+	taskData := readTarEntry(t, tarPath, "task.json")
+	var bt bundledTask
+	if err := json.Unmarshal(taskData, &bt); err != nil {
+		t.Fatalf("parse task.json: %v", err)
+	}
+	if bt.Slug != "my-task" || bt.Name != "My Task" {
+		t.Errorf("task fields wrong: %+v", bt)
+	}
+	if strings.Contains(string(taskData), "session_id") {
+		t.Errorf("task.json must not contain session_id")
+	}
+
+	// Verify work_dir uses <HOME> placeholder.
+	if !strings.HasPrefix(bt.WorkDir, "<HOME>") {
+		t.Errorf("work_dir not masked: %q", bt.WorkDir)
+	}
+
+	// Verify brief.md and update file present.
+	if !tarContains(t, tarPath, "brief.md") {
+		t.Errorf("brief.md missing from bundle")
+	}
+	if !tarContains(t, tarPath, "updates/2026-04-23-progress.md") {
+		t.Errorf("update file missing from bundle")
+	}
+}
+
+func TestExportTaskNoBriefOk(t *testing.T) {
+	root, db := showListEditDB(t)
+	insertTask(t, db, "no-brief", "No Brief", "backlog", "medium", filepath.Join(root, "x"), nil)
+
+	outDir := t.TempDir()
+	out := captureStdout(t, func() {
+		if rc := cmdExport([]string{"task", "no-brief", "--output", outDir}); rc != 0 {
+			t.Errorf("rc=%d", rc)
+		}
+	})
+	tarPath := strings.TrimSpace(out)
+	if _, err := os.Stat(tarPath); err != nil {
+		t.Errorf("bundle missing: %v", err)
+	}
+	if !tarContains(t, tarPath, "manifest.json") || !tarContains(t, tarPath, "task.json") {
+		t.Errorf("core entries missing")
+	}
+}
+
+func TestExportTaskUnknownSlugErrors(t *testing.T) {
+	_, _ = showListEditDB(t)
+	out := captureStdout(t, func() {
+		if rc := cmdExport([]string{"task", "nope"}); rc != 1 {
+			t.Errorf("rc should be 1 for unknown slug")
+		}
+	})
+	if !strings.Contains(out, "nope") {
+		t.Errorf("expected slug in error; out=%q", out)
+	}
+}
+
+func TestExportTaskMissingSlugErrors(t *testing.T) {
+	_, _ = showListEditDB(t)
+	if rc := cmdExport([]string{"task"}); rc != 2 {
+		t.Errorf("rc=%d, want 2", rc)
+	}
+}
+
+func TestExportBadSubcommand(t *testing.T) {
+	_, _ = showListEditDB(t)
+	if rc := cmdExport(nil); rc != 2 {
+		t.Errorf("rc=%d, want 2", rc)
+	}
+	if rc := cmdExport([]string{"nope"}); rc != 2 {
+		t.Errorf("rc=%d, want 2", rc)
+	}
+}
+
+func TestMaskHome(t *testing.T) {
+	home := "/Users/alice"
+	cases := []struct{ in, want string }{
+		{"/Users/alice/code/repo", "<HOME>/code/repo"},
+		{"/Users/alice", "<HOME>"},
+		{"/opt/something", "/opt/something"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		got := maskHome(c.in, home)
+		if got != c.want {
+			t.Errorf("maskHome(%q, %q) = %q, want %q", c.in, home, got, c.want)
+		}
+	}
+}
+
+func TestExpandHome(t *testing.T) {
+	home := "/Users/bob"
+	cases := []struct{ in, want string }{
+		{"<HOME>/code/repo", "/Users/bob/code/repo"},
+		{"<HOME>", "/Users/bob"},
+		{"/opt/something", "/opt/something"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		got := expandHome(c.in, home)
+		if got != c.want {
+			t.Errorf("expandHome(%q, %q) = %q, want %q", c.in, home, got, c.want)
+		}
+	}
+}
+
+// Dummy reference to flowdb to avoid unused import if needed.
+var _ = flowdb.TaskFilter{}

--- a/internal/app/import.go
+++ b/internal/app/import.go
@@ -93,7 +93,7 @@ func importTaskBundle(db *sql.DB, root string, files map[string][]byte, home str
 
 	taskRoot := filepath.Join(root, "tasks", bt.Slug)
 	skip := map[string]bool{"manifest.json": true, "task.json": true}
-	if err := writeFiles(files, "", taskRoot, skip); err != nil {
+	if err := writeFiles(files, taskRoot, skip); err != nil {
 		return err
 	}
 
@@ -149,7 +149,7 @@ func importProjectBundle(db *sql.DB, root string, files map[string][]byte, home 
 			return err
 		}
 		taskRoot := filepath.Join(root, "tasks", bt.Slug)
-		if err := writeFiles(tFiles, "", taskRoot, map[string]bool{"task.json": true}); err != nil {
+		if err := writeFiles(tFiles, taskRoot, map[string]bool{"task.json": true}); err != nil {
 			return err
 		}
 		printWorkDirWarning(bt.WorkDir, home, bt.Slug)
@@ -186,8 +186,12 @@ func importAllBundle(db *sql.DB, root string, files map[string][]byte, home stri
 				continue
 			}
 			dst := filepath.Join(projRoot, filepath.FromSlash(name))
-			os.MkdirAll(filepath.Dir(dst), 0o755)
-			os.WriteFile(dst, data, 0o644)
+			if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+				return err
+			}
+			if err := os.WriteFile(dst, data, 0o644); err != nil {
+				return err
+			}
 		}
 		importedProj++
 
@@ -205,7 +209,9 @@ func importAllBundle(db *sql.DB, root string, files map[string][]byte, home stri
 				return err
 			}
 			taskRoot := filepath.Join(root, "tasks", bt.Slug)
-			writeFiles(tFiles, "", taskRoot, map[string]bool{"task.json": true})
+			if err := writeFiles(tFiles, taskRoot, map[string]bool{"task.json": true}); err != nil {
+				return err
+			}
 			importedTask++
 		}
 	}
@@ -223,7 +229,9 @@ func importAllBundle(db *sql.DB, root string, files map[string][]byte, home stri
 			return err
 		}
 		taskRoot := filepath.Join(root, "tasks", bt.Slug)
-		writeFiles(tFiles, "", taskRoot, map[string]bool{"task.json": true})
+		if err := writeFiles(tFiles, taskRoot, map[string]bool{"task.json": true}); err != nil {
+			return err
+		}
 		importedTask++
 	}
 
@@ -233,8 +241,12 @@ func importAllBundle(db *sql.DB, root string, files map[string][]byte, home stri
 			continue
 		}
 		dst := filepath.Join(root, filepath.FromSlash(name))
-		os.MkdirAll(filepath.Dir(dst), 0o755)
-		os.WriteFile(dst, data, 0o644)
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(dst, data, 0o644); err != nil {
+			return err
+		}
 	}
 
 	fmt.Printf("imported %d projects, %d tasks\n", importedProj, importedTask)
@@ -245,7 +257,9 @@ func importAllBundle(db *sql.DB, root string, files map[string][]byte, home stri
 
 func upsertTask(db *sql.DB, bt bundledTask, targetSlug, home string, force bool) error {
 	var exists int
-	db.QueryRow(`SELECT COUNT(*) FROM tasks WHERE slug = ?`, targetSlug).Scan(&exists)
+	if err := db.QueryRow(`SELECT COUNT(*) FROM tasks WHERE slug = ?`, targetSlug).Scan(&exists); err != nil {
+		return fmt.Errorf("check task existence: %w", err)
+	}
 	if exists > 0 && !force {
 		return fmt.Errorf("task %q already exists; use --force to overwrite", targetSlug)
 	}
@@ -286,7 +300,9 @@ func upsertTask(db *sql.DB, bt bundledTask, targetSlug, home string, force bool)
 
 func upsertProject(db *sql.DB, bp bundledProject, home string, force bool) error {
 	var exists int
-	db.QueryRow(`SELECT COUNT(*) FROM projects WHERE slug = ?`, bp.Slug).Scan(&exists)
+	if err := db.QueryRow(`SELECT COUNT(*) FROM projects WHERE slug = ?`, bp.Slug).Scan(&exists); err != nil {
+		return fmt.Errorf("check project existence: %w", err)
+	}
 	if exists > 0 && !force {
 		return fmt.Errorf("project %q already exists; use --force to overwrite", bp.Slug)
 	}
@@ -308,7 +324,7 @@ func upsertProject(db *sql.DB, bp bundledProject, home string, force bool) error
 
 // writeFiles writes files map entries (except skip entries) to dstRoot.
 // Tar paths are forward-slash; filepath.FromSlash converts for the OS.
-func writeFiles(files map[string][]byte, _ string, dstRoot string, skip map[string]bool) error {
+func writeFiles(files map[string][]byte, dstRoot string, skip map[string]bool) error {
 	for name, data := range files {
 		if skip[name] {
 			continue

--- a/internal/app/import.go
+++ b/internal/app/import.go
@@ -1,0 +1,356 @@
+package app
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"flow/internal/flowdb"
+)
+
+func cmdImport(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "error: import requires a bundle file path")
+		return 2
+	}
+	bundlePath := args[0]
+	fs := flagSet("import")
+	force := fs.Bool("force", false, "overwrite existing slugs on conflict")
+	if err := fs.Parse(args[1:]); err != nil {
+		return 2
+	}
+
+	dbPath, err := flowDBPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	db, err := flowdb.OpenDB(dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: open db: %v\n", err)
+		return 1
+	}
+	defer db.Close()
+
+	root, err := flowRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	home, _ := os.UserHomeDir()
+
+	if err := importBundle(db, root, bundlePath, home, *force); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func importBundle(db *sql.DB, root, bundlePath, home string, force bool) error {
+	files, err := readTarFiles(bundlePath)
+	if err != nil {
+		return err
+	}
+
+	mfData, ok := files["manifest.json"]
+	if !ok {
+		return fmt.Errorf("bundle missing manifest.json")
+	}
+	var mf bundleManifest
+	if err := json.Unmarshal(mfData, &mf); err != nil {
+		return fmt.Errorf("parse manifest: %w", err)
+	}
+
+	switch mf.Type {
+	case "task":
+		return importTaskBundle(db, root, files, home, force)
+	case "project":
+		return importProjectBundle(db, root, files, home, force)
+	case "all":
+		return importAllBundle(db, root, files, home, force)
+	}
+	return fmt.Errorf("unknown bundle type %q", mf.Type)
+}
+
+// ---------- task bundle import ----------
+
+func importTaskBundle(db *sql.DB, root string, files map[string][]byte, home string, force bool) error {
+	taskData, ok := files["task.json"]
+	if !ok {
+		return fmt.Errorf("bundle missing task.json")
+	}
+	var bt bundledTask
+	if err := json.Unmarshal(taskData, &bt); err != nil {
+		return fmt.Errorf("parse task.json: %w", err)
+	}
+
+	if err := upsertTask(db, bt, bt.Slug, home, force); err != nil {
+		return err
+	}
+
+	taskRoot := filepath.Join(root, "tasks", bt.Slug)
+	skip := map[string]bool{"manifest.json": true, "task.json": true}
+	if err := writeFiles(files, "", taskRoot, skip); err != nil {
+		return err
+	}
+
+	fmt.Printf("imported task %q\n", bt.Slug)
+	printWorkDirWarning(bt.WorkDir, home, bt.Slug)
+	return nil
+}
+
+// ---------- project bundle import ----------
+
+func importProjectBundle(db *sql.DB, root string, files map[string][]byte, home string, force bool) error {
+	projData, ok := files["project.json"]
+	if !ok {
+		return fmt.Errorf("bundle missing project.json")
+	}
+	var bp bundledProject
+	if err := json.Unmarshal(projData, &bp); err != nil {
+		return fmt.Errorf("parse project.json: %w", err)
+	}
+
+	if err := upsertProject(db, bp, home, force); err != nil {
+		return err
+	}
+
+	// Write project-level files (brief.md, updates/) — skip tasks/ subtree.
+	projRoot := filepath.Join(root, "projects", bp.Slug)
+	skip := map[string]bool{"manifest.json": true, "project.json": true}
+	for name, data := range files {
+		if skip[name] || strings.HasPrefix(name, "tasks/") {
+			continue
+		}
+		dst := filepath.Join(projRoot, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(dst, data, 0o644); err != nil {
+			return err
+		}
+	}
+
+	// Import each task nested under tasks/.
+	taskGroups := groupByPrefix(files, "tasks/")
+	for taskSlug, tFiles := range taskGroups {
+		taskData, ok := tFiles["task.json"]
+		if !ok {
+			continue
+		}
+		var bt bundledTask
+		if err := json.Unmarshal(taskData, &bt); err != nil {
+			return fmt.Errorf("parse tasks/%s/task.json: %w", taskSlug, err)
+		}
+		if err := upsertTask(db, bt, bt.Slug, home, force); err != nil {
+			return err
+		}
+		taskRoot := filepath.Join(root, "tasks", bt.Slug)
+		if err := writeFiles(tFiles, "", taskRoot, map[string]bool{"task.json": true}); err != nil {
+			return err
+		}
+		printWorkDirWarning(bt.WorkDir, home, bt.Slug)
+	}
+
+	fmt.Printf("imported project %q with %d tasks\n", bp.Slug, len(taskGroups))
+	printWorkDirWarning(bp.WorkDir, home, "project:"+bp.Slug)
+	return nil
+}
+
+// ---------- all bundle import ----------
+
+func importAllBundle(db *sql.DB, root string, files map[string][]byte, home string, force bool) error {
+	projGroups := groupByPrefix(files, "projects/")
+	floatGroups := groupByPrefix(files, "floating-tasks/")
+
+	importedProj, importedTask := 0, 0
+
+	for projSlug, pFiles := range projGroups {
+		projData, ok := pFiles["project.json"]
+		if !ok {
+			continue
+		}
+		var bp bundledProject
+		if err := json.Unmarshal(projData, &bp); err != nil {
+			return fmt.Errorf("parse projects/%s/project.json: %w", projSlug, err)
+		}
+		if err := upsertProject(db, bp, home, force); err != nil {
+			return err
+		}
+		projRoot := filepath.Join(root, "projects", bp.Slug)
+		for name, data := range pFiles {
+			if name == "project.json" || strings.HasPrefix(name, "tasks/") {
+				continue
+			}
+			dst := filepath.Join(projRoot, filepath.FromSlash(name))
+			os.MkdirAll(filepath.Dir(dst), 0o755)
+			os.WriteFile(dst, data, 0o644)
+		}
+		importedProj++
+
+		taskGroups := groupByPrefix(pFiles, "tasks/")
+		for _, tFiles := range taskGroups {
+			taskData, ok := tFiles["task.json"]
+			if !ok {
+				continue
+			}
+			var bt bundledTask
+			if err := json.Unmarshal(taskData, &bt); err != nil {
+				return err
+			}
+			if err := upsertTask(db, bt, bt.Slug, home, force); err != nil {
+				return err
+			}
+			taskRoot := filepath.Join(root, "tasks", bt.Slug)
+			writeFiles(tFiles, "", taskRoot, map[string]bool{"task.json": true})
+			importedTask++
+		}
+	}
+
+	for _, tFiles := range floatGroups {
+		taskData, ok := tFiles["task.json"]
+		if !ok {
+			continue
+		}
+		var bt bundledTask
+		if err := json.Unmarshal(taskData, &bt); err != nil {
+			return err
+		}
+		if err := upsertTask(db, bt, bt.Slug, home, force); err != nil {
+			return err
+		}
+		taskRoot := filepath.Join(root, "tasks", bt.Slug)
+		writeFiles(tFiles, "", taskRoot, map[string]bool{"task.json": true})
+		importedTask++
+	}
+
+	// KB files.
+	for name, data := range files {
+		if !strings.HasPrefix(name, "kb/") {
+			continue
+		}
+		dst := filepath.Join(root, filepath.FromSlash(name))
+		os.MkdirAll(filepath.Dir(dst), 0o755)
+		os.WriteFile(dst, data, 0o644)
+	}
+
+	fmt.Printf("imported %d projects, %d tasks\n", importedProj, importedTask)
+	return nil
+}
+
+// ---------- DB upsert helpers ----------
+
+func upsertTask(db *sql.DB, bt bundledTask, targetSlug, home string, force bool) error {
+	var exists int
+	db.QueryRow(`SELECT COUNT(*) FROM tasks WHERE slug = ?`, targetSlug).Scan(&exists)
+	if exists > 0 && !force {
+		return fmt.Errorf("task %q already exists; use --force to overwrite", targetSlug)
+	}
+
+	now := flowdb.NowISO()
+	workDir := expandHome(bt.WorkDir, home)
+
+	project := sql.NullString{}
+	if bt.ProjectSlug != "" {
+		project = sql.NullString{String: bt.ProjectSlug, Valid: true}
+	}
+	waitingOn := sql.NullString{}
+	if bt.WaitingOn != "" {
+		waitingOn = sql.NullString{String: bt.WaitingOn, Valid: true}
+	}
+	dueDate := sql.NullString{}
+	if bt.DueDate != "" {
+		dueDate = sql.NullString{String: bt.DueDate, Valid: true}
+	}
+	statusChangedAt := sql.NullString{}
+	if bt.StatusChangedAt != "" {
+		statusChangedAt = sql.NullString{String: bt.StatusChangedAt, Valid: true}
+	}
+	archivedAt := sql.NullString{}
+	if bt.ArchivedAt != "" {
+		archivedAt = sql.NullString{String: bt.ArchivedAt, Valid: true}
+	}
+
+	_, err := db.Exec(`INSERT OR REPLACE INTO tasks
+		(slug, name, project_slug, status, priority, work_dir, waiting_on, due_date,
+		 status_changed_at, created_at, updated_at, archived_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		targetSlug, bt.Name, project, bt.Status, bt.Priority, workDir,
+		waitingOn, dueDate, statusChangedAt, bt.CreatedAt, now, archivedAt,
+	)
+	return err
+}
+
+func upsertProject(db *sql.DB, bp bundledProject, home string, force bool) error {
+	var exists int
+	db.QueryRow(`SELECT COUNT(*) FROM projects WHERE slug = ?`, bp.Slug).Scan(&exists)
+	if exists > 0 && !force {
+		return fmt.Errorf("project %q already exists; use --force to overwrite", bp.Slug)
+	}
+	now := flowdb.NowISO()
+	archivedAt := sql.NullString{}
+	if bp.ArchivedAt != "" {
+		archivedAt = sql.NullString{String: bp.ArchivedAt, Valid: true}
+	}
+	workDir := expandHome(bp.WorkDir, home)
+	_, err := db.Exec(`INSERT OR REPLACE INTO projects
+		(slug, name, status, priority, work_dir, created_at, updated_at, archived_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		bp.Slug, bp.Name, bp.Status, bp.Priority, workDir, bp.CreatedAt, now, archivedAt,
+	)
+	return err
+}
+
+// ---------- file-write helpers ----------
+
+// writeFiles writes files map entries (except skip entries) to dstRoot.
+// Tar paths are forward-slash; filepath.FromSlash converts for the OS.
+func writeFiles(files map[string][]byte, _ string, dstRoot string, skip map[string]bool) error {
+	for name, data := range files {
+		if skip[name] {
+			continue
+		}
+		dst := filepath.Join(dstRoot, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(dst, data, 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// groupByPrefix extracts sub-maps from files keyed by a path prefix.
+// e.g. prefix="tasks/", entry "tasks/task-a/task.json" → sub-slug="task-a", key="task.json".
+func groupByPrefix(files map[string][]byte, prefix string) map[string]map[string][]byte {
+	groups := map[string]map[string][]byte{}
+	for name, data := range files {
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		rest := strings.TrimPrefix(name, prefix)
+		parts := strings.SplitN(rest, "/", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		sub, rel := parts[0], parts[1]
+		if groups[sub] == nil {
+			groups[sub] = map[string][]byte{}
+		}
+		groups[sub][rel] = data
+	}
+	return groups
+}
+
+// printWorkDirWarning warns if work_dir still has <HOME> after expansion
+// (meaning expandHome couldn't resolve it).
+func printWorkDirWarning(workDir, home, label string) {
+	expanded := expandHome(workDir, home)
+	if strings.Contains(expanded, "<HOME>") {
+		fmt.Fprintf(os.Stderr, "  ⚠ work_dir for %s may need updating: %s\n    run: flow update task %s --work-dir <path>\n", label, expanded, label)
+	}
+}

--- a/internal/app/import_test.go
+++ b/internal/app/import_test.go
@@ -296,5 +296,39 @@ func TestCmdImportFileNotFound(t *testing.T) {
 	}
 }
 
+func TestCmdImportWritesToFlowRoot(t *testing.T) {
+	// Build a task bundle from a source root.
+	bundle := makeTaskBundle(t, "e2e-import-task", "E2E Import Task", "backlog", "high")
+
+	// Set up a fresh FLOW_ROOT as the import target.
+	importRoot, _ := showListEditDB(t)
+
+	// Run cmdImport — it uses flowRoot() internally, which reads $FLOW_ROOT.
+	out := captureStdout(t, func() {
+		if rc := cmdImport([]string{bundle}); rc != 0 {
+			t.Errorf("cmdImport rc=%d", rc)
+		}
+	})
+	if !strings.Contains(out, "imported task") {
+		t.Errorf("expected confirmation; out=%q", out)
+	}
+
+	// Verify via cmdShow that the task is queryable through the normal CLI path.
+	showOut := captureStdout(t, func() {
+		if rc := cmdShow([]string{"task", "e2e-import-task"}); rc != 0 {
+			t.Errorf("cmdShow rc=%d", rc)
+		}
+	})
+	if !strings.Contains(showOut, "E2E Import Task") {
+		t.Errorf("task not visible via flow show: %s", showOut)
+	}
+
+	// Verify files on disk under the correct FLOW_ROOT.
+	briefPath := filepath.Join(importRoot, "tasks", "e2e-import-task", "brief.md")
+	if _, err := os.Stat(briefPath); err != nil {
+		t.Errorf("brief.md not written to FLOW_ROOT: %v", err)
+	}
+}
+
 // Suppress unused import warning — flowdb used in test helpers above.
 var _ = json.Marshal

--- a/internal/app/import_test.go
+++ b/internal/app/import_test.go
@@ -1,0 +1,300 @@
+package app
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"flow/internal/flowdb"
+)
+
+// makeTaskBundle creates a task tar bundle and returns its path.
+// It uses a separate temp FLOW_ROOT so it doesn't interfere with the import root.
+func makeTaskBundle(t *testing.T, slug, name, status, priority string) string {
+	t.Helper()
+	// Temporarily point FLOW_ROOT at a source dir just for building the bundle.
+	srcRoot := t.TempDir()
+	srcHome := srcRoot
+	srcDB, err := flowdb.OpenDB(filepath.Join(srcRoot, "flow.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer srcDB.Close()
+	for _, sub := range []string{"projects", "tasks"} {
+		os.MkdirAll(filepath.Join(srcRoot, sub), 0o755)
+	}
+	now := flowdb.NowISO()
+	srcDB.Exec(`INSERT INTO tasks (slug, name, status, priority, work_dir, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		slug, name, status, priority, filepath.Join(srcHome, "code", "repo"), now, now)
+
+	taskDir := filepath.Join(srcRoot, "tasks", slug)
+	os.MkdirAll(filepath.Join(taskDir, "updates"), 0o755)
+	os.WriteFile(filepath.Join(taskDir, "brief.md"), []byte("# "+name), 0o644)
+	os.WriteFile(filepath.Join(taskDir, "updates", "2026-04-23-note.md"), []byte("Progress."), 0o644)
+
+	task, err := flowdb.GetTask(srcDB, slug)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	outDir := t.TempDir()
+	outPath, err := writeTaskBundle(task, srcRoot, outDir, srcHome)
+	if err != nil {
+		t.Fatalf("writeTaskBundle: %v", err)
+	}
+	return outPath
+}
+
+// makeProjectBundle creates a project tar bundle and returns its path.
+func makeProjectBundle(t *testing.T, projSlug, projName string, taskSlugs []string) string {
+	t.Helper()
+	srcRoot := t.TempDir()
+	srcHome := srcRoot
+	srcDB, err := flowdb.OpenDB(filepath.Join(srcRoot, "flow.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer srcDB.Close()
+	for _, sub := range []string{"projects", "tasks"} {
+		os.MkdirAll(filepath.Join(srcRoot, sub), 0o755)
+	}
+	now := flowdb.NowISO()
+	srcDB.Exec(`INSERT INTO projects (slug, name, status, priority, work_dir, created_at, updated_at) VALUES (?, ?, 'active', 'medium', ?, ?, ?)`,
+		projSlug, projName, filepath.Join(srcHome, "code"), now, now)
+
+	projDir := filepath.Join(srcRoot, "projects", projSlug)
+	os.MkdirAll(filepath.Join(projDir, "updates"), 0o755)
+	os.WriteFile(filepath.Join(projDir, "brief.md"), []byte("# "+projName), 0o644)
+
+	for _, ts := range taskSlugs {
+		srcDB.Exec(`INSERT INTO tasks (slug, name, project_slug, status, priority, work_dir, created_at, updated_at) VALUES (?, ?, ?, 'backlog', 'medium', ?, ?, ?)`,
+			ts, "Task "+ts, projSlug, filepath.Join(srcHome, "code"), now, now)
+		td := filepath.Join(srcRoot, "tasks", ts)
+		os.MkdirAll(filepath.Join(td, "updates"), 0o755)
+		os.WriteFile(filepath.Join(td, "brief.md"), []byte("# "+ts), 0o644)
+	}
+
+	project, _ := flowdb.GetProject(srcDB, projSlug)
+	tasks, _ := flowdb.ListTasks(srcDB, flowdb.TaskFilter{Project: projSlug})
+	outDir := t.TempDir()
+	outPath, err := writeProjectBundle(project, tasks, srcRoot, outDir, srcHome)
+	if err != nil {
+		t.Fatalf("writeProjectBundle: %v", err)
+	}
+	return outPath
+}
+
+// ---------- task import ----------
+
+func TestImportTaskRoundTrip(t *testing.T) {
+	bundle := makeTaskBundle(t, "rt-task", "RoundTrip Task", "backlog", "high")
+
+	importRoot, importDB := showListEditDB(t)
+
+	if err := importBundle(importDB, importRoot, bundle, importRoot, false); err != nil {
+		t.Fatalf("importBundle: %v", err)
+	}
+
+	task, err := flowdb.GetTask(importDB, "rt-task")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if task.Name != "RoundTrip Task" {
+		t.Errorf("name wrong: %q", task.Name)
+	}
+	if task.SessionID.Valid {
+		t.Errorf("session_id should be NULL after import")
+	}
+	// work_dir should be expanded: <HOME> → importRoot.
+	if !strings.HasPrefix(task.WorkDir, importRoot) {
+		t.Errorf("work_dir not expanded: %q", task.WorkDir)
+	}
+
+	briefPath := filepath.Join(importRoot, "tasks", "rt-task", "brief.md")
+	if _, err := os.Stat(briefPath); err != nil {
+		t.Errorf("brief.md missing: %v", err)
+	}
+	updatePath := filepath.Join(importRoot, "tasks", "rt-task", "updates", "2026-04-23-note.md")
+	if _, err := os.Stat(updatePath); err != nil {
+		t.Errorf("update file missing: %v", err)
+	}
+}
+
+func TestImportTaskConflictErrors(t *testing.T) {
+	bundle := makeTaskBundle(t, "conflict-task", "Conflict", "backlog", "medium")
+	importRoot, importDB := showListEditDB(t)
+	insertTask(t, importDB, "conflict-task", "Existing", "done", "low", filepath.Join(importRoot, "x"), nil)
+
+	err := importBundle(importDB, importRoot, bundle, importRoot, false)
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("expected 'already exists'; got: %v", err)
+	}
+}
+
+func TestImportTaskForce(t *testing.T) {
+	bundle := makeTaskBundle(t, "force-task", "Force Task", "backlog", "high")
+	importRoot, importDB := showListEditDB(t)
+	insertTask(t, importDB, "force-task", "Old Name", "done", "low", filepath.Join(importRoot, "x"), nil)
+
+	if err := importBundle(importDB, importRoot, bundle, importRoot, true); err != nil {
+		t.Fatalf("importBundle --force: %v", err)
+	}
+	task, _ := flowdb.GetTask(importDB, "force-task")
+	if task.Name != "Force Task" {
+		t.Errorf("task not overwritten: %q", task.Name)
+	}
+}
+
+// ---------- project import ----------
+
+func TestImportProjectRoundTrip(t *testing.T) {
+	bundle := makeProjectBundle(t, "my-proj", "My Project", []string{"t-alpha", "t-beta"})
+	importRoot, importDB := showListEditDB(t)
+
+	if err := importBundle(importDB, importRoot, bundle, importRoot, false); err != nil {
+		t.Fatalf("importBundle project: %v", err)
+	}
+
+	proj, err := flowdb.GetProject(importDB, "my-proj")
+	if err != nil {
+		t.Fatalf("project not found: %v", err)
+	}
+	if proj.Name != "My Project" {
+		t.Errorf("project name wrong: %q", proj.Name)
+	}
+
+	for _, ts := range []string{"t-alpha", "t-beta"} {
+		task, err := flowdb.GetTask(importDB, ts)
+		if err != nil {
+			t.Fatalf("task %s not found: %v", ts, err)
+		}
+		if task.ProjectSlug.String != "my-proj" {
+			t.Errorf("task %s project_slug wrong: %q", ts, task.ProjectSlug.String)
+		}
+		if task.SessionID.Valid {
+			t.Errorf("task %s session_id should be NULL", ts)
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(importRoot, "projects", "my-proj", "brief.md")); err != nil {
+		t.Errorf("project brief.md missing: %v", err)
+	}
+}
+
+func TestImportProjectConflictErrors(t *testing.T) {
+	bundle := makeProjectBundle(t, "dup-proj", "Dup Project", nil)
+	importRoot, importDB := showListEditDB(t)
+	insertProject(t, importDB, "dup-proj", "Existing", filepath.Join(importRoot, "x"), "low")
+
+	err := importBundle(importDB, importRoot, bundle, importRoot, false)
+	if err == nil {
+		t.Fatal("expected conflict error for project")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("expected 'already exists'; got: %v", err)
+	}
+}
+
+func TestImportProjectForce(t *testing.T) {
+	bundle := makeProjectBundle(t, "fp", "Force Project", []string{"fp-task"})
+	importRoot, importDB := showListEditDB(t)
+	insertProject(t, importDB, "fp", "Old Project", filepath.Join(importRoot, "x"), "low")
+
+	if err := importBundle(importDB, importRoot, bundle, importRoot, true); err != nil {
+		t.Fatalf("importBundle --force project: %v", err)
+	}
+	proj, _ := flowdb.GetProject(importDB, "fp")
+	if proj.Name != "Force Project" {
+		t.Errorf("project not overwritten: %q", proj.Name)
+	}
+}
+
+// ---------- all import ----------
+
+func TestImportAllRoundTrip(t *testing.T) {
+	// Build an "all" bundle directly.
+	srcRoot := t.TempDir()
+	srcHome := srcRoot
+	srcDB, _ := flowdb.OpenDB(filepath.Join(srcRoot, "flow.db"))
+	defer srcDB.Close()
+	for _, sub := range []string{"projects", "tasks", "kb"} {
+		os.MkdirAll(filepath.Join(srcRoot, sub), 0o755)
+	}
+	now := flowdb.NowISO()
+	srcDB.Exec(`INSERT INTO projects (slug, name, status, priority, work_dir, created_at, updated_at) VALUES ('all-proj','All Project','active','high',?,?,?)`,
+		filepath.Join(srcHome, "code"), now, now)
+	srcDB.Exec(`INSERT INTO tasks (slug, name, project_slug, status, priority, work_dir, created_at, updated_at) VALUES ('all-task','All Task','all-proj','backlog','high',?,?,?)`,
+		filepath.Join(srcHome, "code"), now, now)
+	srcDB.Exec(`INSERT INTO tasks (slug, name, status, priority, work_dir, created_at, updated_at) VALUES ('float-task','Float Task','in-progress','medium',?,?,?)`,
+		filepath.Join(srcHome, "other"), now, now)
+	os.WriteFile(filepath.Join(srcRoot, "kb", "user.md"), []byte("# User"), 0o644)
+
+	allProjects, _ := flowdb.ListProjects(srcDB, flowdb.ProjectFilter{IncludeArchived: true})
+	allTasks, _ := flowdb.ListTasks(srcDB, flowdb.TaskFilter{IncludeArchived: true})
+	outDir := t.TempDir()
+	bundlePath, err := writeAllBundle(allProjects, allTasks, srcRoot, outDir, srcHome)
+	if err != nil {
+		t.Fatalf("writeAllBundle: %v", err)
+	}
+
+	importRoot, importDB := showListEditDB(t)
+	os.MkdirAll(filepath.Join(importRoot, "kb"), 0o755)
+	if err := importBundle(importDB, importRoot, bundlePath, importRoot, false); err != nil {
+		t.Fatalf("importBundle all: %v", err)
+	}
+
+	if _, err := flowdb.GetProject(importDB, "all-proj"); err != nil {
+		t.Errorf("project not imported: %v", err)
+	}
+	if _, err := flowdb.GetTask(importDB, "all-task"); err != nil {
+		t.Errorf("project task not imported: %v", err)
+	}
+	if _, err := flowdb.GetTask(importDB, "float-task"); err != nil {
+		t.Errorf("floating task not imported: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(importRoot, "kb", "user.md")); err != nil {
+		t.Errorf("kb/user.md not restored: %v", err)
+	}
+}
+
+// ---------- cmdImport integration ----------
+
+func TestCmdImportTaskDispatch(t *testing.T) {
+	bundle := makeTaskBundle(t, "cli-task", "CLI Task", "backlog", "high")
+	_, _ = showListEditDB(t)
+
+	out := captureStdout(t, func() {
+		if rc := cmdImport([]string{bundle}); rc != 0 {
+			t.Errorf("rc=%d", rc)
+		}
+	})
+	if !strings.Contains(out, "imported") {
+		t.Errorf("expected import confirmation; out=%q", out)
+	}
+}
+
+func TestCmdImportMissingFile(t *testing.T) {
+	_, _ = showListEditDB(t)
+	if rc := cmdImport(nil); rc != 2 {
+		t.Errorf("rc=%d, want 2", rc)
+	}
+}
+
+func TestCmdImportFileNotFound(t *testing.T) {
+	_, _ = showListEditDB(t)
+	out := captureStdout(t, func() {
+		if rc := cmdImport([]string{"/tmp/nonexistent-bundle.tar"}); rc != 1 {
+			t.Errorf("expected rc=1")
+		}
+	})
+	if !strings.Contains(out, "open bundle") {
+		t.Errorf("expected open error; out=%q", out)
+	}
+}
+
+// Suppress unused import warning — flowdb used in test helpers above.
+var _ = json.Marshal

--- a/internal/app/list_test.go
+++ b/internal/app/list_test.go
@@ -127,8 +127,9 @@ func TestCmdListTasksArchivedHiddenByDefault(t *testing.T) {
 func TestCmdListTasksSinceToday(t *testing.T) {
 	root, db := showListEditDB(t)
 	insertTask(t, db, "today-task", "A", "backlog", "high", filepath.Join(root, "x"), nil)
-	// Set it to 12 hours ago so it's still "today" in any reasonable timezone.
-	recent := time.Now().Add(-2 * time.Hour).Format(time.RFC3339)
+	// Pin to noon today — guaranteed to be within "today" regardless of when the test runs.
+	y, mo, d := time.Now().Date()
+	recent := time.Date(y, mo, d, 12, 0, 0, 0, time.Now().Location()).Format(time.RFC3339)
 	if _, err := db.Exec(`UPDATE tasks SET updated_at = ? WHERE slug = ?`, recent, "today-task"); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/app/sanitize.go
+++ b/internal/app/sanitize.go
@@ -48,7 +48,7 @@ var sensitiveRules = []sensitiveRule{
 	// Requires value >= 12 chars to avoid flagging short words like "high" or "done".
 	// Preserves the key name in the output.
 	{
-		re:          regexp.MustCompile(`(?i)((?:password|passwd|pwd|secret|api[_-]?key|access[_-]?key|auth[_-]?token|client[_-]?secret|private[_-]?key|signing[_-]?key|encryption[_-]?key|bearer)\s*[:=]\s*)([A-Za-z0-9+/=_\-\.!@#$%^&*]{12,})`),
+		re:          regexp.MustCompile(`(?i)((?:password|passwd|pwd|secret|api[_-]?key|access[_-]?key|auth[_-]?token|client[_-]?secret|private[_-]?key|signing[_-]?key|encryption[_-]?key|bearer)\s*[:=]\s*)([A-Za-z0-9+/=_\-\.!@#$%^&*]+)`),
 		replacement: "${1}<sensitive>",
 	},
 }

--- a/internal/app/sanitize.go
+++ b/internal/app/sanitize.go
@@ -1,0 +1,68 @@
+package app
+
+import (
+	"regexp"
+)
+
+// sensitiveRule pairs a compiled pattern with its replacement string.
+// Capture group ${key} preserves the key name where applicable.
+type sensitiveRule struct {
+	re          *regexp.Regexp
+	replacement string
+}
+
+// sensitiveRules is the ordered list of patterns applied to text file content
+// during export. Order matters: more specific patterns run first.
+var sensitiveRules = []sensitiveRule{
+	// Connection strings: proto://user:pass@host — keep proto:// visible
+	{
+		re:          regexp.MustCompile(`(?i)((?:mysql|postgres(?:ql)?|mongodb(?:\+srv)?|redis|amqp|https?)://)[^:\s]+:[^@\s]+(@)`),
+		replacement: "${1}<sensitive>${2}",
+	},
+	// PEM private key blocks
+	{
+		re:          regexp.MustCompile(`(?i)-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----`),
+		replacement: "<sensitive>",
+	},
+	// AWS Access Key IDs
+	{
+		re:          regexp.MustCompile(`(?:AKIA|ASIA|AROA|AIDA)[0-9A-Z]{16}`),
+		replacement: "<sensitive>",
+	},
+	// GitHub personal access tokens / fine-grained tokens
+	{
+		re:          regexp.MustCompile(`(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{34,}`),
+		replacement: "<sensitive>",
+	},
+	// Slack tokens
+	{
+		re:          regexp.MustCompile(`xox[baprs]-[0-9]{8,12}-[0-9]{8,12}(?:-[0-9]{8,12})?-[A-Za-z0-9]{24,}`),
+		replacement: "<sensitive>",
+	},
+	// Stripe API keys
+	{
+		re:          regexp.MustCompile(`(?:sk|pk|rk)_(?:live|test)_[A-Za-z0-9]{24,}`),
+		replacement: "<sensitive>",
+	},
+	// Generic key/secret/password/token assignments (key = value or key: value).
+	// Requires value >= 12 chars to avoid flagging short words like "high" or "done".
+	// Preserves the key name in the output.
+	{
+		re:          regexp.MustCompile(`(?i)((?:password|passwd|pwd|secret|api[_-]?key|access[_-]?key|auth[_-]?token|client[_-]?secret|private[_-]?key|signing[_-]?key|encryption[_-]?key|bearer)\s*[:=]\s*)([A-Za-z0-9+/=_\-\.!@#$%^&*]{12,})`),
+		replacement: "${1}<sensitive>",
+	},
+}
+
+// maskSensitiveContent applies all sensitiveRules to data and returns the
+// cleaned content plus a flag indicating whether any masking occurred.
+func maskSensitiveContent(data []byte) ([]byte, bool) {
+	result := data
+	masked := false
+	for _, rule := range sensitiveRules {
+		if rule.re.Match(result) {
+			result = rule.re.ReplaceAll(result, []byte(rule.replacement))
+			masked = true
+		}
+	}
+	return result, masked
+}

--- a/internal/app/sanitize_test.go
+++ b/internal/app/sanitize_test.go
@@ -1,0 +1,99 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMaskSensitiveContentConnectionString(t *testing.T) {
+	input := []byte("DB_URL=postgres://alice:hunter2@db.internal:5432/prod")
+	out, masked := maskSensitiveContent(input)
+	if !masked {
+		t.Error("expected masking")
+	}
+	if strings.Contains(string(out), "hunter2") {
+		t.Errorf("password not masked: %s", out)
+	}
+	if !strings.Contains(string(out), "postgres://") {
+		t.Errorf("protocol should be preserved: %s", out)
+	}
+}
+
+func TestMaskSensitiveContentAWSKey(t *testing.T) {
+	input := []byte("export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE")
+	out, masked := maskSensitiveContent(input)
+	if !masked {
+		t.Error("expected masking")
+	}
+	if strings.Contains(string(out), "AKIAIOSFODNN7EXAMPLE") {
+		t.Errorf("AWS key not masked: %s", out)
+	}
+}
+
+func TestMaskSensitiveContentGenericKeyValue(t *testing.T) {
+	input := []byte("api_key=abcdef123456789012345")
+	out, masked := maskSensitiveContent(input)
+	if !masked {
+		t.Error("expected masking")
+	}
+	if strings.Contains(string(out), "abcdef123456789012345") {
+		t.Errorf("api_key value not masked: %s", out)
+	}
+	if !strings.Contains(string(out), "api_key") {
+		t.Errorf("key name should be preserved: %s", out)
+	}
+	if !strings.Contains(string(out), "<sensitive>") {
+		t.Errorf("expected <sensitive> placeholder: %s", out)
+	}
+}
+
+func TestMaskSensitiveContentGitHubToken(t *testing.T) {
+	input := []byte("token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef12")
+	out, masked := maskSensitiveContent(input)
+	if !masked {
+		t.Error("expected masking")
+	}
+	if strings.Contains(string(out), "ghp_") {
+		t.Errorf("GitHub token not masked: %s", out)
+	}
+}
+
+func TestMaskSensitiveContentPrivateKey(t *testing.T) {
+	input := []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA\n-----END RSA PRIVATE KEY-----")
+	out, masked := maskSensitiveContent(input)
+	if !masked {
+		t.Error("expected masking")
+	}
+	if strings.Contains(string(out), "MIIEowIBAAKCAQEA") {
+		t.Errorf("private key content not masked: %s", out)
+	}
+}
+
+func TestMaskSensitiveContentSafeContent(t *testing.T) {
+	// Short values and common flow field values must NOT be masked.
+	cases := []string{
+		"status: in-progress",
+		"priority: high",
+		"## Done when",
+		"- Deploy to staging",
+		"work_dir: /Users/alice/code",
+		"token: [this is a reference to a design token]", // < 12 chars after colon
+	}
+	for _, c := range cases {
+		out, masked := maskSensitiveContent([]byte(c))
+		if masked {
+			t.Errorf("false positive on %q — got %q", c, out)
+		}
+	}
+}
+
+func TestMaskSensitiveContentStripeKey(t *testing.T) {
+	input := []byte("STRIPE_SECRET=sk_live_ABCDEFGHIJKLMNOPQRSTUVWX")
+	out, masked := maskSensitiveContent(input)
+	if !masked {
+		t.Error("expected masking")
+	}
+	if strings.Contains(string(out), "sk_live_") {
+		t.Errorf("Stripe key not masked: %s", out)
+	}
+}

--- a/internal/app/sanitize_test.go
+++ b/internal/app/sanitize_test.go
@@ -77,12 +77,31 @@ func TestMaskSensitiveContentSafeContent(t *testing.T) {
 		"## Done when",
 		"- Deploy to staging",
 		"work_dir: /Users/alice/code",
-		"token: [this is a reference to a design token]", // < 12 chars after colon
+		"token: [this is a reference to a design token]", // brackets not in value charset
 	}
 	for _, c := range cases {
 		out, masked := maskSensitiveContent([]byte(c))
 		if masked {
 			t.Errorf("false positive on %q — got %q", c, out)
+		}
+	}
+}
+
+func TestMaskSensitiveContentShortPassword(t *testing.T) {
+	// Any length value after a sensitive field name must be masked — no minimum.
+	cases := []string{
+		"password=secret123",
+		"password=abc",
+		"pwd=x1y2z3",
+		"secret=val",
+	}
+	for _, c := range cases {
+		out, masked := maskSensitiveContent([]byte(c))
+		if !masked {
+			t.Errorf("expected masking for %q", c)
+		}
+		if !strings.Contains(string(out), "<sensitive>") {
+			t.Errorf("expected <sensitive> in output for %q; got %q", c, out)
 		}
 	}
 }

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -730,7 +730,7 @@ runs the check.
 flow update task <slug> --work-dir <correct-path>
 ```
 
-**Security:** Bundles never contain session IDs, session timestamps, credentials, or any secrets.
+**Security:** Bundles never contain session IDs or session timestamps. All markdown files (briefs, updates, KB) are scanned for common secret patterns (passwords, API keys, tokens, private keys, connection strings) and masked with `<sensitive>` before export. A warning is printed when masking occurs. To fix a masked value after import, the recipient should update the relevant brief or update file manually.
 
 ## 6. The `work_dir` question — rules
 

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -694,6 +694,44 @@ topics) — that state only exists inside the running conversation. The
 hook's job is to make sure the skill is loaded; the skill is what
 runs the check.
 
+### 4.12 Export and import (`flow export` / `flow import`)
+
+**Triggers:** "export this task", "share this project", "hand off to a teammate",
+"export everything", "send my tasks", "import a bundle", "receive a handoff",
+"migrate to another machine", "give someone my tasks".
+
+**Export recipe:**
+
+1. Ask what to export using `AskUserQuestion`:
+   - header: "Export scope"
+   - options: ["This task (`flow export task`)", "A project (`flow export project`)", "Everything (`flow export all`)"]
+2. If task: use `$FLOW_TASK` if set, otherwise ask for the slug.
+   If project: use `$FLOW_PROJECT` if set, otherwise ask for the slug.
+3. Ask where to save with `AskUserQuestion`:
+   - header: "Output dir"
+   - options: ["Current directory (default)", "~/Desktop", "Custom path"]
+   - If "Custom path": ask the user to type it.
+4. Run the appropriate command:
+   ```
+   flow export task <slug> [--output <dir>]
+   flow export project <slug> [--output <dir>]
+   flow export all [--output <dir>]
+   ```
+5. Print the bundle path and tell the user to send the `.tar` file to their teammate.
+
+**Import recipe:**
+
+1. Run: `flow import <file>` (the `.tar` file received from the sender).
+2. If there is a conflict error, offer `--force` (overwrite) via `AskUserQuestion`.
+3. After success: run `flow show task <slug>` or `flow list tasks` to confirm.
+
+**Work-dir note:** `work_dir` paths are portable — the source machine's `$HOME` is replaced with `<HOME>` on export and expanded back to the target's `$HOME` on import. If the path doesn't exist on the target machine, a warning appears. Fix it with:
+```
+flow update task <slug> --work-dir <correct-path>
+```
+
+**Security:** Bundles never contain session IDs, session timestamps, credentials, or any secrets.
+
 ## 6. The `work_dir` question — rules
 
 When you're about to ask the user "where does this task live?", run


### PR DESCRIPTION
## Summary

  - Adds `flow export task|project|all` — creates a portable `.tar` bundle from the local `~/.flow/` data
  - Adds `flow import <file> [--force]` — unpacks a bundle into the target machine's `~/.flow/`, making everything immediately queryable via `flow list`, `flow show`, etc.
  - Export masks sensitive content in all markdown files (briefs, updates, KB) using deterministic regex patterns before bundling

  ## How it works

  **Bundle types**

  | Command | Output | Contains |
  |---------|--------|---------|
  | `flow export task <slug>` | `flow-task-<slug>-<date>.tar` | task.json, brief.md, updates/ |
  | `flow export project <slug>` | `flow-project-<slug>-<date>.tar` | project.json, brief.md, all tasks |
  | `flow export all` | `flow-all-<date>.tar` | all projects, tasks, KB files |

  **Portability** — `work_dir` paths use `$HOME` → `<HOME>` substitution on export, reversed on import so paths resolve correctly on the recipient's machine. A warning is printed if the path still needs manual updating.

  **Security** — Bundles never contain session IDs or session timestamps. Markdown files are scanned for secrets (passwords, API keys, tokens, private keys, connection strings) and masked with `<sensitive>` before export.

  **Conflict handling** — `flow import` errors on slug conflicts by default; `--force` overwrites.

  ## Test plan
  - [ ] `go test ./...` passes (11 new test functions, 1 flaky test fixed)
  - [ ] `flow export task <slug> --output /tmp` → inspect bundle with `tar -tvf`
  - [ ] `flow import <bundle>` → verify `flow show task` and `flow list tasks` reflect imported data
  - [ ] Export a brief containing `password=secret123` → confirm `<sensitive>` in bundle
  - [ ] Import on a different machine path → confirm `<HOME>` expansion in `work_dir`