### PR TITLE
docs: clarify README upgrade procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,10 @@ In any Claude Code session:
 
 > Upgrade flow from https://github.com/Facets-cloud/flow
 
-Or download the new binary the same way you installed it — the next
-flow command auto-refreshes the skill and SessionStart hook. Check
-the running version with `flow --version`.
+Claude fetches the latest release binary and runs `flow skill
+update` to refresh the skill and re-wire the SessionStart and
+UserPromptSubmit hooks. Check the running version with
+`flow --version`.
 
 ## Quickstart
 


### PR DESCRIPTION
## Summary

The Upgrade section's old text mixed two distinct paths — "ask Claude to upgrade" and "download manually, let auto-upgrade refresh on next flow command" — without making either explicit. The auto-upgrade fallback works (`maybeAutoUpgradeSkill` runs on every flow invocation) but it's not what the prose described, and it left Claude with no explicit procedure to follow when the user says "upgrade flow".

New text matches skill §4.15 (added in #17): fetch the latest release binary, then run `flow skill update` to refresh the skill and re-wire both the SessionStart and UserPromptSubmit hooks. One procedure, named hooks, end of story.

## Test plan

- [ ] CI passes (vet/test/build)
- [ ] Visual: render the README on the PR page; the Upgrade section reads as a single procedure, not two muddled paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)