### PR TITLE
feat: macOS Terminal.app backend + always-on skill nudge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,8 @@ bugs reproduce deterministically with a small command sequence.
 
 ## Scope
 
-flow is **macOS + iTerm2 + Claude Code** by design. Cross-platform
-support, alternative spawners, and non-Claude integrations are out of
-scope for the current motion. If you have a use case that would change
-that, open an issue first to discuss before sending code.
+flow is **macOS (iTerm2 or stock Terminal.app) + Claude Code** by
+design. Linux/tmux/zellij/wezterm, Windows Terminal, and non-Claude
+integrations are out of scope for the current motion. If you have a
+use case that would change that, open an issue first to discuss
+before sending code.

--- a/README.md
+++ b/README.md
@@ -156,8 +156,9 @@ handles the rest.
 ## What you get
 
 - **One task, one Claude session, one tab.** `flow do <task>`
-  spawns a dedicated iTerm tab. Tomorrow's `flow do <task>` resumes
-  the same conversation.
+  spawns a dedicated tab in iTerm2 or stock macOS Terminal — flow
+  picks whichever you launched it from. Tomorrow's `flow do <task>`
+  resumes the same conversation.
 - **Interview-driven task capture.** No forms. flow asks
   what / why / where / done-when, then writes a structured brief.
 - **A knowledge base that grows.** Five markdown buckets for
@@ -175,12 +176,27 @@ handles the rest.
 ## How it works under the hood
 
 `flow do <task>` pre-allocates a session UUID, writes it to the
-task row, and spawns an iTerm tab running `claude --session-id <uuid>`
-with `FLOW_TASK` / `FLOW_PROJECT` inlined. The jsonl file lands at
-the deterministic path `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`,
-so future `flow do` calls run `claude --resume <uuid>` to continue
-the same conversation. A SessionStart hook re-injects the task brief,
-updates, and CLAUDE.md context on every resume.
+task row, and spawns a tab in iTerm2 or stock Terminal.app (chosen
+by `TERM_PROGRAM`, falls back to iTerm) running
+`claude --session-id <uuid>` with `FLOW_TASK` / `FLOW_PROJECT`
+inlined. The jsonl file lands at the deterministic path
+`~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`, so future
+`flow do` calls run `claude --resume <uuid>` to continue the same
+conversation. A SessionStart hook re-injects the task brief,
+updates, and CLAUDE.md context on every resume; a UserPromptSubmit
+hook keeps the flow skill discoverable in ad-hoc Claude sessions.
+
+The first `flow do` from stock Terminal.app needs macOS Accessibility
+permission for the **app hosting your shell** — not the `flow` binary
+itself. Terminal.app's AppleScript dictionary has no "make new tab"
+verb, so flow drives cmd-T through System Events, and System Events
+checks Accessibility against the responsible parent app. Until that's
+granted, `flow do` errors out with a multi-line explanation pointing at
+System Settings → Privacy & Security → Accessibility (enable the
+toggle for "Terminal" if you launched flow from Terminal.app, "iTerm"
+from iTerm2, "Claude" if Claude Code is the host, etc.; add it via the
++ button if it's not listed). After the grant the spawn is silent.
+iTerm2 doesn't need this — it has a native `create tab` verb.
 
 ## Your data — local, portable, yours
 
@@ -245,9 +261,9 @@ and reinstall the skill + hook.
 
 ## Where flow runs (and where we'd love help)
 
-Today flow runs on **macOS + iTerm2 + Claude Code only**. That's the
-stack we use, and that's what the session-spawn layer was built and
-tested against.
+Today flow runs on **macOS (iTerm2 or stock Terminal.app) + Claude
+Code only**. That's the stack we use, and that's what the
+session-spawn layer was built and tested against.
 
 The architecture is portable — session spawning is one small
 package — but other harnesses (Codex, Cursor, plain shell) and other

--- a/internal/app/do.go
+++ b/internal/app/do.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"flow/internal/flowdb"
-	"flow/internal/iterm"
+	"flow/internal/spawner"
 	"fmt"
 	"net/url"
 	"os"
@@ -223,7 +223,7 @@ func cmdDo(args []string) int {
 			isFirstRun = runCount <= 1
 		}
 		prompt := buildBootstrapPromptForKindV2(task.Slug, task.Kind, playbookSlug, isFirstRun)
-		command = fmt.Sprintf("claude --session-id %s %s", sessionID, iterm.ShellQuote(prompt))
+		command = fmt.Sprintf("claude --session-id %s %s", sessionID, spawner.ShellQuote(prompt))
 	} else {
 		// Resume path: the UUID we already have in the DB is what claude
 		// used to write its existing jsonl.
@@ -236,7 +236,28 @@ func cmdDo(args []string) int {
 	if project != nil {
 		envVars["FLOW_PROJECT"] = project.Slug
 	}
-	if err := iterm.SpawnTab(buildTabTitle(project, task), cwd, command, envVars); err != nil {
+	if err := spawner.SpawnTab(buildTabTitle(project, task), cwd, command, envVars); err != nil {
+		if needsBootstrap {
+			// Spawn failed before claude could write its jsonl. Undo
+			// the session_id pre-allocation so the next `flow do`
+			// retries bootstrap fresh; otherwise the DB has a
+			// session_id with no backing jsonl and every subsequent
+			// `flow do` runs `claude --resume <uuid>` which fails
+			// with "No conversation found" indefinitely. The status
+			// flip is preserved: the task is genuinely in-progress
+			// even when spawn fails, and the user's next attempt
+			// should resume that intent.
+			//
+			// The WHERE clause guards against a concurrent `flow do`
+			// having mutated session_id between commit and now —
+			// only nil it out if it's still the UUID we allocated.
+			if _, undoErr := db.Exec(
+				`UPDATE tasks SET session_id=NULL, session_started=NULL WHERE slug=? AND session_id=?`,
+				task.Slug, sessionID,
+			); undoErr != nil {
+				fmt.Fprintf(os.Stderr, "warning: rollback pre-allocated session after spawn failure: %v\n", undoErr)
+			}
+		}
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
 	}

--- a/internal/app/do_test.go
+++ b/internal/app/do_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"flow/internal/flowdb"
 	"flow/internal/iterm"
 	"strings"
@@ -85,6 +86,95 @@ func TestCmdDoFreshAllocatesSessionID(t *testing.T) {
 	}
 	if !strings.Contains(script, "fresh-task") {
 		t.Errorf("spawn script missing task slug: %s", script)
+	}
+}
+
+// TestCmdDoFreshSpawnFailureRollsBackSessionID pins the rollback
+// invariant: when a fresh-bootstrap spawn fails (e.g. Terminal.app
+// Accessibility denied), the session_id we pre-allocated must be
+// nilled out so the next `flow do` retries bootstrap fresh. Without
+// this, the DB ends up with a session_id pointing at a non-existent
+// jsonl file, and every subsequent `flow do` runs `claude --resume
+// <uuid>` which fails with "No conversation found" indefinitely.
+//
+// Repro of the user-reported bug: spawn-failure → DB has orphan
+// session_id → next flow do takes resume path → claude can't find
+// the jsonl. The fix preserves the status flip (task is in-progress
+// even though spawn failed) but undoes the session_id allocation.
+func TestCmdDoFreshSpawnFailureRollsBackSessionID(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "fail-task")
+
+	const pinnedSID = "ffffffff-aaaa-bbbb-cccc-dddddddddddd"
+	oldNewUUID := newUUID
+	newUUID = func() (string, error) { return pinnedSID, nil }
+	t.Cleanup(func() { newUUID = oldNewUUID })
+
+	// Stub iterm.Runner to fail every call — simulates the
+	// Accessibility-denied path on Terminal.app, but works equally
+	// well to model any spawn failure.
+	old := iterm.Runner
+	iterm.Runner = func(args []string) error { return errors.New("simulated osascript failure") }
+	t.Cleanup(func() { iterm.Runner = old })
+
+	if rc := cmdDo([]string{"fail-task"}); rc != 1 {
+		t.Errorf("cmdDo on spawn failure: got rc=%d, want 1", rc)
+	}
+
+	db := openFlowDB(t)
+	task, err := flowdb.GetTask(db, "fail-task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.SessionID.Valid {
+		t.Errorf("session_id should be NULL after spawn failure rollback; got %q", task.SessionID.String)
+	}
+	if task.SessionStarted.Valid {
+		t.Errorf("session_started should be NULL after spawn failure rollback; got %q", task.SessionStarted.String)
+	}
+	// Status flip is preserved — the task is genuinely in-progress
+	// even though spawn failed. The user's next attempt should
+	// resume that intent without re-flipping.
+	if task.Status != "in-progress" {
+		t.Errorf("status after spawn failure: got %q, want in-progress (flip preserved)", task.Status)
+	}
+}
+
+// TestCmdDoResumeSpawnFailureKeepsSessionID is the inverse of the
+// fresh-bootstrap case: when a RESUME spawn fails (the session_id
+// already pointed at a real jsonl from a previous successful spawn),
+// the DB row must be left untouched. A transient osascript failure
+// should not cost the user their conversation history.
+func TestCmdDoResumeSpawnFailureKeepsSessionID(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "resume-fail-task")
+
+	db := openFlowDB(t)
+	const existingSID = "real-existing-sid"
+	if _, err := db.Exec(
+		`UPDATE tasks SET session_id=?, session_started=? WHERE slug='resume-fail-task'`,
+		existingSID, flowdb.NowISO(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+
+	old := iterm.Runner
+	iterm.Runner = func(args []string) error { return errors.New("simulated osascript failure") }
+	t.Cleanup(func() { iterm.Runner = old })
+
+	if rc := cmdDo([]string{"resume-fail-task"}); rc != 1 {
+		t.Errorf("cmdDo on resume spawn failure: got rc=%d, want 1", rc)
+	}
+
+	db = openFlowDB(t)
+	task, err := flowdb.GetTask(db, "resume-fail-task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !task.SessionID.Valid || task.SessionID.String != existingSID {
+		t.Errorf("session_id was rolled back on a RESUME spawn failure; got %+v, want %s",
+			task.SessionID, existingSID)
 	}
 }
 

--- a/internal/app/hook.go
+++ b/internal/app/hook.go
@@ -6,21 +6,31 @@ import (
 	"os"
 )
 
-// cmdHook dispatches `flow hook <subcommand>`. The only subcommand in
-// v2 is `session-start`, which is intended to be wired as a Claude Code
-// SessionStart hook so that EVERY session start (fresh spawn AND resume)
-// re-injects the "load your task context" instruction. Without the hook,
-// resumed sessions never re-read briefs and updates that may have been
-// edited since the previous session.
+// cmdHook dispatches `flow hook <subcommand>`. Two subcommands:
+//
+//   - session-start: wired as a Claude Code SessionStart hook so that
+//     every session start (fresh spawn AND resume) re-injects the
+//     "load your task context" instruction. Without it, resumed
+//     sessions never re-read briefs and updates that may have been
+//     edited since the previous session.
+//
+//   - user-prompt-submit: wired as a UserPromptSubmit hook. Fires on
+//     every user prompt; in ad-hoc sessions (FLOW_TASK unset) it
+//     reminds Claude to invoke the flow skill before responding so the
+//     §4.14 substantive-work check actually runs. In bound sessions
+//     (FLOW_TASK set) it no-ops; the SessionStart context already
+//     covers the bound case.
 func cmdHook(args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "error: hook requires a subcommand (session-start)")
+		fmt.Fprintln(os.Stderr, "error: hook requires a subcommand (session-start|user-prompt-submit)")
 		return 2
 	}
 	sub, rest := args[0], args[1:]
 	switch sub {
 	case "session-start":
 		return cmdHookSessionStart(rest)
+	case "user-prompt-submit":
+		return cmdHookUserPromptSubmit(rest)
 	default:
 		fmt.Fprintf(os.Stderr, "error: unknown hook subcommand %q\n", sub)
 		return 2
@@ -85,26 +95,48 @@ func cmdHookSessionStart(args []string) int {
 }
 
 // emitAmbientSkillHint is the FLOW_TASK-unset branch of the SessionStart
-// hook. Used for ad-hoc `claude` sessions where there is no specific
-// task to load. It nudges Claude to invoke the flow skill when
-// the user's request touches flow-managed concerns, and — critically —
-// to offer to create a new flow task or switch to an existing one when
-// the user starts substantive work without a task attached. Otherwise
-// the transcript of this session is homeless: no brief, no updates, no
-// resumability tomorrow.
+// hook. The user has installed flow — a personal task/session manager
+// and knowledge base — and benefits from having work flow through it.
+// The hint frames that value prop and tells Claude to load the skill;
+// it deliberately does NOT ask Claude to pre-judge whether the user's
+// request is "substantive enough". That gate is the skill's job, not
+// the hook's, and prior framing leaked Claude's interpretive bias.
 func emitAmbientSkillHint() int {
-	hint := "This session is not bound to any flow task (FLOW_TASK is unset).\n" +
-		"When substantive work emerges, run §4.14 of the flow skill to offer the user a flow task.\n" +
-		"The check is ongoing, not one-shot — re-evaluate on every turn."
+	hint := "This Claude session is not bound to a flow task. The user already tracks " +
+		"their work and knowledge in flow — a personal task and session manager that " +
+		"captures work as briefs, logs progress notes, resumes Claude sessions across " +
+		"days, and maintains a central knowledge base of durable facts about them, " +
+		"their org, and their work. Their tasks, projects, and KB already exist. " +
+		"Invoke the `flow` skill via the Skill tool now and let it run alongside the " +
+		"conversation. When the user starts any work in this session, before doing it, " +
+		"confirm with them via AskUserQuestion: is this part of an existing flow task, " +
+		"or should we create a new one? The user's work belongs in flow — don't " +
+		"silently proceed in an unbound transcript. The skill knows how to list " +
+		"candidates, run intake, and `flow do` the chosen task. " +
+		"\n\n" +
+		"If the user's message uses unfamiliar terminology — an internal codename, a " +
+		"person, a customer, a product line, a tool you don't recognize — consult " +
+		"flow's data before guessing or asking. The KB at ~/.flow/kb/ holds durable " +
+		"facts; the briefs under ~/.flow/projects/<slug>/ and ~/.flow/tasks/<slug>/ " +
+		"hold project and task context. Names and context that are non-obvious from " +
+		"this conversation alone are very likely already documented there. The skill's " +
+		"§4.10 governs how to lazy-load these without reading them eagerly every turn."
 	return emitSessionStartContext(hint)
 }
 
-// emitSessionStartContext marshals the SessionStart hookSpecificOutput
-// shape to stdout. Shared by both the per-task and ambient paths.
+// emitSessionStartContext is a thin wrapper around emitHookContext for
+// the SessionStart event.
 func emitSessionStartContext(ctx string) int {
+	return emitHookContext("SessionStart", ctx)
+}
+
+// emitHookContext marshals a hookSpecificOutput payload for the given
+// Claude Code hook event name. Used by both SessionStart and
+// UserPromptSubmit hook handlers.
+func emitHookContext(event, ctx string) int {
 	out := map[string]any{
 		"hookSpecificOutput": map[string]any{
-			"hookEventName":     "SessionStart",
+			"hookEventName":     event,
 			"additionalContext": ctx,
 		},
 	}
@@ -113,4 +145,41 @@ func emitSessionStartContext(ctx string) int {
 		return 1
 	}
 	return 0
+}
+
+// cmdHookUserPromptSubmit implements `flow hook user-prompt-submit`.
+// In ad-hoc sessions (FLOW_TASK unset) it emits a directive instructing
+// Claude to invoke the flow skill BEFORE responding and to apply
+// §4.14. No keyword gate — the directive fires on every prompt because
+// users describe substantive work in their own words ("help me build
+// X", "fix this bug") and won't say "create a task" themselves.
+//
+// In bound sessions (FLOW_TASK set) it exits 0 with no output. The
+// SessionStart hook already loaded full task context for those, and
+// repeating that on every prompt would be noisy and expensive.
+func cmdHookUserPromptSubmit(args []string) int {
+	fs := flagSet("hook user-prompt-submit")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if os.Getenv("FLOW_TASK") != "" {
+		// Bound session — no-op.
+		return 0
+	}
+	hint := "The user already tracks their work and knowledge in flow (a personal " +
+		"task/session manager with a central knowledge base of durable facts about " +
+		"them, their org, and their work) and this Claude session is unbound. Their " +
+		"tasks and KB already exist. Before responding: invoke the `flow` skill via " +
+		"the Skill tool if you haven't already this session — it is the operating " +
+		"manual for capturing work as flow tasks, logging progress, and keeping the " +
+		"user's KB current. When the user starts any work in this session, before " +
+		"doing it, confirm with them via AskUserQuestion: is this part of an existing " +
+		"flow task, or should we create a new one? The user's work belongs in flow — " +
+		"don't silently proceed in an unbound transcript. " +
+		"If the user's wording is non-standard or uses names/codenames/tools you " +
+		"don't recognize, consult flow's KB (~/.flow/kb/), project briefs " +
+		"(~/.flow/projects/), and task briefs (~/.flow/tasks/) before guessing or " +
+		"asking. The skill's §4.10 governs lazy-loading so you don't read everything " +
+		"every turn."
+	return emitHookContext("UserPromptSubmit", hint)
 }

--- a/internal/app/hook_test.go
+++ b/internal/app/hook_test.go
@@ -8,9 +8,10 @@ import (
 
 // TestHookSessionStartNoFlowTaskEmitsAmbientHint pins the contract for
 // ad-hoc sessions (e.g. bare `claude` with no FLOW_TASK): the hook must
-// emit a one-liner pointing at §4.14 of the flow skill. The skill —
-// not the hook — owns the substantive-work detection logic and offers
-// the three-choice prompt; the hook is only the one-shot trigger.
+// emit a value-prop framing that names flow, instructs Skill-tool
+// invocation, and explicitly disclaims any "substantive" gate. The
+// skill — not the hook — owns the decision of whether to offer a task,
+// save a KB entry, or stay quiet.
 func TestHookSessionStartNoFlowTaskEmitsAmbientHint(t *testing.T) {
 	t.Setenv("FLOW_TASK", "")
 	out := captureStdout(t, func() {
@@ -31,16 +32,29 @@ func TestHookSessionStartNoFlowTaskEmitsAmbientHint(t *testing.T) {
 		t.Errorf("hookEventName = %q, want SessionStart", parsed.HookSpecificOutput.HookEventName)
 	}
 	ctx := parsed.HookSpecificOutput.AdditionalContext
-	// Must point at §4.14 of the flow skill (skill owns the logic).
-	if !strings.Contains(ctx, "4.14") {
-		t.Errorf("ambient hint must reference §4.14, got:\n%s", ctx)
+	for _, want := range []string{
+		"already tracks",
+		"`flow` skill",
+		"Skill tool",
+		"knowledge base",
+		"AskUserQuestion",
+		"existing flow task",
+		"create a new one",
+		"~/.flow/kb/",
+		"don't recognize",
+	} {
+		if !strings.Contains(ctx, want) {
+			t.Errorf("ambient hint missing %q; got:\n%s", want, ctx)
+		}
 	}
-	// Must communicate that the check is ongoing, not one-shot.
-	if !strings.Contains(ctx, "ongoing, not one-shot") {
-		t.Errorf("ambient hint must say %q, got:\n%s", "ongoing, not one-shot", ctx)
+	// The hint must NOT mention "substantive" — naming the past gate
+	// just primes Claude to think about gating again. Affirmative
+	// framing only: load the skill, confirm task binding, proceed.
+	if strings.Contains(ctx, "substantive") {
+		t.Errorf("ambient hint must not mention 'substantive'; got:\n%s", ctx)
 	}
-	// Must NOT include task-specific instructions (register-session,
-	// reading the brief) since there is no task bound to this session.
+	// Must NOT include task-specific instructions (no register-session,
+	// no slug-bound reload).
 	if strings.Contains(ctx, "flow register-session") {
 		t.Errorf("ambient hint should not instruct register-session (no FLOW_TASK bound):\n%s", ctx)
 	}
@@ -84,6 +98,70 @@ func TestHookSessionStartRequiresSkillInvocation(t *testing.T) {
 	}
 	if !strings.Contains(ctx, "some-slug") {
 		t.Errorf("additionalContext should mention the task slug, got:\n%s", ctx)
+	}
+}
+
+// TestHookUserPromptSubmitAdHocEmitsSkillNudge pins the contract for
+// ad-hoc sessions (FLOW_TASK unset): every prompt must produce a
+// hookSpecificOutput payload that nudges Claude to invoke the flow
+// skill and apply §4.14 — without keyword gating, since users won't
+// say "create a task" themselves.
+func TestHookUserPromptSubmitAdHocEmitsSkillNudge(t *testing.T) {
+	t.Setenv("FLOW_TASK", "")
+	out := captureStdout(t, func() {
+		if rc := cmdHookUserPromptSubmit(nil); rc != 0 {
+			t.Fatalf("rc=%d", rc)
+		}
+	})
+	var parsed struct {
+		HookSpecificOutput struct {
+			HookEventName     string `json:"hookEventName"`
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("parse hook output: %v\nraw: %s", err, out)
+	}
+	if parsed.HookSpecificOutput.HookEventName != "UserPromptSubmit" {
+		t.Errorf("hookEventName = %q, want UserPromptSubmit",
+			parsed.HookSpecificOutput.HookEventName)
+	}
+	ctx := parsed.HookSpecificOutput.AdditionalContext
+	for _, want := range []string{
+		"already tracks",
+		"`flow` skill",
+		"Skill tool",
+		"knowledge base",
+		"AskUserQuestion",
+		"existing flow task",
+		"create a new one",
+		"~/.flow/kb/",
+		"don't recognize",
+	} {
+		if !strings.Contains(ctx, want) {
+			t.Errorf("UserPromptSubmit ambient hint missing %q; got:\n%s", want, ctx)
+		}
+	}
+	// Must NOT mention "substantive" — see SessionStart test for the
+	// rationale (don't prime Claude on the rejected gate).
+	if strings.Contains(ctx, "substantive") {
+		t.Errorf("UserPromptSubmit hint must not mention 'substantive'; got:\n%s", ctx)
+	}
+}
+
+// TestHookUserPromptSubmitBoundIsNoOp pins the bound-session contract:
+// when FLOW_TASK is set, the hook exits 0 with no output. The
+// SessionStart hook already loaded full task context; repeating it on
+// every prompt would be noisy and expensive.
+func TestHookUserPromptSubmitBoundIsNoOp(t *testing.T) {
+	t.Setenv("FLOW_TASK", "some-slug")
+	out := captureStdout(t, func() {
+		if rc := cmdHookUserPromptSubmit(nil); rc != 0 {
+			t.Fatalf("rc=%d", rc)
+		}
+	})
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("expected empty stdout when FLOW_TASK is set, got:\n%s", out)
 	}
 }
 

--- a/internal/app/skill.go
+++ b/internal/app/skill.go
@@ -22,6 +22,11 @@ const hookCommand = "flow hook session-start"
 // fresh startup and `claude --resume`.
 const hookMatcher = "startup|resume"
 
+// userPromptSubmitHookCommand is the exact string written into
+// settings.json under hooks.UserPromptSubmit. Same stability rule as
+// hookCommand: changing this string would orphan existing installs.
+const userPromptSubmitHookCommand = "flow hook user-prompt-submit"
+
 // skillInstallPath returns the absolute path where the skill should be
 // installed on disk: ~/.claude/skills/flow/SKILL.md.
 func skillInstallPath() (string, error) {
@@ -116,6 +121,7 @@ func maybeAutoUpgradeSkill() {
 	}
 	_ = writeSkillVersion(Version)
 	_, _ = installSessionStartHook()
+	_, _ = installUserPromptSubmitHook()
 	fmt.Fprintf(os.Stderr, "flow: upgraded skill to %s\n", Version)
 }
 
@@ -188,6 +194,15 @@ func skillInstall(args []string, forceDefault bool) int {
 	} else {
 		fmt.Println("SessionStart hook already installed — leaving as is")
 	}
+	if added, err := installUserPromptSubmitHook(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not install UserPromptSubmit hook: %v\n", err)
+		return 0
+	} else if added {
+		settings, _ := userSettingsPath()
+		fmt.Printf("installed UserPromptSubmit hook in %s (nudges flow skill on every ad-hoc prompt)\n", settings)
+	} else {
+		fmt.Println("UserPromptSubmit hook already installed — leaving as is")
+	}
 	return 0
 }
 
@@ -224,19 +239,54 @@ func skillUninstall(args []string) int {
 		settings, _ := userSettingsPath()
 		fmt.Printf("removed SessionStart hook from %s\n", settings)
 	}
+	if removed, err := uninstallUserPromptSubmitHook(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not remove UserPromptSubmit hook: %v\n", err)
+		return 0
+	} else if removed {
+		settings, _ := userSettingsPath()
+		fmt.Printf("removed UserPromptSubmit hook from %s\n", settings)
+	}
 	return 0
 }
 
 // installSessionStartHook idempotently adds the flow SessionStart hook
-// to ~/.claude/settings.json. Returns (added, err) where added is true
-// if the settings file was actually modified (false if the hook was
-// already present).
-//
-// The merge preserves all existing top-level keys, all existing hooks
-// under other events (PreToolUse, etc.), and all existing SessionStart
-// entries. It only appends a new entry if no existing SessionStart
-// entry references `flow hook session-start`.
+// to ~/.claude/settings.json. Thin wrapper around installClaudeHook.
 func installSessionStartHook() (bool, error) {
+	return installClaudeHook("SessionStart", hookMatcher, hookCommand)
+}
+
+// uninstallSessionStartHook removes the flow SessionStart hook entry.
+// Thin wrapper around uninstallClaudeHook.
+func uninstallSessionStartHook() (bool, error) {
+	return uninstallClaudeHook("SessionStart", hookCommand)
+}
+
+// installUserPromptSubmitHook idempotently adds the flow
+// UserPromptSubmit hook. Fires on every user prompt; the hook command
+// itself decides whether to emit additionalContext (FLOW_TASK unset)
+// or no-op (FLOW_TASK set).
+func installUserPromptSubmitHook() (bool, error) {
+	// UserPromptSubmit doesn't take a matcher.
+	return installClaudeHook("UserPromptSubmit", "", userPromptSubmitHookCommand)
+}
+
+// uninstallUserPromptSubmitHook removes the flow UserPromptSubmit hook
+// entry. Thin wrapper around uninstallClaudeHook.
+func uninstallUserPromptSubmitHook() (bool, error) {
+	return uninstallClaudeHook("UserPromptSubmit", userPromptSubmitHookCommand)
+}
+
+// installClaudeHook idempotently adds a hook entry for the given
+// Claude Code event to ~/.claude/settings.json. matcher may be empty —
+// some events (UserPromptSubmit, Notification) don't use a matcher and
+// the field is omitted from the entry. command is both the literal
+// command Claude Code will execute AND the marker we look for to decide
+// whether the hook is already installed.
+//
+// Returns (added, err) where added is true iff the file was modified.
+// The merge preserves all existing top-level keys, all hooks under
+// other events, and all existing entries under the same event.
+func installClaudeHook(event, matcher, command string) (bool, error) {
 	path, err := userSettingsPath()
 	if err != nil {
 		return false, err
@@ -263,11 +313,9 @@ func installSessionStartHook() (bool, error) {
 	if hooks == nil {
 		hooks = map[string]any{}
 	}
-	sessionStart, _ := hooks["SessionStart"].([]any)
+	entries, _ := hooks[event].([]any)
 
-	// Walk existing SessionStart entries; if any inner hook's command
-	// equals our marker, it's already installed.
-	for _, entry := range sessionStart {
+	for _, entry := range entries {
 		m, ok := entry.(map[string]any)
 		if !ok {
 			continue
@@ -278,24 +326,25 @@ func installSessionStartHook() (bool, error) {
 			if !ok {
 				continue
 			}
-			if cmd, _ := hm["command"].(string); cmd == hookCommand {
+			if cmd, _ := hm["command"].(string); cmd == command {
 				return false, nil
 			}
 		}
 	}
 
-	// Not present — append our entry.
 	newEntry := map[string]any{
-		"matcher": hookMatcher,
 		"hooks": []any{
 			map[string]any{
 				"type":    "command",
-				"command": hookCommand,
+				"command": command,
 			},
 		},
 	}
-	sessionStart = append(sessionStart, newEntry)
-	hooks["SessionStart"] = sessionStart
+	if matcher != "" {
+		newEntry["matcher"] = matcher
+	}
+	entries = append(entries, newEntry)
+	hooks[event] = entries
 	settings["hooks"] = hooks
 
 	out, err := json.MarshalIndent(settings, "", "  ")
@@ -309,10 +358,10 @@ func installSessionStartHook() (bool, error) {
 	return true, nil
 }
 
-// uninstallSessionStartHook removes any SessionStart entry whose inner
-// hooks reference the flow hook command. Returns (removed, err) where
-// removed is true if the settings file was actually modified.
-func uninstallSessionStartHook() (bool, error) {
+// uninstallClaudeHook removes any entry under hooks.<event> whose
+// inner hook list contains a command matching the given marker.
+// Returns (removed, err) where removed is true iff the file changed.
+func uninstallClaudeHook(event, command string) (bool, error) {
 	path, err := userSettingsPath()
 	if err != nil {
 		return false, err
@@ -332,14 +381,14 @@ func uninstallSessionStartHook() (bool, error) {
 	if hooks == nil {
 		return false, nil
 	}
-	sessionStart, _ := hooks["SessionStart"].([]any)
-	if len(sessionStart) == 0 {
+	entries, _ := hooks[event].([]any)
+	if len(entries) == 0 {
 		return false, nil
 	}
 
 	changed := false
-	kept := make([]any, 0, len(sessionStart))
-	for _, entry := range sessionStart {
+	kept := make([]any, 0, len(entries))
+	for _, entry := range entries {
 		m, ok := entry.(map[string]any)
 		if !ok {
 			kept = append(kept, entry)
@@ -354,14 +403,13 @@ func uninstallSessionStartHook() (bool, error) {
 				continue
 			}
 			cmd, _ := hm["command"].(string)
-			if strings.TrimSpace(cmd) == hookCommand {
+			if strings.TrimSpace(cmd) == command {
 				changed = true
 				continue
 			}
 			filteredInner = append(filteredInner, h)
 		}
 		if len(filteredInner) == 0 {
-			// Entry had only our hook → drop the entry entirely.
 			changed = true
 			continue
 		}
@@ -373,9 +421,9 @@ func uninstallSessionStartHook() (bool, error) {
 		return false, nil
 	}
 	if len(kept) == 0 {
-		delete(hooks, "SessionStart")
+		delete(hooks, event)
 	} else {
-		hooks["SessionStart"] = kept
+		hooks[event] = kept
 	}
 	if len(hooks) == 0 {
 		delete(settings, "hooks")

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -42,6 +42,38 @@ edits they imply. You never edit `flow.db` directly. You never solve
 problems during task intake — you interview, then write what the user
 said.
 
+## 1a. When invoked explicitly with no intent
+
+If this skill is invoked without a trigger phrase — for example the
+user typed `/flow` or asked you to load the flow skill but did not
+say what they want done — DO NOT auto-run any workflow. Do not
+silently call `flow list tasks`, do not enter §4.1 "start the day",
+do not propose opening a task, do not start an intake interview.
+The user just asked what this skill is for. Answer that question
+first; let them choose what happens next.
+
+**Behavior:**
+
+1. In 2–3 sentences, describe what you can do for the user with
+   flow under the hood — capture work as briefs, log progress
+   notes, resume Claude sessions across days, track what they're
+   waiting on. Frame it as your capabilities, not commands. The
+   user does not need to learn flow's CLI.
+2. Use `AskUserQuestion` (header: "What now?") to offer the main
+   actions. Pick 3–4 options that fit the current state — for
+   example:
+   - "Show me what's on my plate" — runs §4.1 start-the-day.
+   - "Add a new task" — runs §4.2 task intake.
+   - "Add a project" — runs §4.3 project intake.
+   - "Just exploring" — stop and wait.
+3. Dispatch on the user's pick. If "Just exploring" or the user
+   skips the question, stop and let them lead.
+
+This section ONLY governs the bare-invocation case. Trigger-phrase
+recipes in §4 ("what should I work on", "add a task", etc.) still
+fire on natural-language requests — when the user already expressed
+an intent, follow the matching recipe instead of re-asking via §1a.
+
 ## 2. The model
 
 - **Projects** group related tasks. Every project has a name, a slug, a
@@ -85,12 +117,12 @@ run `flow list tasks` or `flow list projects` as a probe:
 - If the command **succeeds** (even with zero results): flow is
   initialized. Proceed normally. **Do not check again this session.**
 - If the command **errors** with a message about a missing database:
-  the user hasn't run `flow init` yet. Use `AskUserQuestion` (header:
-  "Run init?", options: "Yes, run flow init" / "No, I'll do it later")
-  with question text explaining that `flow init` sets up the data
-  directory (`$FLOW_ROOT` if set, otherwise `~/.flow`) and database.
-  If "Yes", run `flow init` and then enter the **first-run coaching**
-  below. If "No", stop.
+  the user hasn't initialized flow yet. Use `AskUserQuestion` (header:
+  "Set up flow?", options: "Yes, set it up" / "No, not now") with
+  question text describing flow as a personal task and session
+  manager that will store its data in `$FLOW_ROOT` (or `~/.flow` if
+  unset). On "Yes", run `flow init` yourself and then enter the
+  **first-run coaching** below. On "No", stop.
 
 ### First-run coaching
 
@@ -383,9 +415,9 @@ why they made it. Immediately after `flow add project` succeeds:
    Where / Done when / Out of scope / Open questions as usual.
 3. If the user says "I don't know yet" or "just create the project
    for now", DO NOT create a placeholder task and DO NOT silently
-   drop it. Instead, explicitly tell them: "OK, no task for now.
-   Remember: run `flow add task --project <slug>` before `flow do`,
-   because there's nothing to do yet on this project."
+   drop it. Instead, explicitly tell them: "OK, no task for now —
+   just tell me when you're ready to add one and I'll set it up."
+   Do not surface the underlying `flow` commands.
 4. If the user describes several tasks at once, create them all via
    sequential §5.2 interviews. Don't try to batch-extract; one
    interview per task.
@@ -451,6 +483,34 @@ and stop. Do NOT:
 If `flow do` itself errored (rc != 0), relay the error and stop. Do
 not attempt workarounds; the user will decide what to do next.
 
+#### Special case: macOS Accessibility error from the Terminal.app backend
+
+When `flow do` runs from a stock Terminal.app shell and macOS hasn't
+granted Accessibility, the binary returns a multi-line error that
+explicitly names "Terminal" as the app needing the grant and includes
+a `open "x-apple.systempreferences:..."` URL to jump straight to the
+right Settings pane. When you see that error:
+
+1. **Trust the error verbatim.** It says "Terminal" because macOS
+   attributes Accessibility to the responsible parent app, which is
+   Terminal.app — NOT Claude Code, NOT the flow binary. Do not advise
+   the user to toggle "Claude" or "flow"; that wastes their time.
+2. **Open the Accessibility pane for them**: run
+   `open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"`.
+3. **Tell the user, in plain language**, what to do next: enable the
+   toggle for "Terminal" in the list (or click + and add Terminal.app
+   from `/System/Applications/Utilities/` if it isn't shown).
+4. **Wait for the user to confirm** they've granted it. Don't poll
+   or retry on a timer.
+5. When they confirm, retry the original `flow do` invocation with
+   the same flags they originally chose (session mode, `--fresh`,
+   etc.).
+
+Macros for this: do not invent more candidate apps to toggle, do not
+suggest the user reinstall flow, do not attempt to grant Accessibility
+yourself. macOS guards Accessibility deliberately — there is no CLI to
+self-grant it, and Claude cannot bypass that.
+
 ### 4.5 Save a progress note
 
 **Triggers:** "save a note", "log progress", "write an update", "note
@@ -515,9 +575,9 @@ to disambiguate which task this is for.
 **Recipe:**
 
 1. Confirm via `AskUserQuestion` (header: "Mark done?", options:
-   "Yes, `flow done <slug>`" / "No, not yet") before mutating. Per
-   §8, never mark done without explicit confirmation — even if the
-   user says "great, I finished that".
+   "Yes, mark it done" / "No, not yet") before mutating. Per §8,
+   never mark done without explicit confirmation — even if the user
+   says "great, I finished that".
 2. If the user hasn't just saved a progress note, use
    `AskUserQuestion` (header: "Closing note?", options:
    "Yes, save a note first" / "No, just mark done") to offer.
@@ -1204,6 +1264,17 @@ type. Always prefer the tool. If you find yourself typing "Want me
 to X?" or "Should I Y?" into chat, stop and use `AskUserQuestion`
 instead.
 
+- **Do not surface flow commands to the user.** You use flow under
+  the hood; users never need to learn the CLI. Never tell the user
+  to "run `flow X`", "type `flow Y`", or "see `flow Z --help`".
+  Never put a literal `flow ...` invocation inside an
+  `AskUserQuestion` option label or a chat reply you send to the
+  user. Describe outcomes ("I'll mark it done", "I'll archive it",
+  "set up", "saved") instead of commands. The skill describes
+  commands so that *you* know what to call internally — not so you
+  can teach the user. Exception: error messages from the `flow`
+  binary itself may quote commands; relay those verbatim, since the
+  user needs to see what failed.
 - **Do not invent context.** If the user says "add a task for the
   budgeting thing", ASK what the budgeting thing is (via
   `AskUserQuestion` if you can list candidates from existing tasks /
@@ -1222,8 +1293,8 @@ instead.
   "No, stay on `<current-task>`"). Don't assume.
 - **Do not mark tasks done without explicit confirmation.** Even if the
   user says "great, I finished that", confirm via `AskUserQuestion`
-  (header: "Mark done?", options: "Yes, `flow done <slug>`" / "No,
-  not yet") and wait for the click.
+  (header: "Mark done?", options: "Yes, mark it done" / "No, not
+  yet") and wait for the click.
 - **Do not hand-edit `session_id` or any other DB field.** Never edit
   `flow.db` directly, never instruct the user to. The only supported
   mutations are `flow` commands.

--- a/internal/app/skill_test.go
+++ b/internal/app/skill_test.go
@@ -1,11 +1,62 @@
 package app
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func readSettings(t *testing.T, path string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("parse settings: %v\nraw: %s", err, raw)
+	}
+	return m
+}
+
+func hookEventReferencesCommand(hooks map[string]any, event, command string) bool {
+	entries, _ := hooks[event].([]any)
+	return countMatchingHookEntries(entries, command) >= 1
+}
+
+func countMatchingHookEntries(entries []any, command string) int {
+	n := 0
+	for _, entry := range entries {
+		m, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		inner, _ := m["hooks"].([]any)
+		for _, h := range inner {
+			hm, ok := h.(map[string]any)
+			if !ok {
+				continue
+			}
+			if cmd, _ := hm["command"].(string); cmd == command {
+				n++
+				break
+			}
+		}
+	}
+	return n
+}
+
+func expectedCommand(event string) string {
+	switch event {
+	case "SessionStart":
+		return "flow hook session-start"
+	case "UserPromptSubmit":
+		return "flow hook user-prompt-submit"
+	}
+	return ""
+}
 
 // withTempHome redirects $HOME to a tempdir for the duration of the test.
 func withTempHome(t *testing.T) string {
@@ -104,6 +155,76 @@ func TestSkillUninstallIdempotent(t *testing.T) {
 	// Nothing installed — uninstall should still succeed.
 	if rc := cmdSkill([]string{"uninstall"}); rc != 0 {
 		t.Errorf("uninstall on empty home rc=%d", rc)
+	}
+}
+
+// TestSkillInstallWritesBothHooks verifies install wires up BOTH the
+// SessionStart hook (existing behavior) and the new UserPromptSubmit
+// hook into ~/.claude/settings.json.
+func TestSkillInstallWritesBothHooks(t *testing.T) {
+	home := withTempHome(t)
+	if rc := cmdSkill([]string{"install"}); rc != 0 {
+		t.Fatalf("install rc=%d", rc)
+	}
+	settings := readSettings(t, filepath.Join(home, ".claude", "settings.json"))
+	hooks, _ := settings["hooks"].(map[string]any)
+	if hooks == nil {
+		t.Fatal("settings.json has no hooks key")
+	}
+	if !hookEventReferencesCommand(hooks, "SessionStart", "flow hook session-start") {
+		t.Errorf("SessionStart hook missing or wrong command: %#v", hooks["SessionStart"])
+	}
+	if !hookEventReferencesCommand(hooks, "UserPromptSubmit", "flow hook user-prompt-submit") {
+		t.Errorf("UserPromptSubmit hook missing or wrong command: %#v", hooks["UserPromptSubmit"])
+	}
+}
+
+// TestSkillInstallIsIdempotent verifies a second install --force does
+// not duplicate either hook entry. Past regressions append duplicates
+// silently; pin against that.
+func TestSkillInstallIsIdempotent(t *testing.T) {
+	home := withTempHome(t)
+	if rc := cmdSkill([]string{"install"}); rc != 0 {
+		t.Fatalf("first install rc=%d", rc)
+	}
+	if rc := cmdSkill([]string{"install", "--force"}); rc != 0 {
+		t.Fatalf("second install --force rc=%d", rc)
+	}
+	settings := readSettings(t, filepath.Join(home, ".claude", "settings.json"))
+	hooks, _ := settings["hooks"].(map[string]any)
+	for _, event := range []string{"SessionStart", "UserPromptSubmit"} {
+		entries, _ := hooks[event].([]any)
+		if got := countMatchingHookEntries(entries, expectedCommand(event)); got != 1 {
+			t.Errorf("%s: got %d matching entries, want 1", event, got)
+		}
+	}
+}
+
+// TestSkillUninstallRemovesBothHooks verifies uninstall strips both
+// hook entries and ends with an empty hooks map (or no hooks key).
+func TestSkillUninstallRemovesBothHooks(t *testing.T) {
+	home := withTempHome(t)
+	if rc := cmdSkill([]string{"install"}); rc != 0 {
+		t.Fatalf("install rc=%d", rc)
+	}
+	if rc := cmdSkill([]string{"uninstall"}); rc != 0 {
+		t.Fatalf("uninstall rc=%d", rc)
+	}
+	settings := readSettings(t, filepath.Join(home, ".claude", "settings.json"))
+	hooks, _ := settings["hooks"].(map[string]any)
+	if hooks != nil && len(hooks) != 0 {
+		t.Errorf("expected hooks map empty or absent after uninstall, got %#v", hooks)
+	}
+}
+
+// TestSkillInstallSkipHook leaves settings.json untouched when --skip-hook.
+func TestSkillInstallSkipHook(t *testing.T) {
+	home := withTempHome(t)
+	if rc := cmdSkill([]string{"install", "--skip-hook"}); rc != 0 {
+		t.Fatalf("install --skip-hook rc=%d", rc)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "settings.json")); !os.IsNotExist(err) {
+		t.Errorf("--skip-hook should not create settings.json; stat err=%v", err)
 	}
 }
 
@@ -234,6 +355,76 @@ func TestSkillHasMidInterviewDriftRule(t *testing.T) {
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("skill missing mid-interview-drift content %q", want)
+		}
+	}
+}
+
+// TestSkillHasAccessibilityErrorRecipe pins the §4.4 recipe for
+// handling the macOS Accessibility error from the Terminal.app
+// backend: name Terminal definitively (not Claude/flow), open the
+// right Settings pane via the deep-link URL, and retry only after
+// explicit user confirmation.
+func TestSkillHasAccessibilityErrorRecipe(t *testing.T) {
+	got := string(embeddedSkill)
+	for _, want := range []string{
+		"macOS Accessibility error from the Terminal.app backend",
+		"Trust the error verbatim",
+		"NOT Claude Code",
+		"NOT the flow binary",
+		"x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
+		"there is no CLI to",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("skill missing Accessibility recipe: %q", want)
+		}
+	}
+}
+
+// TestSkillHasExplicitInvocationSection pins the §1a behavior: when
+// the skill is invoked without a trigger phrase, it should describe
+// its capabilities and AskUserQuestion for the user's intent — NOT
+// auto-run §4.1, auto-list tasks, or auto-propose opening a task.
+func TestSkillHasExplicitInvocationSection(t *testing.T) {
+	got := string(embeddedSkill)
+	for _, want := range []string{
+		"## 1a. When invoked explicitly with no intent",
+		"DO NOT auto-run any workflow",
+		"do not enter §4.1",
+		`What now?`,
+		"Just exploring",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("skill missing §1a content: %q", want)
+		}
+	}
+}
+
+// TestSkillNoCliCoachingInUserFacingLabels pins the rule that the
+// skill must not put literal `flow ...` invocations inside
+// AskUserQuestion option labels or chat replies. Users should never
+// see CLI commands; Claude uses flow under the hood.
+//
+// We pin two specific past offenders that motivated the sweep — the
+// "Run init?" prompt that read "Yes, run flow init", and the
+// "Mark done?" prompt that read "Yes, `flow done <slug>`". If either
+// regresses, a future sweep loses ground silently.
+func TestSkillNoCliCoachingInUserFacingLabels(t *testing.T) {
+	got := string(embeddedSkill)
+	for _, banned := range []string{
+		`"Yes, run flow init"`,
+		"\"Yes, `flow done <slug>`\"",
+	} {
+		if strings.Contains(got, banned) {
+			t.Errorf("user-facing label still exposes CLI: %s", banned)
+		}
+	}
+	// And the rule itself must be present in §8.
+	for _, want := range []string{
+		"Do not surface flow commands to the user",
+		"users never need to learn the CLI",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("skill missing CLI-coaching anti-pattern: %q", want)
 		}
 	}
 }

--- a/internal/spawner/spawner.go
+++ b/internal/spawner/spawner.go
@@ -1,0 +1,69 @@
+// Package spawner picks a terminal backend (iTerm2 or macOS Terminal.app)
+// at runtime and forwards SpawnTab to it.
+//
+// Selection is driven by the TERM_PROGRAM env var that the host
+// terminal sets in every shell it spawns:
+//
+//	TERM_PROGRAM=iTerm.app        → internal/iterm
+//	TERM_PROGRAM=Apple_Terminal   → internal/terminal
+//	anything else (or unset)      → internal/iterm  (historical default)
+//
+// The Override var lets tests pin the backend deterministically without
+// having to set TERM_PROGRAM via t.Setenv. Existing tests that mock
+// iterm.Runner continue to work unchanged because the default fallback
+// is iTerm.
+package spawner
+
+import (
+	"flow/internal/iterm"
+	"flow/internal/terminal"
+	"os"
+)
+
+// Backend identifies which terminal app a SpawnTab call targets.
+type Backend string
+
+const (
+	BackendITerm    Backend = "iterm"
+	BackendTerminal Backend = "terminal"
+)
+
+// Override, if non-empty, forces a backend regardless of TERM_PROGRAM.
+// Used by tests; production code should leave it as "".
+var Override Backend
+
+// Detect returns the backend that SpawnTab will use for the current
+// process environment. Exposed so callers (and tests) can inspect the
+// choice without spawning.
+func Detect() Backend {
+	if Override != "" {
+		return Override
+	}
+	switch os.Getenv("TERM_PROGRAM") {
+	case "Apple_Terminal":
+		return BackendTerminal
+	case "iTerm.app":
+		return BackendITerm
+	default:
+		return BackendITerm
+	}
+}
+
+// SpawnTab opens a tab in the auto-detected backend. The contract
+// matches both iterm.SpawnTab and terminal.SpawnTab.
+func SpawnTab(title, cwd, command string, envVars map[string]string) error {
+	switch Detect() {
+	case BackendTerminal:
+		return terminal.SpawnTab(title, cwd, command, envVars)
+	default:
+		return iterm.SpawnTab(title, cwd, command, envVars)
+	}
+}
+
+// ShellQuote is re-exported so callers don't need to import the chosen
+// backend just to quote a value before handing it to SpawnTab. Both
+// backends quote identically (POSIX single-quote with embedded-quote
+// escape), so we delegate to iterm's implementation.
+func ShellQuote(s string) string {
+	return iterm.ShellQuote(s)
+}

--- a/internal/spawner/spawner_test.go
+++ b/internal/spawner/spawner_test.go
@@ -1,0 +1,128 @@
+package spawner
+
+import (
+	"flow/internal/iterm"
+	"flow/internal/terminal"
+	"strings"
+	"testing"
+)
+
+// TestDetectFromEnv verifies the TERM_PROGRAM → backend mapping. The
+// Override knob has higher precedence and is checked separately below.
+func TestDetectFromEnv(t *testing.T) {
+	cases := []struct {
+		termProgram string
+		want        Backend
+	}{
+		{"iTerm.app", BackendITerm},
+		{"Apple_Terminal", BackendTerminal},
+		{"", BackendITerm},
+		{"WezTerm", BackendITerm},
+		{"vscode", BackendITerm},
+	}
+	for _, tc := range cases {
+		t.Run(tc.termProgram, func(t *testing.T) {
+			t.Setenv("TERM_PROGRAM", tc.termProgram)
+			Override = ""
+			if got := Detect(); got != tc.want {
+				t.Errorf("Detect() with TERM_PROGRAM=%q: got %q, want %q",
+					tc.termProgram, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestOverrideBeatsEnv confirms the test escape hatch: setting Override
+// pins the backend regardless of TERM_PROGRAM, so individual tests can
+// pin the dispatcher without relying on env-var mutation order.
+func TestOverrideBeatsEnv(t *testing.T) {
+	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	t.Cleanup(func() { Override = "" })
+
+	Override = BackendTerminal
+	if got := Detect(); got != BackendTerminal {
+		t.Errorf("Override=Terminal: got %q, want %q", got, BackendTerminal)
+	}
+	Override = BackendITerm
+	if got := Detect(); got != BackendITerm {
+		t.Errorf("Override=ITerm: got %q, want %q", got, BackendITerm)
+	}
+}
+
+// TestSpawnTabRoutesToITerm asserts the iterm Runner is the one called
+// when Detect() resolves to BackendITerm.
+func TestSpawnTabRoutesToITerm(t *testing.T) {
+	Override = BackendITerm
+	t.Cleanup(func() { Override = "" })
+
+	itermCalled, terminalCalled := stubBothRunners(t)
+	if err := SpawnTab("title", "/tmp", "echo hi", nil); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+	if !*itermCalled {
+		t.Error("expected iterm.Runner to be called")
+	}
+	if *terminalCalled {
+		t.Error("did not expect terminal.Runner to be called")
+	}
+}
+
+// TestSpawnTabRoutesToTerminal asserts the terminal Runner is the one
+// called when Detect() resolves to BackendTerminal.
+func TestSpawnTabRoutesToTerminal(t *testing.T) {
+	Override = BackendTerminal
+	t.Cleanup(func() { Override = "" })
+
+	itermCalled, terminalCalled := stubBothRunners(t)
+	if err := SpawnTab("title", "/tmp", "echo hi", nil); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+	if *itermCalled {
+		t.Error("did not expect iterm.Runner to be called")
+	}
+	if !*terminalCalled {
+		t.Error("expected terminal.Runner to be called")
+	}
+}
+
+// TestShellQuoteParity makes sure the re-exported helper matches
+// iterm's implementation. Both backends quote identically.
+func TestShellQuoteParity(t *testing.T) {
+	cases := []string{"plain", "with space", "with'quote", `back\slash`}
+	for _, in := range cases {
+		if got, want := ShellQuote(in), iterm.ShellQuote(in); got != want {
+			t.Errorf("ShellQuote(%q): got %q, want %q", in, got, want)
+		}
+	}
+}
+
+// stubBothRunners replaces both backends' Runner vars with no-op stubs
+// that flip a per-runner boolean when called. Restores originals on
+// test cleanup. Returns pointers so the caller can read post-call.
+func stubBothRunners(t *testing.T) (*bool, *bool) {
+	t.Helper()
+	var itermCalled, terminalCalled bool
+
+	oldITerm := iterm.Runner
+	iterm.Runner = func(args []string) error {
+		itermCalled = true
+		// Sanity-check: every iterm script targets iTerm2.
+		if len(args) >= 2 && !strings.Contains(args[1], "iTerm2") {
+			t.Errorf("iterm script does not target iTerm2: %s", args[1])
+		}
+		return nil
+	}
+	t.Cleanup(func() { iterm.Runner = oldITerm })
+
+	oldTerm := terminal.Runner
+	terminal.Runner = func(args []string) error {
+		terminalCalled = true
+		if len(args) >= 2 && !strings.Contains(args[1], `"Terminal"`) {
+			t.Errorf("terminal script does not target Terminal: %s", args[1])
+		}
+		return nil
+	}
+	t.Cleanup(func() { terminal.Runner = oldTerm })
+
+	return &itermCalled, &terminalCalled
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -1,0 +1,163 @@
+// Package terminal provides macOS Terminal.app tab spawning via osascript.
+//
+// Mirrors the contract of internal/iterm — same SpawnTab signature,
+// same env-injection semantics (inline prefix, single-leading-space
+// for histignorespace), same Runner mock var for tests. The only
+// difference is the AppleScript talks to "Terminal" (not "iTerm2") and
+// has to drive a cmd-T keystroke through System Events to get a new
+// tab in the front window. That requires Accessibility permission for
+// whichever process invokes osascript; macOS prompts the user the
+// first time, and the prompt is documented in the README.
+package terminal
+
+import (
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// Runner is the function used to execute osascript. Tests override
+// this to capture arguments without touching real Terminal.app.
+var Runner = func(args []string) error {
+	cmd := exec.Command("osascript", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("osascript failed: %v: %s", err, string(out))
+	}
+	return nil
+}
+
+// SpawnTab opens a new Terminal.app tab with the given title, cwd, and
+// command. envVars are attached as an inline prefix to `command` only —
+// so they are present in the spawned process's environment but do NOT
+// persist in the tab's shell after the command exits.
+//
+// The typed line is prefixed with a single space so shells with
+// `histignorespace` (zsh) or `HISTCONTROL=ignorespace`/`ignoreboth`
+// (bash) skip writing it to the shared history file.
+//
+// New-tab behavior: when Terminal.app already has a window open, we
+// drive a cmd-T keystroke via System Events to open a new tab in the
+// front window. When Terminal.app has no windows (e.g. it wasn't
+// running), `do script` with no `in` clause opens a new window with a
+// single tab and we use that. Either way the result is one fresh tab
+// running our command, with the requested title.
+func SpawnTab(title, cwd, command string, envVars map[string]string) error {
+	envPrefix := ""
+	if len(envVars) > 0 {
+		keys := make([]string, 0, len(envVars))
+		for k := range envVars {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		parts := make([]string, 0, len(envVars))
+		for _, k := range keys {
+			parts = append(parts, fmt.Sprintf("%s=%s", k, ShellQuote(envVars[k])))
+		}
+		envPrefix = strings.Join(parts, " ") + " "
+	}
+	fullCommand := fmt.Sprintf(" cd %s && %s%s", ShellQuote(cwd), envPrefix, command)
+	safeCommand := escapeAppleScriptString(fullCommand)
+	safeTitle := escapeAppleScriptString(title)
+
+	script := fmt.Sprintf(`tell application "Terminal"
+  activate
+  if (count of windows) is 0 then
+    set newTab to do script "%s"
+  else
+    tell application "System Events"
+      keystroke "t" using {command down}
+    end tell
+    delay 0.2
+    set newTab to selected tab of front window
+    do script "%s" in newTab
+  end if
+  set custom title of newTab to "%s"
+end tell
+`, safeCommand, safeCommand, safeTitle)
+
+	if err := Runner([]string{"-e", script}); err != nil {
+		if isAccessibilityDenied(err) {
+			return wrapAccessibilityError(err)
+		}
+		return err
+	}
+	return nil
+}
+
+// isAccessibilityDenied reports whether an osascript failure looks
+// like a missing-Accessibility-permission error. Patterns are the
+// standard error fragments macOS surfaces when System Events is
+// invoked from a process that hasn't been granted Accessibility:
+//
+//   - "not allowed assistive access"  — pre-Catalina wording
+//   - "is not allowed to send keystrokes" — common Catalina+ wording
+//   - "not authorized to send Apple events"
+//   - error codes -1002, -1719, -1743, -25211 returned by osascript
+//
+// We deliberately match liberally — false positives only mean the
+// user sees a slightly verbose error when something else broke, which
+// is recoverable; false negatives mean the user gets a cryptic
+// osascript error and has to figure out the fix on their own, which
+// is the whole problem we're solving.
+func isAccessibilityDenied(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, pat := range []string{
+		"not allowed assistive access",
+		"is not allowed to send keystrokes",
+		"is not allowed sending keystrokes",
+		"not authorized to send Apple events",
+		"(-1002)",
+		"(-1719)",
+		"(-1743)",
+		"(-25211)",
+	} {
+		if strings.Contains(msg, pat) {
+			return true
+		}
+	}
+	return false
+}
+
+// wrapAccessibilityError returns a multi-line error explaining what's
+// missing and how to fix it. The Claude session that ran `flow do`
+// surfaces this error verbatim and can walk the user through System
+// Settings → Privacy → Accessibility from there.
+//
+// Note on which app to grant: macOS attributes Accessibility to the
+// "responsible process" — the user-launched terminal app that owns
+// the shell, NOT the flow binary or Claude Code. This function only
+// fires when the Terminal.app backend was selected, which only
+// happens when TERM_PROGRAM=Apple_Terminal — so we can name "Terminal"
+// definitively without enumerating other candidates. Past wording
+// listed "Terminal / iTerm / Claude" as possible answers and sent
+// Claude sessions advising users to toggle the wrong app.
+func wrapAccessibilityError(err error) error {
+	return fmt.Errorf(`Terminal.app tab spawn requires macOS Accessibility permission for Terminal — the app hosting this shell.
+
+Why this is needed: Terminal.app's AppleScript dictionary has no "make new tab" command. Apple never exposed it. The only way to open a new tab from code is to send cmd-T through System Events, and System Events checks Accessibility against the responsible parent app, which is Terminal.app itself — NOT Claude Code, NOT the flow binary. This gate only applies to the Terminal.app backend; iTerm2 has a native "create tab" verb and does not need it.
+
+How to grant it:
+  1. Open the right pane: open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+  2. In the Accessibility list, enable the toggle for "Terminal". If "Terminal" is not listed, click + and add /System/Applications/Utilities/Terminal.app.
+  3. Re-run the same "flow do" command.
+
+After the grant, future "flow do" invocations from Terminal.app spawn tabs silently with no further prompts.
+
+Underlying osascript error: %w`, err)
+}
+
+// ShellQuote wraps s in single quotes with proper escaping.
+func ShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+func escapeAppleScriptString(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return s
+}

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -1,0 +1,183 @@
+package terminal
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestSpawnTabScriptShape verifies the AppleScript emitted to osascript
+// targets Terminal.app, embeds env-var assignments before the command,
+// uses cmd-T via System Events for the new-tab path, and falls back to
+// `do script` (no `in` clause) when no windows exist. The osascript
+// binary is mocked via Runner.
+func TestSpawnTabScriptShape(t *testing.T) {
+	var captured string
+	old := Runner
+	Runner = func(args []string) error {
+		if len(args) >= 2 {
+			captured = args[1]
+		}
+		return nil
+	}
+	t.Cleanup(func() { Runner = old })
+
+	envVars := map[string]string{
+		"FLOW_TASK":    "my-task",
+		"FLOW_PROJECT": "flow",
+	}
+	if err := SpawnTab("flow/my-task", "/Users/me/repo", "claude --resume abc", envVars); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+
+	mustContain := []string{
+		`tell application "Terminal"`,
+		`activate`,
+		`if (count of windows) is 0 then`,
+		`do script "`,
+		`tell application "System Events"`,
+		`keystroke "t" using {command down}`,
+		`set custom title of newTab to "flow/my-task"`,
+		// env vars assigned alphabetically, before the command, all on one line:
+		`FLOW_PROJECT='flow' FLOW_TASK='my-task' claude --resume abc`,
+		// cd is the first thing in the typed line, single-leading-space
+		// for histignorespace:
+		` cd '/Users/me/repo' && `,
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(captured, s) {
+			t.Errorf("script missing %q\n--- script ---\n%s", s, captured)
+		}
+	}
+}
+
+// TestSpawnTabNoEnvVars covers the env-prefix branch when envVars is
+// nil — the line should still cd and run the command, just with no
+// VAR=value assignments in front.
+func TestSpawnTabNoEnvVars(t *testing.T) {
+	var captured string
+	old := Runner
+	Runner = func(args []string) error {
+		if len(args) >= 2 {
+			captured = args[1]
+		}
+		return nil
+	}
+	t.Cleanup(func() { Runner = old })
+
+	if err := SpawnTab("t", "/tmp", "echo hi", nil); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+	if !strings.Contains(captured, ` cd '/tmp' && echo hi`) {
+		t.Errorf("expected bare `cd … && echo hi` line; got:\n%s", captured)
+	}
+	if strings.Contains(captured, "=") && strings.Contains(captured, "echo hi=") {
+		t.Errorf("unexpected env assignment in command line: %s", captured)
+	}
+}
+
+// TestSpawnTabWrapsAccessibilityError verifies that when osascript
+// fails with a macOS Accessibility-denied error pattern, SpawnTab
+// returns a wrapped error explaining what's missing and how to fix
+// it. The Claude session that called `flow do` relies on this
+// message verbatim to walk the user through System Settings.
+func TestSpawnTabWrapsAccessibilityError(t *testing.T) {
+	cases := []struct{ name, stderr string }{
+		{"keystrokes-denied",
+			"osascript failed: exit status 1: System Events got an error: osascript is not allowed to send keystrokes. (-1002)"},
+		{"assistive-access",
+			"osascript failed: exit status 1: not allowed assistive access (-25211)"},
+		{"apple-events",
+			"osascript failed: exit status 1: not authorized to send Apple events to System Events. (-1743)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			old := Runner
+			Runner = func(args []string) error { return errors.New(tc.stderr) }
+			t.Cleanup(func() { Runner = old })
+
+			err := SpawnTab("t", "/tmp", "echo hi", nil)
+			if err == nil {
+				t.Fatal("expected error from SpawnTab, got nil")
+			}
+			for _, want := range []string{
+				"macOS Accessibility permission for Terminal",
+				`"Terminal"`,
+				"x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
+				"NOT Claude Code",
+				"NOT the flow binary",
+				"flow do",
+				tc.stderr, // underlying error preserved via %w
+			} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("wrapped error missing %q\n--- error ---\n%v", want, err)
+				}
+			}
+		})
+	}
+}
+
+// TestSpawnTabPassesThroughUnknownErrors verifies that non-Accessibility
+// errors from osascript are returned unchanged — only the specific
+// permission-denied patterns trigger the wrap.
+func TestSpawnTabPassesThroughUnknownErrors(t *testing.T) {
+	old := Runner
+	want := errors.New("osascript failed: exit status 1: some unrelated AppleScript error")
+	Runner = func(args []string) error { return want }
+	t.Cleanup(func() { Runner = old })
+
+	err := SpawnTab("t", "/tmp", "echo hi", nil)
+	if err == nil {
+		t.Fatal("expected error from SpawnTab, got nil")
+	}
+	if err.Error() != want.Error() {
+		t.Errorf("expected pass-through of unrelated error, got:\n%v", err)
+	}
+	if strings.Contains(err.Error(), "Accessibility") {
+		t.Errorf("non-Accessibility error should not be wrapped with permission text:\n%v", err)
+	}
+}
+
+// TestIsAccessibilityDenied unit-tests the pattern matcher in isolation.
+func TestIsAccessibilityDenied(t *testing.T) {
+	cases := []struct {
+		msg  string
+		want bool
+	}{
+		{"is not allowed to send keystrokes", true},
+		{"not allowed assistive access", true},
+		{"not authorized to send Apple events", true},
+		{"some error (-1002)", true},
+		{"some error (-1743)", true},
+		{"some error (-25211)", true},
+		{"completely unrelated AppleScript syntax error", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		got := isAccessibilityDenied(errors.New(tc.msg))
+		if got != tc.want {
+			t.Errorf("isAccessibilityDenied(%q) = %v, want %v", tc.msg, got, tc.want)
+		}
+	}
+	// Nil error must never be flagged as Accessibility-denied.
+	if isAccessibilityDenied(nil) {
+		t.Error("isAccessibilityDenied(nil) should be false")
+	}
+}
+
+// TestShellQuote is a sanity check on the local helper — same contract
+// as iterm.ShellQuote.
+func TestShellQuote(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"plain", "'plain'"},
+		{"with space", "'with space'"},
+		{"with'quote", `'with'\''quote'`},
+	}
+	for _, tc := range cases {
+		if got := ShellQuote(tc.in); got != tc.want {
+			t.Errorf("ShellQuote(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Three threads, one theme: flow should be invisible-but-present wherever the user is — both at the terminal layer and at the Claude-prompt layer.

**Spawner**
- New `internal/spawner` dispatcher routes to `internal/iterm` or the new `internal/terminal` backend based on `TERM_PROGRAM` (`Apple_Terminal` → Terminal.app, otherwise → iTerm). `do.go` now calls `spawner.SpawnTab`; existing `iterm.Runner` test stubs continue to work unchanged because the dispatcher defaults to iterm.
- Terminal.app uses `cmd-T` via System Events to open a new tab (Apple's AppleScript dictionary has no native "make new tab" verb). When macOS Accessibility is denied, `terminal.SpawnTab` parses osascript's stderr for the standard denial patterns (`(-1002)`, `(-1743)`, `(-25211)`, `is not allowed to send keystrokes`, `not allowed assistive access`, `not authorized to send Apple events`) and wraps the error with a multi-line explanation: why this is needed, the System Settings deep-link URL, and the specific app to grant — `"Terminal"`, definitively, not Claude Code, not the flow binary. The skill's §4.4 has a matching recipe so Claude opens the right Settings pane via `open "x-apple.systempreferences:..."` and waits for user confirmation instead of guessing the wrong app.

**Hooks**
- New `flow hook user-prompt-submit` subcommand fires on every prompt in ad-hoc Claude sessions (`FLOW_TASK` unset). No keyword gate; bound sessions no-op since SessionStart already covered them.
- Both ambient hints reframed: lead with "user already tracks their work and knowledge in flow" (not "installed" or "substantive work"), instruct Claude to consult `~/.flow/kb/` and project/task briefs when the user's wording uses unfamiliar terminology, and require an `AskUserQuestion` confirmation (existing flow task vs create new) before doing any work — so unbound transcripts stop collecting orphan work.
- `installSessionStartHook` / `uninstallSessionStartHook` generalized to `installClaudeHook(event, matcher, command)`. `flow skill install` / `update` / `uninstall` and the auto-upgrade path wire and unwire both hooks idempotently.

**Skill**
- New §1a "When invoked explicitly with no intent" overrides the §4.1 default: bare `/flow` invocations describe capabilities via a "What now?" `AskUserQuestion` menu instead of auto-running start-the-day.
- New §8 anti-pattern: do not surface flow commands to the user. Three offending option labels rewritten (`"Yes, run flow init"` → `"Yes, set it up"`, `"Yes, \`flow done <slug>\`"` → `"Yes, mark it done"`, post-add-project chat directive that listed `flow add task --project ...` reframed to outcome language).
- README and CONTRIBUTING.md scope updated to "macOS (iTerm2 or stock Terminal.app) + Claude Code".

**Bug fix**
- `flow do` now rolls back its pre-allocated `session_id` when a fresh-bootstrap spawn fails (e.g. Accessibility denied). Prior behavior left an orphan UUID in the DB, after which every subsequent `flow do` took the resume path and ran `claude --resume <uuid>` — failing with "No conversation found" forever. The status flip is preserved; only `session_id` and `session_started` are nilled. New tests cover both the fresh-failure rollback path and the resume-failure preservation path.

## Test plan

- [ ] `go test ./...` — all packages pass (covered: spawner dispatcher routing, Terminal.app AppleScript shape + Accessibility error wrapping, UserPromptSubmit hook ad-hoc/bound paths, install-both-hooks idempotency, skill §1a + §8 anti-pattern + Accessibility recipe, do.go fresh-spawn rollback + resume preservation)
- [ ] `make build && ./flow skill update` — installs both hooks into `~/.claude/settings.json`, refreshes embedded SKILL.md
- [ ] Manual: `flow do <task>` from iTerm — tab opens silently, no Accessibility prompt
- [ ] Manual: `flow do <task>` from stock Terminal.app on a machine without Accessibility granted — `flow do` errors with the multi-line guide; deep-link opens System Settings; granting Terminal in the list and re-running spawns silently
- [ ] Manual: kill the spawn mid-bootstrap (or run from Terminal.app pre-grant), then `flow do <slug>` again — resume path is NOT taken; bootstrap retries with a fresh UUID

🤖 Generated with [Claude Code](https://claude.com/claude-code)