### PR TITLE
feat: release binaries with auto skill upgrade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        include:
+          - goarch: arm64
+            asset: flow-darwin-arm64
+          - goarch: amd64
+            asset: flow-darwin-amd64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build ${{ matrix.asset }}
+        env:
+          GOOS: darwin
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: '0'
+        run: |
+          go build -trimpath \
+            -ldflags "-s -w -X main.version=${GITHUB_REF_NAME}" \
+            -o "${{ matrix.asset }}" .
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: ${{ matrix.asset }}
+          if-no-files-found: error
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Generate checksums
+        working-directory: dist
+        run: |
+          shasum -a 256 flow-darwin-* > SHA256SUMS
+          cat SHA256SUMS
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/flow-darwin-arm64
+            dist/flow-darwin-amd64
+            dist/SHA256SUMS
+          generate_release_notes: true
+          fail_on_unmatched_files: true

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
 BINARY   := flow
 REPO_DIR := $(shell pwd)
 
+# VERSION is injected into the binary via -ldflags. Defaults to "dev";
+# the release workflow overrides this with VERSION=<tag>.
+VERSION  ?= dev
+LDFLAGS  := -X main.version=$(VERSION)
+
 .PHONY: build install uninstall test clean
 
 build:
-	go build -o $(BINARY) .
+	go build -ldflags '$(LDFLAGS)' -o $(BINARY) .
 
 test:
 	go test ./...

--- a/README.md
+++ b/README.md
@@ -72,18 +72,72 @@ conversation — same context, same thread, same momentum.
 ## Prerequisites
 
 - macOS (iTerm2 for session spawning)
-- Go 1.25+ (to build from source)
 - [Claude Code](https://claude.ai/claude-code) CLI installed
 
 ## Install
 
+Download the latest binary for your Mac, mark it executable, clear the
+quarantine flag, and put it on your PATH:
+
 ```bash
-git clone git@github.com:Facets-cloud/flow.git && cd flow && make install && source ~/.zshrc
+# Apple Silicon (M1/M2/M3/M4):
+ARCH=arm64
+# Intel:
+# ARCH=amd64
+
+curl -fsSL -o /usr/local/bin/flow \
+  "https://github.com/Facets-cloud/flow/releases/latest/download/flow-darwin-${ARCH}"
+chmod +x /usr/local/bin/flow
+xattr -d com.apple.quarantine /usr/local/bin/flow 2>/dev/null || true
+
+flow init
 ```
 
-Then run **`claude`** and say **"let's get to work"**. The flow skill
-is installed at ~/.claude/skills/flow/SKILL.md. To refresh it after
-upgrading flow, run `flow skill update` (or `make install` again).
+`flow init` creates `~/.flow/`, the database, the knowledge base, and
+installs the flow skill into `~/.claude/skills/flow/SKILL.md` plus a
+SessionStart hook in `~/.claude/settings.json`.
+
+Then run **`claude`** and say **"let's get to work"**.
+
+> The `xattr` step removes Gatekeeper's quarantine attribute so macOS
+> doesn't refuse to run the unsigned binary. If you prefer, the first
+> launch will fail and you can right-click → Open in Finder to allow
+> it instead.
+
+## Upgrade
+
+Re-download the binary the same way you installed it:
+
+```bash
+curl -fsSL -o /usr/local/bin/flow \
+  "https://github.com/Facets-cloud/flow/releases/latest/download/flow-darwin-${ARCH}"
+chmod +x /usr/local/bin/flow
+xattr -d com.apple.quarantine /usr/local/bin/flow 2>/dev/null || true
+```
+
+The next time you run any flow command, the binary detects the version
+bump and refreshes the skill + SessionStart hook automatically. Check
+the running version with:
+
+```bash
+flow --version
+```
+
+## Build from source
+
+If you want to hack on flow, clone and build with the included
+Makefile:
+
+```bash
+git clone git@github.com:Facets-cloud/flow.git
+cd flow
+make install     # builds, adds repo dir to PATH, installs skill + hook
+source ~/.zshrc
+flow init
+```
+
+Local dev builds are tagged `dev` and skip the auto-upgrade check, so
+you can iterate on the skill without your changes being clobbered.
 
 ## Usage
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -7,6 +7,11 @@ import (
 	"os"
 )
 
+// Version holds the binary version string, set by main.go from a
+// `-ldflags -X main.version=<tag>` build. Defaults to "dev" if main
+// never assigns it (e.g. tests linking the package directly).
+var Version = "dev"
+
 // Run is the entry point for the CLI. Returns an exit code.
 func Run(args []string) int {
 	if len(args) == 0 {
@@ -14,7 +19,22 @@ func Run(args []string) int {
 		return 0
 	}
 	cmd, rest := args[0], args[1:]
+
+	// Auto-upgrade the skill + SessionStart hook if the binary version
+	// has changed since the last install. Skipped for `init`, `skill`,
+	// and `--version` — those manage the skill themselves or need to
+	// run before any install state exists. See maybeAutoUpgradeSkill.
 	switch cmd {
+	case "init", "skill", "--version", "-v", "version", "-h", "--help", "help":
+		// no auto-upgrade
+	default:
+		maybeAutoUpgradeSkill()
+	}
+
+	switch cmd {
+	case "--version", "-v", "version":
+		fmt.Println(Version)
+		return 0
 	case "init":
 		return cmdInit(rest)
 	case "add":

--- a/internal/app/init.go
+++ b/internal/app/init.go
@@ -108,6 +108,9 @@ func cmdInit(args []string) int {
 			fmt.Fprintf(os.Stderr, "error: write %s: %v\n", skillPath, err)
 			return 1
 		}
+		if err := writeSkillVersion(Version); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not record skill version: %v\n", err)
+		}
 		fmt.Printf("installed flow skill to %s\n", skillPath)
 	} else if err != nil {
 		fmt.Fprintf(os.Stderr, "error: stat %s: %v\n", skillPath, err)

--- a/internal/app/skill.go
+++ b/internal/app/skill.go
@@ -32,6 +32,45 @@ func skillInstallPath() (string, error) {
 	return filepath.Join(home, ".claude", "skills", "flow", "SKILL.md"), nil
 }
 
+// skillVersionPath returns the sidecar file that records which binary
+// version installed the current SKILL.md — used by the auto-upgrade
+// check to decide whether to refresh the skill.
+func skillVersionPath() (string, error) {
+	skill, err := skillInstallPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(filepath.Dir(skill), "VERSION"), nil
+}
+
+// readSkillVersion returns the recorded version string, or "" if the
+// sidecar file is missing or unreadable.
+func readSkillVersion() string {
+	p, err := skillVersionPath()
+	if err != nil {
+		return ""
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+// writeSkillVersion records v as the version of the binary that
+// installed the current SKILL.md. Errors are non-fatal — failing to
+// write the sidecar should never block a successful skill install.
+func writeSkillVersion(v string) error {
+	p, err := skillVersionPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(p, []byte(v+"\n"), 0o644)
+}
+
 // userSettingsPath returns ~/.claude/settings.json.
 func userSettingsPath() (string, error) {
 	home, err := os.UserHomeDir()
@@ -39,6 +78,45 @@ func userSettingsPath() (string, error) {
 		return "", fmt.Errorf("no home dir: %w", err)
 	}
 	return filepath.Join(home, ".claude", "settings.json"), nil
+}
+
+// maybeAutoUpgradeSkill checks the recorded skill version against the
+// running binary's version and, if they differ, refreshes the skill +
+// SessionStart hook. Designed to run on every flow invocation so the
+// user gets a self-healing upgrade flow after replacing the binary.
+//
+// The check is intentionally conservative — it does nothing when:
+//   - The binary is a "dev" build (Version == "dev"). Local devs use
+//     `make install` and shouldn't fight an auto-installer.
+//   - The skill isn't installed at all (sentinel: SKILL.md missing).
+//     Treat this as an explicit user opt-out; never re-install.
+//   - The recorded version already matches Version. The common path.
+//
+// All errors are silent — auto-upgrade is best-effort plumbing, not a
+// command. A user-visible failure here would be far more annoying than
+// the eventual symptom of a stale skill.
+func maybeAutoUpgradeSkill() {
+	if Version == "" || Version == "dev" {
+		return
+	}
+	skillPath, err := skillInstallPath()
+	if err != nil {
+		return
+	}
+	if _, err := os.Stat(skillPath); err != nil {
+		// Not installed → user opted out; don't reinstall behind their back.
+		return
+	}
+	if readSkillVersion() == Version {
+		return
+	}
+	// Version mismatch — refresh skill bytes and the SessionStart hook.
+	if err := os.WriteFile(skillPath, embeddedSkill, 0o644); err != nil {
+		return
+	}
+	_ = writeSkillVersion(Version)
+	_, _ = installSessionStartHook()
+	fmt.Fprintf(os.Stderr, "flow: upgraded skill to %s\n", Version)
 }
 
 // cmdSkill dispatches `flow skill install|uninstall|update`.
@@ -88,6 +166,9 @@ func skillInstall(args []string, forceDefault bool) int {
 	if err := os.WriteFile(dest, embeddedSkill, 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "error: write %s: %v\n", dest, err)
 		return 1
+	}
+	if err := writeSkillVersion(Version); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not record skill version: %v\n", err)
 	}
 	fmt.Printf("installed flow skill to %s\n", dest)
 

--- a/internal/app/version_test.go
+++ b/internal/app/version_test.go
@@ -1,0 +1,126 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// withVersion temporarily overrides the package-level Version for the
+// duration of a test.
+func withVersion(t *testing.T, v string) {
+	t.Helper()
+	old := Version
+	Version = v
+	t.Cleanup(func() { Version = old })
+}
+
+func TestSkillInstallWritesVersionSidecar(t *testing.T) {
+	home := withTempHome(t)
+	withVersion(t, "v9.9.9")
+
+	if rc := cmdSkill([]string{"install"}); rc != 0 {
+		t.Fatalf("install rc=%d", rc)
+	}
+	got, err := os.ReadFile(filepath.Join(home, ".claude", "skills", "flow", "VERSION"))
+	if err != nil {
+		t.Fatalf("read VERSION: %v", err)
+	}
+	if want := "v9.9.9\n"; string(got) != want {
+		t.Errorf("VERSION sidecar = %q, want %q", got, want)
+	}
+}
+
+func TestCmdInitWritesVersionSidecar(t *testing.T) {
+	initTempFlowRoot(t)
+	withVersion(t, "v1.2.3")
+
+	if rc := cmdInit(nil); rc != 0 {
+		t.Fatalf("cmdInit rc=%d", rc)
+	}
+	if got := readSkillVersion(); got != "v1.2.3" {
+		t.Errorf("readSkillVersion=%q, want v1.2.3", got)
+	}
+}
+
+func TestMaybeAutoUpgradeUpgradesOnMismatch(t *testing.T) {
+	home := withTempHome(t)
+	withVersion(t, "v1.0.0")
+	if rc := cmdSkill([]string{"install"}); rc != 0 {
+		t.Fatalf("install rc=%d", rc)
+	}
+	// Stomp on the on-disk skill so we can detect the refresh.
+	skillPath := filepath.Join(home, ".claude", "skills", "flow", "SKILL.md")
+	if err := os.WriteFile(skillPath, []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Bump binary version → auto-upgrade should trigger.
+	Version = "v2.0.0"
+	maybeAutoUpgradeSkill()
+
+	got, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) == "stale" {
+		t.Error("auto-upgrade did not refresh SKILL.md")
+	}
+	if v := readSkillVersion(); v != "v2.0.0" {
+		t.Errorf("VERSION sidecar=%q after upgrade, want v2.0.0", v)
+	}
+}
+
+func TestMaybeAutoUpgradeIdempotent(t *testing.T) {
+	home := withTempHome(t)
+	withVersion(t, "v1.0.0")
+	if rc := cmdSkill([]string{"install"}); rc != 0 {
+		t.Fatalf("install rc=%d", rc)
+	}
+	skillPath := filepath.Join(home, ".claude", "skills", "flow", "SKILL.md")
+	before, _ := os.Stat(skillPath)
+
+	// Same version → no rewrite.
+	maybeAutoUpgradeSkill()
+
+	after, err := os.Stat(skillPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Error("auto-upgrade rewrote SKILL.md when version was unchanged")
+	}
+}
+
+func TestMaybeAutoUpgradeSkipsForDev(t *testing.T) {
+	home := withTempHome(t)
+	withVersion(t, "v1.0.0")
+	if rc := cmdSkill([]string{"install"}); rc != 0 {
+		t.Fatalf("install rc=%d", rc)
+	}
+	skillPath := filepath.Join(home, ".claude", "skills", "flow", "SKILL.md")
+	if err := os.WriteFile(skillPath, []byte("dev edits"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Dev build → must not touch user-edited skill.
+	Version = "dev"
+	maybeAutoUpgradeSkill()
+
+	got, _ := os.ReadFile(skillPath)
+	if string(got) != "dev edits" {
+		t.Error("dev build clobbered locally-edited SKILL.md")
+	}
+}
+
+func TestMaybeAutoUpgradeSkipsWhenSkillMissing(t *testing.T) {
+	withTempHome(t)
+	withVersion(t, "v2.0.0")
+
+	// No install, no skill on disk → should be a no-op.
+	maybeAutoUpgradeSkill()
+
+	if _, err := os.Stat(filepath.Join(os.Getenv("HOME"), ".claude", "skills", "flow", "SKILL.md")); !os.IsNotExist(err) {
+		t.Errorf("auto-upgrade created a skill file when none existed; err=%v", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,12 @@ import (
 	"flow/internal/app"
 )
 
+// version is the binary version string. Overridden at build time via
+// `-ldflags -X main.version=<tag>` from the GitHub Actions release
+// workflow. A value of "dev" means an unversioned local build.
+var version = "dev"
+
 func main() {
+	app.Version = version
 	os.Exit(app.Run(os.Args[1:]))
 }


### PR DESCRIPTION
## Summary

Ships the pipeline needed to make flow installable as a downloadable binary instead of `git clone && make install`:

- **Version embedding** — `-ldflags -X main.version=$TAG`; `flow --version` prints it. Default is `dev` for local builds.
- **Auto skill upgrade** — `~/.claude/skills/flow/VERSION` sidecar records the installing binary's version. On every flow invocation (except `init`/`skill`/`--version`), if the recorded version differs from the running binary's, SKILL.md and the SessionStart hook refresh automatically. Silent for matching versions, no-op for `dev` builds, no-op when the skill isn't installed at all.
- **Release workflow** — `.github/workflows/release.yml` triggers on `push: tags: 'v*'`, builds darwin/arm64 + darwin/amd64 with `-trimpath -ldflags "-s -w -X main.version=$TAG"`, uploads to a GitHub Release with SHA256SUMS.
- **README** — install/upgrade sections rewritten around direct binary download with the `xattr -d com.apple.quarantine` workaround for unsigned binaries. `make install` still documented under "Build from source".
- **Tests** — five new tests in `internal/app/version_test.go` cover sidecar write, init flow, version-mismatch upgrade, idempotency, dev skip, and skill-not-installed skip.

Out of scope: Linux/Windows builds, install scripts, Homebrew tap, code signing/notarization, self-update of the binary itself.

## Test plan

- [x] `go vet ./... && go test ./...` (full suite green)
- [x] Cross-compile darwin/arm64 + darwin/amd64 locally; both produce valid Mach-O binaries with the embedded version
- [x] End-to-end smoke: dev install → rebuild as v0.1.0 → next flow command auto-upgrades skill, prints "flow: upgraded skill to v0.1.0", subsequent runs are silent
- [ ] Cut a real `v0.1.0` tag after merge to exercise the release workflow against actual GitHub Actions
- [ ] Fresh-machine install via the README curl + xattr path