### PR TITLE
feat: write project updates during done close-out sweep

### DIFF
--- a/internal/app/done.go
+++ b/internal/app/done.go
@@ -8,10 +8,11 @@ import (
 	"os/exec"
 )
 
-// claudeRunner invokes the headless `claude -p` CLI for the KB sweep.
-// Tests override this var to capture invocations without spawning claude.
-// Stdout/stderr are discarded — the sweep prompt instructs claude to
-// write KB entries silently and produce no chat output.
+// claudeRunner invokes the headless `claude -p` CLI for the post-done
+// close-out sweep. Tests override this var to capture invocations
+// without spawning claude. Stdout/stderr are discarded — the sweep
+// prompt instructs claude to write KB entries and (when applicable) a
+// project update silently and produce no chat output.
 var claudeRunner = func(slug, prompt string) error {
 	cmd := exec.Command("claude", "-p", prompt, "--dangerously-skip-permissions")
 	cmd.Env = append(os.Environ(), "FLOW_TASK="+slug)
@@ -26,11 +27,19 @@ var claudeRunner = func(slug, prompt string) error {
 // manually reopening the task if the user ever needs to.
 //
 // After the status flip, if the task has a session_id, done synchronously
-// spawns a headless `claude -p` session that loads the flow skill, reads
-// the task's transcript, and applies §4.10 scoop rules to ~/.flow/kb/*.md.
-// The CLI prints "updating kbs..." while it waits. A failed sweep
-// (missing claude binary, non-zero exit) only emits a warning — the
-// status flip is the contract; the sweep is best-effort.
+// spawns a single headless `claude -p` session that loads the flow skill,
+// reads the task's transcript, and runs a two-part close-out sweep:
+//  1. KB scoop per §4.10 → ~/.flow/kb/*.md.
+//  2. If the task is attached to a project, optionally write one
+//     project-level update at
+//     ~/.flow/projects/<slug>/updates/<date>-<title>.md capturing
+//     decisions/learnings worth carrying forward to sibling-task
+//     sessions. Substance gating is delegated to the LLM — empty or
+//     purely-mechanical sessions yield no file.
+//
+// The CLI prints "updating kbs, project updates..." while it waits.
+// A failed sweep (missing claude binary, non-zero exit) only emits a
+// warning — the status flip is the contract; the sweep is best-effort.
 func cmdDone(args []string) int {
 	if len(args) == 0 {
 		fmt.Fprintln(os.Stderr, "error: done requires a task ref")
@@ -75,10 +84,14 @@ func cmdDone(args []string) int {
 	fmt.Printf("Marked %s as done\n", task.Slug)
 
 	if task.SessionID.Valid && task.SessionID.String != "" {
-		fmt.Print("updating kbs...")
-		if err := claudeRunner(task.Slug, buildKBSweepPrompt(task.Slug)); err != nil {
+		fmt.Print("updating kbs, project updates...")
+		projectSlug := ""
+		if task.ProjectSlug.Valid {
+			projectSlug = task.ProjectSlug.String
+		}
+		if err := claudeRunner(task.Slug, buildCloseoutSweepPrompt(task.Slug, projectSlug)); err != nil {
 			fmt.Println()
-			fmt.Fprintf(os.Stderr, "warning: kb sweep failed: %v\n", err)
+			fmt.Fprintf(os.Stderr, "warning: close-out sweep failed: %v\n", err)
 		} else {
 			fmt.Println(" done")
 		}
@@ -86,29 +99,60 @@ func cmdDone(args []string) int {
 	return 0
 }
 
-// buildKBSweepPrompt composes the headless prompt that drives the
-// post-done KB sweep. The prompt is passed as a single positional arg
-// to `claude -p` via exec.Command — no shell interpolation, so any
-// characters are safe.
+// buildCloseoutSweepPrompt composes the headless prompt that drives
+// the post-done close-out sweep. The prompt is passed as a single
+// positional arg to `claude -p` via exec.Command — no shell
+// interpolation, so any characters are safe.
 //
-// All dedupe/append discipline lives in the flow skill (§4.10), not in
-// this prompt. The prompt's job is just: load the skill, read the
-// transcript, apply the rules. The skill takes it from there.
-func buildKBSweepPrompt(slug string) string {
-	return fmt.Sprintf(
-		"You are running an automated KB sweep for completed flow task %q. Do this:\n\n"+
-			"1. Invoke the flow skill via the Skill tool. This loads §4.10 (the scoop-mode KB rules) which you must follow exactly.\n\n"+
+// Two responsibilities, executed in order by the same headless session:
+//  1. KB scoop — append durable facts to ~/.flow/kb/*.md per §4.10.
+//  2. (only when projectSlug != "") project update — optionally write
+//     one ~/.flow/projects/<projectSlug>/updates/<date>-<title>.md
+//     capturing project-level decisions/learnings worth carrying
+//     forward to future sibling-task sessions. Same shape as task
+//     updates per §4.5.
+//
+// All dedupe/append discipline and update-file shape lives in the flow
+// skill, not in this prompt. The prompt's job is just: load the skill,
+// read the transcript, apply the rules. Substance gating is delegated
+// to the LLM — empty or purely-mechanical sessions yield no new
+// entries and no project update.
+func buildCloseoutSweepPrompt(slug, projectSlug string) string {
+	header := fmt.Sprintf(
+		"You are running an automated close-out sweep for completed flow task %q. Do this:\n\n"+
+			"1. Invoke the flow skill via the Skill tool. This loads §4.10 (the scoop-mode KB rules) and §4.5 (update-file shape) which you must follow exactly.\n\n"+
 			"2. Run: flow transcript %s\n"+
 			"   This prints the conversation transcript from the task's Claude session. Read it carefully.\n\n"+
-			"3. For each of these five files, decide whether the transcript revealed any durable facts that belong there per §4.10's bucket table:\n"+
+			"3. KB sweep. For each of these five files, decide whether the transcript revealed any durable facts that belong there per §4.10's bucket table:\n"+
 			"   - ~/.flow/kb/user.md\n"+
 			"   - ~/.flow/kb/org.md\n"+
 			"   - ~/.flow/kb/products.md\n"+
 			"   - ~/.flow/kb/processes.md\n"+
 			"   - ~/.flow/kb/business.md\n\n"+
-			"4. For each file you decide needs new entries, Read it first to check for duplicates, then append entries using the §4.10 entry format (one dated bullet per fact, never invent, never embellish, deduplicate against existing entries).\n\n"+
-			"5. Do not output a chat summary. Just write the files silently and exit.\n\n"+
-			"If the transcript is empty or contains no durable facts, do nothing. This is normal — most tasks won't yield new KB entries.",
+			"4. For each KB file you decide needs new entries, Read it first to check for duplicates, then append entries using the §4.10 entry format (one dated bullet per fact, never invent, never embellish, deduplicate against existing entries).\n\n",
 		slug, slug,
 	)
+
+	tailNum := "5"
+	projectStep := ""
+	if projectSlug != "" {
+		projectStep = fmt.Sprintf(
+			"5. Project update. This task is attached to project %q. Consider whether the transcript shows substantive project-level decisions, learnings, or status changes that future sessions on sibling tasks should benefit from. If so, write ONE update file at:\n"+
+				"   ~/.flow/projects/%s/updates/YYYY-MM-DD-<kebab-title>.md\n"+
+				"   - Filename: today's date in YYYY-MM-DD followed by a 3-5 word kebab-case title.\n"+
+				"   - Shape per skill §4.5: <=10 lines, two paragraphs. Paragraph 1: what got decided/learned/shipped at the project level. Paragraph 2: what is next or now open. Optional trailing 'Blocked on: <X>' line.\n"+
+				"   - Substance gate: write ONLY if the session moved the project forward in a way future sibling-task sessions should know about. Mechanical work, narrow bug fixes, and local-only refactors usually do not warrant a project update — skip in that case. There is no obligation to produce a file.\n"+
+				"   - Do NOT write a template or placeholder. Either write a real update or skip.\n\n",
+			projectSlug, projectSlug,
+		)
+		tailNum = "6"
+	}
+
+	tail := fmt.Sprintf(
+		"%s. Do not output a chat summary. Just write the files silently and exit.\n\n"+
+			"If the transcript is empty or contains nothing durable, do nothing. This is normal — most tasks will not yield new entries.",
+		tailNum,
+	)
+
+	return header + projectStep + tail
 }

--- a/internal/app/done_test.go
+++ b/internal/app/done_test.go
@@ -128,11 +128,89 @@ func TestCmdDoneRunsSweepWhenSessionExists(t *testing.T) {
 		t.Error("call prompt is empty")
 	}
 	// Sanity-check the prompt mentions key behavior so a regression in
-	// buildKBSweepPrompt that drops the skill load or the transcript
-	// step gets caught here.
+	// buildCloseoutSweepPrompt that drops the skill load or the
+	// transcript step gets caught here.
 	for _, want := range []string{"flow skill", "flow transcript has-session", "kb/"} {
 		if !contains(got.prompt, want) {
 			t.Errorf("prompt missing %q", want)
+		}
+	}
+}
+
+// TestCmdDoneCloseoutSweepIncludesProjectStep verifies that when the
+// task is attached to a project, the close-out prompt includes the
+// project-update step pointing at the project's updates/ directory.
+func TestCmdDoneCloseoutSweepIncludesProjectStep(t *testing.T) {
+	setupFlowRoot(t)
+	calls := stubClaudeRunner(t, nil)
+
+	wd := t.TempDir()
+	if rc := cmdAdd([]string{"project", "Some Proj", "--slug", "sp", "--work-dir", wd}); rc != 0 {
+		t.Fatalf("add project rc=%d", rc)
+	}
+	if rc := cmdAdd([]string{"task", "Has Proj", "--project", "sp"}); rc != 0 {
+		t.Fatalf("add task rc=%d", rc)
+	}
+
+	db := openFlowDB(t)
+	if _, err := db.Exec(
+		`UPDATE tasks SET session_id=?, session_started=? WHERE slug=?`,
+		"hp-uuid", flowdb.NowISO(), "has-proj",
+	); err != nil {
+		t.Fatalf("seed session_id: %v", err)
+	}
+	db.Close()
+
+	if rc := cmdDone([]string{"has-proj"}); rc != 0 {
+		t.Fatalf("done rc=%d", rc)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("expected 1 sweep call, got %d", len(*calls))
+	}
+	got := (*calls)[0].prompt
+	for _, want := range []string{
+		"Project update",
+		"\"sp\"",
+		"~/.flow/projects/sp/updates/",
+	} {
+		if !contains(got, want) {
+			t.Errorf("prompt missing %q", want)
+		}
+	}
+}
+
+// TestCmdDoneCloseoutSweepSkipsProjectStepForFloating verifies that
+// floating tasks (no project) get a prompt without any project-update
+// instructions or path references.
+func TestCmdDoneCloseoutSweepSkipsProjectStepForFloating(t *testing.T) {
+	setupFlowRoot(t)
+	calls := stubClaudeRunner(t, nil)
+
+	if rc := cmdAdd([]string{"task", "Floating"}); rc != 0 {
+		t.Fatalf("add task rc=%d", rc)
+	}
+	db := openFlowDB(t)
+	if _, err := db.Exec(
+		`UPDATE tasks SET session_id=?, session_started=? WHERE slug=?`,
+		"f-uuid", flowdb.NowISO(), "floating",
+	); err != nil {
+		t.Fatalf("seed session_id: %v", err)
+	}
+	db.Close()
+
+	if rc := cmdDone([]string{"floating"}); rc != 0 {
+		t.Fatalf("done rc=%d", rc)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("expected 1 sweep call, got %d", len(*calls))
+	}
+	got := (*calls)[0].prompt
+	for _, unwanted := range []string{
+		"Project update",
+		"~/.flow/projects/",
+	} {
+		if contains(got, unwanted) {
+			t.Errorf("floating-task prompt unexpectedly contains %q", unwanted)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Extends the existing post-`flow done` KB sweep to also write an optional project-level update file at `~/.flow/projects/<slug>/updates/<date>-<title>.md` when the closed task is attached to a project.
- Same single headless `claude -p` invocation handles both responsibilities — no extra process. Substance gating is delegated to the LLM, so empty or purely-mechanical sessions yield nothing.
- Floating tasks (no project) skip the new step cleanly.

## Test plan
- [x] `go test ./...` — all green, including two new tests pinning the project-step inclusion/skip behavior (`TestCmdDoneCloseoutSweepIncludesProjectStep`, `TestCmdDoneCloseoutSweepSkipsProjectStepForFloating`).
- [ ] Manual smoke: `flow done <project-attached-task>` produces an update file when the session had substantive project-level activity, and produces nothing for a no-op session.
- [ ] Manual smoke: `flow done <floating-task>` runs the KB-only sweep and writes no project file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)