### PR TITLE
fix: escape \n/\r/\t in AppleScript spawner so multi-line prompts parse

### DIFF
--- a/internal/iterm/iterm.go
+++ b/internal/iterm/iterm.go
@@ -66,8 +66,18 @@ func ShellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
+// escapeAppleScriptString prepares s for embedding inside an
+// AppleScript double-quoted string literal. Newlines / carriage
+// returns / tabs are converted to their AppleScript escape sequences
+// (`\n`, `\r`, `\t`) so the resulting literal is single-line. See
+// the matching helper in internal/terminal for the rationale —
+// keeping the two backends consistent so neither one silently
+// regresses.
 func escapeAppleScriptString(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, `"`, `\"`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, "\r", `\r`)
+	s = strings.ReplaceAll(s, "\t", `\t`)
 	return s
 }

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -156,8 +156,27 @@ func ShellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
+// escapeAppleScriptString prepares s for embedding inside an
+// AppleScript double-quoted string literal. Beyond the obvious `\` and
+// `"`, we also escape newlines / carriage returns / tabs to their
+// AppleScript escape sequences (`\n`, `\r`, `\t`) so the resulting
+// string literal is single-line. AppleScript decodes the escapes back
+// to literal control chars before handing the string to `do script`,
+// so the shell sees the original multi-line content. This sidesteps
+// a class of osascript -2741 ("Expected end of line but found class
+// name") failures that surfaced on long multi-line prompts where the
+// embedded literal newlines confused the parser.
+//
+// Order matters: replace `\` first (it adds new `\` characters that
+// must not be re-escaped), then `"`, then the control chars. The
+// control-char replacements introduce new `\n` / `\r` / `\t`
+// sequences whose backslashes do NOT get double-escaped because the
+// `\\` pass already happened.
 func escapeAppleScriptString(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, `"`, `\"`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, "\r", `\r`)
+	s = strings.ReplaceAll(s, "\t", `\t`)
 	return s
 }

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -165,6 +165,52 @@ func TestIsAccessibilityDenied(t *testing.T) {
 	}
 }
 
+// TestSpawnTabSingleLineScriptForMultiLinePrompt pins the regression
+// fix: when the spawned command contains literal newlines (any
+// fresh-bootstrap path embeds the multi-line bootstrap prompt), the
+// AppleScript we emit must remain a single logical line per
+// `do script` invocation. Past behavior emitted literal newlines
+// inside the AppleScript string literal, which produced osascript
+// -2741 ("Expected end of line but found class name") on certain
+// long inputs. The fix escapes \n/\r/\t to AppleScript escape
+// sequences so the string literal stays single-line.
+func TestSpawnTabSingleLineScriptForMultiLinePrompt(t *testing.T) {
+	var captured string
+	old := Runner
+	Runner = func(args []string) error {
+		if len(args) >= 2 {
+			captured = args[1]
+		}
+		return nil
+	}
+	t.Cleanup(func() { Runner = old })
+
+	multilineCmd := "claude --session-id abc 'line one\nline two\n\tindented\rcr-line'"
+	if err := SpawnTab("t", "/tmp", multilineCmd, nil); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+
+	// No raw control characters should remain inside the script — they
+	// must be encoded as AppleScript escape sequences.
+	if strings.Contains(captured, "line one\nline two") {
+		t.Errorf("captured script still contains literal newline between prompt lines:\n%s", captured)
+	}
+	if strings.Contains(captured, "\tindented") {
+		t.Errorf("captured script still contains literal tab:\n%s", captured)
+	}
+	if strings.Contains(captured, "\rcr-line") {
+		t.Errorf("captured script still contains literal CR:\n%s", captured)
+	}
+
+	// And the escape sequences must be present (`\n`, `\r`, `\t` as
+	// two-character sequences inside the double-quoted string literal).
+	for _, want := range []string{`line one\nline two`, `\tindented`, `\rcr-line`} {
+		if !strings.Contains(captured, want) {
+			t.Errorf("expected AppleScript escape %q in script:\n%s", want, captured)
+		}
+	}
+}
+
 // TestShellQuote is a sanity check on the local helper — same contract
 // as iterm.ShellQuote.
 func TestShellQuote(t *testing.T) {


### PR DESCRIPTION
## Summary

Real reported error from a fresh `flow do` spawn:

```
error: osascript failed: exit status 1: 41:47: syntax error:
Expected end of line but found class name. (-2741)
```

**Root cause.** `escapeAppleScriptString` was only escaping `\` and `"` in the command embedded inside `do script "<cmd>"`. The bootstrap prompt for fresh sessions is multi-line — `fmt.Sprintf` builds it with literal `\n` bytes — and after shell-quoting + our escape pass, the AppleScript string literal ended up spanning many physical lines (~25 for a regular task, ~43 for a playbook first-run). AppleScript double-quoted strings nominally accept multi-line content, but on some inputs the parser emits `-2741` with a column landing inside the embedded prompt; the pathology isn't deterministic from content shape alone.

**Fix.** Extend the escape function to also map literal newline / carriage return / tab to their AppleScript escape sequences (`\n`, `\r`, `\t`). The string literal stays single-line in the script source, but AppleScript decodes the escapes back to literal control chars before passing the value to `do script`, so the shell sees the original multi-line content. Both backends (iterm and terminal) get the same fix to stay consistent.

Verified by dumping the playbook first-run AppleScript before and after: pre-fix the script was 43 lines, post-fix 15 lines, parses cleanly under `osacompile`.

## Test plan

- [ ] `go test ./...` — all packages pass
- [ ] New `TestSpawnTabSingleLineScriptForMultiLinePrompt` in `internal/terminal` covers the regression: SpawnTab on a command with literal `\n`/`\r`/`\t` produces a script with no raw control chars and with the matching escape sequences present
- [ ] Manual smoke from Terminal.app: `flow do <task>` on a fresh-bootstrap path no longer hits `-2741`

🤖 Generated with [Claude Code](https://claude.com/claude-code)