### PR TITLE
feat: emphasize close-out, add upgrade workflow + version staleness check

### DIFF
--- a/internal/app/hook.go
+++ b/internal/app/hook.go
@@ -91,7 +91,29 @@ func cmdHookSessionStart(args []string) int {
 		slug,
 	)
 
-	return emitSessionStartContext(instructions)
+	return emitSessionStartContext(instructions + appendStaleVersionHint())
+}
+
+// appendStaleVersionHint returns a short suffix to add to SessionStart
+// hint payloads when the local flow binary is older than the latest
+// GitHub release. Returns "" when the check fails, the cache is fresh
+// and matches, or the running binary is a dev build (no version
+// embedded). The check is best-effort and silent on any error —
+// session-start latency must not be impacted by a flaky network.
+func appendStaleVersionHint() string {
+	if Version == "" || Version == "dev" {
+		return ""
+	}
+	latest := LatestRelease()
+	if latest == "" || latest == Version {
+		return ""
+	}
+	return fmt.Sprintf(
+		" flow-version-stale: %s — the running flow binary is %s but a newer release is available. "+
+			"When natural, offer the user an upgrade per skill §4.15 (Upgrade flow itself). "+
+			"Do not interrupt active work to push this; surface it at a pause.",
+		latest, Version,
+	)
 }
 
 // emitAmbientSkillHint is the FLOW_TASK-unset branch of the SessionStart
@@ -121,7 +143,7 @@ func emitAmbientSkillHint() int {
 		"hold project and task context. Names and context that are non-obvious from " +
 		"this conversation alone are very likely already documented there. The skill's " +
 		"§4.10 governs how to lazy-load these without reading them eagerly every turn."
-	return emitSessionStartContext(hint)
+	return emitSessionStartContext(hint + appendStaleVersionHint())
 }
 
 // emitSessionStartContext is a thin wrapper around emitHookContext for

--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -1,0 +1,121 @@
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// githubLatestReleaseURL is the canonical endpoint for the most-recent
+// public release of flow. The SessionStart hook calls this at most
+// once per cacheTTL to surface upgrade availability to Claude.
+const githubLatestReleaseURL = "https://api.github.com/repos/Facets-cloud/flow/releases/latest"
+
+// versionCacheTTL is how long a cached lookup is considered fresh.
+// 24h is a deliberate trade-off: long enough that we don't hit
+// GitHub on every Claude session start (sessions can fire several
+// times a day during active work), short enough that a published
+// release is noticed within a working day.
+const versionCacheTTL = 24 * time.Hour
+
+// versionFetchTimeout caps the synchronous network call inside the
+// SessionStart hook. The hook latency budget is forgiving but not
+// unlimited — 2 seconds is enough for a healthy connection while
+// preventing a stalled network from blocking session start.
+const versionFetchTimeout = 2 * time.Second
+
+// httpGetForVersion is the function used by LatestRelease to fetch
+// the GitHub releases endpoint. Tests override this to avoid real
+// network traffic.
+var httpGetForVersion = func(url string) (*http.Response, error) {
+	client := &http.Client{Timeout: versionFetchTimeout}
+	return client.Get(url)
+}
+
+// nowForVersion is the time source for cache freshness checks. Tests
+// override this to make the TTL boundary deterministic.
+var nowForVersion = time.Now
+
+// versionCache is the on-disk shape of the cache file at
+// ~/.flow/.version-cache.json.
+type versionCache struct {
+	CheckedAt     time.Time `json:"checkedAt"`
+	LatestVersion string    `json:"latestVersion"`
+}
+
+// LatestRelease returns the latest tagged version of flow on GitHub
+// as a tag string (e.g. "v0.1.0-alpha.3"), or "" if the lookup
+// cannot be completed (offline, rate-limited, $FLOW_ROOT unwritable,
+// JSON malformed, …). All failure modes are silent — version-check
+// is best-effort plumbing, never load-bearing.
+func LatestRelease() string {
+	cachePath := versionCachePath()
+	if cachePath == "" {
+		return ""
+	}
+	if v, ok := readCachedVersion(cachePath); ok {
+		return v
+	}
+	return fetchAndCacheLatest(cachePath)
+}
+
+func versionCachePath() string {
+	root := os.Getenv("FLOW_ROOT")
+	if root == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		root = filepath.Join(home, ".flow")
+	}
+	return filepath.Join(root, ".version-cache.json")
+}
+
+func readCachedVersion(path string) (string, bool) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	var c versionCache
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return "", false
+	}
+	if nowForVersion().Sub(c.CheckedAt) > versionCacheTTL {
+		return "", false
+	}
+	return c.LatestVersion, true
+}
+
+func fetchAndCacheLatest(cachePath string) string {
+	resp, err := httpGetForVersion(githubLatestReleaseURL)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return ""
+	}
+	var rel struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return ""
+	}
+	if rel.TagName == "" {
+		return ""
+	}
+	cache := versionCache{
+		CheckedAt:     nowForVersion(),
+		LatestVersion: rel.TagName,
+	}
+	raw, err := json.MarshalIndent(cache, "", "  ")
+	if err != nil {
+		return rel.TagName
+	}
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err == nil {
+		_ = os.WriteFile(cachePath, raw, 0o644)
+	}
+	return rel.TagName
+}

--- a/internal/app/release_test.go
+++ b/internal/app/release_test.go
@@ -1,0 +1,190 @@
+package app
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeHTTPResponse builds a *http.Response with the given JSON body.
+func fakeHTTPResponse(t *testing.T, status int, body string) *http.Response {
+	t.Helper()
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+	}
+}
+
+// withFakeHTTP swaps httpGetForVersion for the duration of the test.
+func withFakeHTTP(t *testing.T, fn func(url string) (*http.Response, error)) {
+	t.Helper()
+	old := httpGetForVersion
+	httpGetForVersion = fn
+	t.Cleanup(func() { httpGetForVersion = old })
+}
+
+// withFlowRoot points $FLOW_ROOT at a tempdir so version-cache writes
+// don't touch the developer's real ~/.flow.
+func withFlowRoot(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("FLOW_ROOT", dir)
+	return dir
+}
+
+// TestLatestReleaseFetchesAndCaches verifies the happy path: no cache
+// → HTTP fetch succeeds → tag returned and cache written.
+func TestLatestReleaseFetchesAndCaches(t *testing.T) {
+	root := withFlowRoot(t)
+	withFakeHTTP(t, func(url string) (*http.Response, error) {
+		return fakeHTTPResponse(t, 200, `{"tag_name":"v9.9.9"}`), nil
+	})
+
+	if got := LatestRelease(); got != "v9.9.9" {
+		t.Errorf("LatestRelease = %q, want v9.9.9", got)
+	}
+	cachePath := filepath.Join(root, ".version-cache.json")
+	if raw, err := os.ReadFile(cachePath); err != nil {
+		t.Errorf("cache file not written: %v", err)
+	} else if !strings.Contains(string(raw), "v9.9.9") {
+		t.Errorf("cache file does not contain version: %s", raw)
+	}
+}
+
+// TestLatestReleaseHonorsCache verifies a fresh cache short-circuits
+// the HTTP path: even if the network is rigged to fail, a fresh
+// cache returns the cached value.
+func TestLatestReleaseHonorsCache(t *testing.T) {
+	root := withFlowRoot(t)
+	cachePath := filepath.Join(root, ".version-cache.json")
+	if err := os.WriteFile(cachePath,
+		[]byte(`{"checkedAt":"`+time.Now().Format(time.RFC3339)+`","latestVersion":"v0.0.1-from-cache"}`),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+	withFakeHTTP(t, func(url string) (*http.Response, error) {
+		t.Errorf("httpGetForVersion called when cache should have been used")
+		return nil, http.ErrServerClosed
+	})
+
+	if got := LatestRelease(); got != "v0.0.1-from-cache" {
+		t.Errorf("LatestRelease = %q, want v0.0.1-from-cache (cache hit)", got)
+	}
+}
+
+// TestLatestReleaseCacheTTLBoundary verifies the cache is treated as
+// stale once it exceeds versionCacheTTL.
+func TestLatestReleaseCacheTTLBoundary(t *testing.T) {
+	root := withFlowRoot(t)
+	cachePath := filepath.Join(root, ".version-cache.json")
+	stale := time.Now().Add(-versionCacheTTL - time.Hour).Format(time.RFC3339)
+	if err := os.WriteFile(cachePath,
+		[]byte(`{"checkedAt":"`+stale+`","latestVersion":"v-old"}`),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+	hits := 0
+	withFakeHTTP(t, func(url string) (*http.Response, error) {
+		hits++
+		return fakeHTTPResponse(t, 200, `{"tag_name":"v-fresh"}`), nil
+	})
+
+	if got := LatestRelease(); got != "v-fresh" {
+		t.Errorf("LatestRelease with stale cache = %q, want v-fresh", got)
+	}
+	if hits != 1 {
+		t.Errorf("expected 1 HTTP fetch on stale cache, got %d", hits)
+	}
+}
+
+// TestLatestReleaseSilentOnNetworkFailure pins the silent-failure
+// contract: every error path returns "" so the SessionStart hook
+// never blocks or surfaces a stack trace.
+func TestLatestReleaseSilentOnNetworkFailure(t *testing.T) {
+	withFlowRoot(t)
+	withFakeHTTP(t, func(url string) (*http.Response, error) {
+		return nil, http.ErrServerClosed
+	})
+
+	if got := LatestRelease(); got != "" {
+		t.Errorf("LatestRelease on network error = %q, want empty", got)
+	}
+}
+
+// TestLatestReleaseSilentOnNon200 covers rate-limited responses.
+func TestLatestReleaseSilentOnNon200(t *testing.T) {
+	withFlowRoot(t)
+	withFakeHTTP(t, func(url string) (*http.Response, error) {
+		return fakeHTTPResponse(t, 429, `{"message":"API rate limit exceeded"}`), nil
+	})
+
+	if got := LatestRelease(); got != "" {
+		t.Errorf("LatestRelease on 429 = %q, want empty", got)
+	}
+}
+
+// TestAppendStaleVersionHintDevBuildIsEmpty pins that dev builds
+// (Version=="dev" or "") never trigger the version check at all —
+// running flow from `make build` shouldn't emit upgrade nudges.
+func TestAppendStaleVersionHintDevBuildIsEmpty(t *testing.T) {
+	old := Version
+	Version = "dev"
+	t.Cleanup(func() { Version = old })
+
+	withFakeHTTP(t, func(url string) (*http.Response, error) {
+		t.Error("httpGetForVersion should not be called for dev builds")
+		return nil, nil
+	})
+
+	if got := appendStaleVersionHint(); got != "" {
+		t.Errorf("dev build appendStaleVersionHint = %q, want empty", got)
+	}
+}
+
+// TestAppendStaleVersionHintMatchingIsEmpty pins that when the local
+// version matches the latest release, no nudge is appended.
+func TestAppendStaleVersionHintMatchingIsEmpty(t *testing.T) {
+	withFlowRoot(t)
+	old := Version
+	Version = "v0.1.0-alpha.3"
+	t.Cleanup(func() { Version = old })
+
+	withFakeHTTP(t, func(url string) (*http.Response, error) {
+		return fakeHTTPResponse(t, 200, `{"tag_name":"v0.1.0-alpha.3"}`), nil
+	})
+
+	if got := appendStaleVersionHint(); got != "" {
+		t.Errorf("matching version appendStaleVersionHint = %q, want empty", got)
+	}
+}
+
+// TestAppendStaleVersionHintStaleEmitsHint pins the staleness signal
+// shape: the hook must include "flow-version-stale:" so the §4.15
+// trigger in the skill picks it up.
+func TestAppendStaleVersionHintStaleEmitsHint(t *testing.T) {
+	withFlowRoot(t)
+	old := Version
+	Version = "v0.1.0-alpha.3"
+	t.Cleanup(func() { Version = old })
+
+	withFakeHTTP(t, func(url string) (*http.Response, error) {
+		return fakeHTTPResponse(t, 200, `{"tag_name":"v0.2.0"}`), nil
+	})
+
+	got := appendStaleVersionHint()
+	for _, want := range []string{
+		"flow-version-stale: v0.2.0",
+		"v0.1.0-alpha.3",
+		"§4.15",
+		"Do not interrupt active work",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("stale hint missing %q; got:\n%s", want, got)
+		}
+	}
+}

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -570,7 +570,27 @@ to disambiguate which task this is for.
 
 ### 4.7 Mark done
 
-**Triggers:** "mark X done", "finish X", "X is done", "close out X".
+**Triggers — explicit:** "mark X done", "finish X", "X is done",
+"close out X", "wrap up X".
+
+**Triggers — wrap-up signals (treat as candidate triggers, then
+confirm via AskUserQuestion):** "shipped", "PR merged", "deployed",
+"released", "wrapped up", "that's working", "bug fixed", "test
+passes", "ready to ship", "all good now", "we're good", "that did
+it".
+
+**Why closing matters — read this before treating `flow done` as
+bookkeeping.** `flow done` is not just a status flip. It runs a
+headless Claude sweep over the task's transcript that distills
+durable facts into the user's KB (`~/.flow/kb/`) and, when the task
+has a project, writes a project update at
+`~/.flow/projects/<slug>/updates/` summarizing what got done and
+why. **If a task never closes, that distillation never happens.**
+Learnings stay locked in the transcript and never reach central
+tracking — which is precisely the value the user installed flow to
+capture. Treat closure as the load-bearing moment of the workflow,
+not a clean-up afterthought. Letting work wrap up without prompting
+closure is a silent loss of durable knowledge.
 
 **Recipe:**
 
@@ -585,12 +605,59 @@ to disambiguate which task this is for.
 3. Run `flow done <ref>`. **Do not close the iTerm tab** and **do
    not kill the Claude session** — `flow done` deliberately leaves
    both intact. The session_id stays on the task row so a future
-   reopen can still resume it.
+   reopen can still resume it. The close-out sweep runs after the
+   status flip; relay any NUDGE block `flow done` prints back to
+   the user verbatim.
+
+**Recognizing natural close-out moments — passive workflow.**
+
+This is a passive workflow that runs alongside §4.10 (KB scoop) and
+§4.11 (scope-creep): you watch the conversation for signals that
+substantive work is wrapping up even when the user hasn't said the
+word "done". When a signal fires, proactively offer closure via
+`AskUserQuestion` — don't wait for the user to remember.
+
+**When to fire:**
+
+- Wrap-up phrasing from the wrap-up trigger list above.
+- A clear milestone just landed (PR merged, deploy succeeded, all
+  tests green, last open question on the brief resolved) and the
+  user has moved to small-talk or signaled satisfaction ("perfect",
+  "that's it", "nice", "thanks").
+- The user references a separate task in a way that implies a
+  context switch ("now let me look at <other thing>") — offer to
+  close the current one first if its work is at a coherent stopping
+  point.
+
+**When NOT to fire:**
+
+- Mid-debugging or mid-implementation, even if a partial milestone
+  was hit. Closure is for coherent stopping points, not every green
+  test.
+- The user explicitly said "more work coming" earlier this session —
+  remember that signal and don't re-ask on the same thread.
+- The very first turns of a session — the user just opened the task;
+  let the work happen first.
+
+**Recipe:**
+
+1. Pause your current line of response.
+2. Use `AskUserQuestion` (header: "Mark done?", options:
+   "Yes — close it and run the close-out sweep" / "Not yet, more
+   work coming"). The "Yes" option's description should name the
+   sweep: "flow done distills KB entries and a project update from
+   this transcript — closing now persists what we learned this
+   session."
+3. On "Yes", proceed to the §4.7 recipe above (closing-note offer,
+   then `flow done`).
+4. On "Not yet", accept the answer and don't re-ask on the same
+   thread of work in the same session.
 
 **Playbook-specific notes:**
 
 - **Run-tasks** (kind=playbook_run) support `flow done <run-slug>` like
-  any task.
+  any task. Their close-out sweep also runs and can capture
+  playbook-specific learnings.
 - Note: **playbook definitions are never "done" — they're archived.**
   When a playbook is no longer in use, run `flow archive <playbook-slug>`.
   There is no `flow done playbook` command.
@@ -1102,6 +1169,50 @@ implementation / debugging work. The SessionStart hook gets you the
 first check; you are responsible for every subsequent check.
 Re-evaluate on every turn.
 
+### 4.15 Upgrade flow itself
+
+**Triggers:** "update flow", "upgrade flow", "is there a new version
+of flow", "new flow version", "what version am I on", "what's the
+latest flow", "flow is stale", a bare `flow --version` typed as
+command-like input. Also fires when the SessionStart hook reports
+`flow-version-stale: <new-version>` in its additionalContext (the
+hook does an at-most-once-per-day cached check against GitHub
+releases) — when you see that signal, proactively offer the upgrade
+via `AskUserQuestion`.
+
+**Recipe:**
+
+1. Run `flow --version` to capture the currently-installed version.
+2. The canonical install/upgrade procedure lives in the README at
+   `https://github.com/Facets-cloud/flow`. Use the `Read` tool /
+   `WebFetch` to read the **Install** and **Upgrade** sections —
+   they're the source of truth for the binary download URL,
+   architecture flag (`arm64` for Apple Silicon, `amd64` for Intel),
+   and the `xattr -d com.apple.quarantine` workaround for unsigned
+   binaries. Do not invent download URLs; read them from the README.
+3. Download the new binary per the README and replace the existing
+   one (typically at `/usr/local/bin/flow`; confirm with
+   `which flow` if unsure).
+4. Run `flow skill update` to refresh the embedded skill on disk and
+   re-wire both the SessionStart and UserPromptSubmit hooks in
+   `~/.claude/settings.json`. (The auto-upgrade path runs the same
+   refresh on the next `flow` invocation, but explicit is better and
+   surfaces any errors immediately.)
+5. Run `flow --version` again and confirm the version changed. If it
+   did not change, the binary on `$PATH` is still the old one —
+   check `which flow` against the path you wrote to.
+
+**Anti-patterns:**
+
+- **Do not invent download URLs.** Read them from the README at
+  `https://github.com/Facets-cloud/flow`. Releases are at
+  `/releases/latest/download/`; the README has the exact form.
+- **Do not run `flow skill install` on an existing install** — it
+  errors. Use `flow skill update` for the refresh path.
+- **Do not skip the `xattr -d com.apple.quarantine`** step on a
+  freshly-downloaded binary — Gatekeeper will refuse to run it
+  otherwise.
+
 ## 6. The `work_dir` question — rules
 
 When you're about to ask the user "where does this task live?", run
@@ -1264,6 +1375,14 @@ type. Always prefer the tool. If you find yourself typing "Want me
 to X?" or "Should I Y?" into chat, stop and use `AskUserQuestion`
 instead.
 
+- **Do not let work wrap up without prompting closure.** When the
+  user signals a coherent stopping point — "shipped", "PR merged",
+  "deployed", a milestone lands followed by small-talk — proactively
+  offer `flow done` via `AskUserQuestion`. `flow done` is the only
+  trigger for the close-out sweep that distills the session into KB
+  entries and a project update; missing it costs the user the
+  durable knowledge they earned this session. See §4.7 for the
+  passive close-out detection workflow.
 - **Do not surface flow commands to the user.** You use flow under
   the hood; users never need to learn the CLI. Never tell the user
   to "run `flow X`", "type `flow Y`", or "see `flow Z --help`".

--- a/internal/app/skill_test.go
+++ b/internal/app/skill_test.go
@@ -359,6 +359,58 @@ func TestSkillHasMidInterviewDriftRule(t *testing.T) {
 	}
 }
 
+// TestSkillHasUpgradeWorkflow pins the §4.15 upgrade procedure: the
+// skill must know how to walk the user through replacing the binary
+// per the README at https://github.com/Facets-cloud/flow and then
+// running `flow skill update`. It must also recognize the
+// `flow-version-stale:` signal the SessionStart hook emits when the
+// local binary lags the latest GitHub release.
+func TestSkillHasUpgradeWorkflow(t *testing.T) {
+	got := string(embeddedSkill)
+	for _, want := range []string{
+		"### 4.15 Upgrade flow itself",
+		"https://github.com/Facets-cloud/flow",
+		"flow --version",
+		"flow skill update",
+		"flow-version-stale:",
+		"xattr -d com.apple.quarantine",
+		"Do not invent download URLs",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("skill missing upgrade workflow content: %q", want)
+		}
+	}
+}
+
+// TestSkillEmphasizesCloseOutValue pins §4.7's framing of `flow done`
+// as the load-bearing moment that persists the session's learnings —
+// it triggers the close-out sweep that writes KB + project update.
+// Without this content the skill treats closure as bookkeeping and
+// Claude never proactively offers to close, which means the user's
+// learnings stay locked in the transcript.
+func TestSkillEmphasizesCloseOutValue(t *testing.T) {
+	got := string(embeddedSkill)
+	for _, want := range []string{
+		"Why closing matters",
+		"close-out sweep",
+		"that distillation never happens",
+		"silent loss of durable knowledge",
+		"Recognizing natural close-out moments",
+		// Expanded trigger list must include real-world wrap-up phrasing,
+		// not just the literal verbs the old skill listed.
+		"shipped",
+		"PR merged",
+		"deployed",
+		"that's working",
+		// Matching §8 anti-pattern reinforces the rule.
+		"Do not let work wrap up without prompting closure",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("skill missing close-out emphasis: %q", want)
+		}
+	}
+}
+
 // TestSkillHasAccessibilityErrorRecipe pins the §4.4 recipe for
 // handling the macOS Accessibility error from the Terminal.app
 // backend: name Terminal definitively (not Claude/flow), open the


### PR DESCRIPTION
## Summary

Three threads, one theme: make the load-bearing moments of the flow workflow (closure, upgrades) explicit so Claude proactively pushes the user toward them instead of treating them as bookkeeping.

### Skill §4.7 — close-out emphasis

- New **"Why closing matters"** paragraph names what `flow done` actually triggers: the headless Claude sweep that distills the transcript into KB entries (`~/.flow/kb/`) and a project update (`~/.flow/projects/<slug>/updates/`). If a task never closes, that distillation never happens — learnings stay locked in the transcript and never reach central tracking.
- Trigger list expanded with real-world wrap-up phrasing: `"shipped"`, `"PR merged"`, `"deployed"`, `"wrapped up"`, `"that's working"`, `"all good now"`, `"we're good"`, `"that did it"` — not just the literal `"done"`/`"finish"` verbs.
- New passive **"Recognizing natural close-out moments"** workflow, mirroring §4.10 (KB scoop) and §4.11 (scope-creep): watch for milestone+small-talk patterns and proactively offer closure via `AskUserQuestion`, with explicit "when NOT to fire" guards (mid-debugging, "more work coming", first turns).
- Matching §8 anti-pattern: *"do not let work wrap up without prompting closure"* — silent loss of durable knowledge.

### Skill §4.15 — upgrade procedure

- New workflow telling Claude how to upgrade flow: read the canonical install/upgrade procedure from the README at https://github.com/Facets-cloud/flow, replace the binary, run `flow skill update`. Anti-patterns explicitly forbid inventing download URLs, skipping the `xattr -d com.apple.quarantine` step, and using `flow skill install` (which errors on existing installs) instead of `flow skill update`.

### Hook — version staleness check

- New `internal/app/release.go`: best-effort fetch of the latest GitHub release tag with 24h on-disk cache at `~/.flow/.version-cache.json` and a 2s HTTP timeout. Every failure mode (offline, rate-limited, malformed JSON) returns `""` silently so the SessionStart hook never blocks or surfaces a stack trace. `httpGetForVersion` and `nowForVersion` are package vars overridable by tests.
- SessionStart hook (both bound and ad-hoc paths) now appends a `flow-version-stale: <new-version>` directive to `additionalContext` when the running binary trails the latest release. Skill §4.15 recognizes that signal as a trigger for the upgrade workflow.
- **UserPromptSubmit deliberately does NOT do the check** — it fires per-turn and the latency budget is too tight. SessionStart fires once per session, where 2s worst-case is acceptable.
- Dev builds (`Version == "dev"` or `""`) never trigger the check. Cache TTL is 24h to balance "noticed within a working day" against "not hitting GitHub on every session".

## Test plan

- [ ] `go test ./...` — all packages pass (covered: happy-path fetch+cache, fresh-cache shortcut, TTL boundary, silent failure on network error and 429, dev-build skip, matching-version skip, stale-version hint shape; skill §4.7 close-out content + §4.15 upgrade content + §8 anti-pattern)
- [ ] Manual: with cache pre-populated to a higher version than the running binary, run `FLOW_TASK="" flow hook session-start` and confirm `additionalContext` includes `flow-version-stale: …`
- [ ] Manual: from any session, say "upgrade flow" and confirm Claude reads the README and walks through the procedure (no invented URLs)
- [ ] Manual: at a coherent stopping point (PR merged + small-talk), confirm Claude proactively offers `flow done` instead of waiting for the literal "mark done" trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)