### PR TITLE
feat: zellij as a first-class spawn backend

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,8 +76,8 @@ bugs reproduce deterministically with a small command sequence.
 
 ## Scope
 
-flow is **macOS (iTerm2 or stock Terminal.app) + Claude Code** by
-design. Linux/tmux/zellij/wezterm, Windows Terminal, and non-Claude
-integrations are out of scope for the current motion. If you have a
-use case that would change that, open an issue first to discuss
-before sending code.
+flow is **macOS (iTerm2, stock Terminal.app, or zellij) + Claude
+Code** by design. zellij works on Linux too as a side effect.
+tmux/wezterm, Windows Terminal, and non-Claude integrations are out
+of scope for the current motion. If you have a use case that would
+change that, open an issue first to discuss before sending code.

--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ handles the rest.
 ## What you get
 
 - **One task, one Claude session, one tab.** `flow do <task>`
-  spawns a dedicated tab in iTerm2 or stock macOS Terminal — flow
-  picks whichever you launched it from. Tomorrow's `flow do <task>`
-  resumes the same conversation.
+  spawns a dedicated tab in iTerm2, stock macOS Terminal, or your
+  current zellij session — flow picks whichever you launched it from.
+  Tomorrow's `flow do <task>` resumes the same conversation.
 - **Interview-driven task capture.** No forms. flow asks
   what / why / where / done-when, then writes a structured brief.
 - **A knowledge base that grows.** Five markdown buckets for
@@ -171,10 +171,10 @@ handles the rest.
 ## How it works under the hood
 
 `flow do <task>` pre-allocates a session UUID, writes it to the
-task row, and spawns a tab in iTerm2 or stock Terminal.app (chosen
-by `TERM_PROGRAM`, falls back to iTerm) running
-`claude --session-id <uuid>` with `FLOW_TASK` / `FLOW_PROJECT`
-inlined. The jsonl file lands at the deterministic path
+task row, and spawns a tab in zellij (when `$ZELLIJ` is set), iTerm2,
+or stock Terminal.app — chosen in that priority order, with iTerm as
+the historical fallback — running `claude --session-id <uuid>` with
+`FLOW_TASK` / `FLOW_PROJECT` inlined. The jsonl file lands at the deterministic path
 `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`, so future
 `flow do` calls run `claude --resume <uuid>` to continue the same
 conversation. A SessionStart hook re-injects the task brief,
@@ -256,15 +256,17 @@ and reinstall the skill + hook.
 
 ## Where flow runs (and where we'd love help)
 
-Today flow runs on **macOS (iTerm2 or stock Terminal.app) + Claude
-Code only**. That's the stack we use, and that's what the
-session-spawn layer was built and tested against.
+Today flow runs on **macOS (iTerm2, stock Terminal.app, or zellij)
++ Claude Code only**. That's the stack we use, and that's what the
+session-spawn layer was built and tested against. zellij works on
+Linux too as a side effect — it's cross-platform and flow's zellij
+backend doesn't depend on any macOS APIs.
 
 The architecture is portable — session spawning is one small
 package — but other harnesses (Codex, Cursor, plain shell) and other
-terminals (Linux + tmux/zellij/wezterm, Windows Terminal) need
-contributors who run those stacks daily and care enough to wire them
-in. If that's you, [a PR is very welcome](CONTRIBUTING.md).
+terminals (Linux + tmux/wezterm, Windows Terminal) need contributors
+who run those stacks daily and care enough to wire them in. If that's
+you, [a PR is very welcome](CONTRIBUTING.md).
 
 ## Where flow came from
 

--- a/README.md
+++ b/README.md
@@ -152,8 +152,9 @@ handles the rest.
 
 - **One task, one Claude session, one tab.** `flow do <task>`
   spawns a dedicated tab in iTerm2, stock macOS Terminal, or your
-  current zellij session — flow picks whichever you launched it from.
-  Tomorrow's `flow do <task>` resumes the same conversation.
+  current zellij session (requires zellij ≥ 0.40) — flow picks
+  whichever you launched it from. Tomorrow's `flow do <task>`
+  resumes the same conversation.
 - **Interview-driven task capture.** No forms. flow asks
   what / why / where / done-when, then writes a structured brief.
 - **A knowledge base that grows.** Five markdown buckets for

--- a/internal/app/do_test.go
+++ b/internal/app/do_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flow/internal/flowdb"
 	"flow/internal/iterm"
+	"flow/internal/spawner"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -13,6 +14,10 @@ import (
 // stubITerm replaces iterm.Runner with a counter + captured-script
 // recorder. Returns the counter pointer and a function that reads the
 // most recent AppleScript argument passed to osascript.
+//
+// It also pins spawner.Override to BackendITerm so the test is not
+// affected by an ambient $ZELLIJ env var (e.g. when the developer runs
+// the test suite from inside a zellij session).
 func stubITerm(t *testing.T) (*int64, func() string) {
 	t.Helper()
 	var count int64
@@ -29,6 +34,13 @@ func stubITerm(t *testing.T) (*int64, func() string) {
 		return nil
 	}
 	t.Cleanup(func() { iterm.Runner = old })
+
+	// Pin the spawner backend so ambient env vars (e.g. ZELLIJ) don't
+	// reroute SpawnTab away from iterm.Runner.
+	oldOverride := spawner.Override
+	spawner.Override = spawner.BackendITerm
+	t.Cleanup(func() { spawner.Override = oldOverride })
+
 	return &count, func() string {
 		mu.Lock()
 		defer mu.Unlock()
@@ -157,6 +169,12 @@ func TestCmdDoFreshSpawnFailureRollsBackSessionID(t *testing.T) {
 	iterm.Runner = func(args []string) error { return errors.New("simulated osascript failure") }
 	t.Cleanup(func() { iterm.Runner = old })
 
+	// Pin the spawner backend so ambient env vars (e.g. ZELLIJ) don't
+	// reroute SpawnTab away from iterm.Runner.
+	oldOverride := spawner.Override
+	spawner.Override = spawner.BackendITerm
+	t.Cleanup(func() { spawner.Override = oldOverride })
+
 	if rc := cmdDo([]string{"fail-task"}); rc != 1 {
 		t.Errorf("cmdDo on spawn failure: got rc=%d, want 1", rc)
 	}
@@ -202,6 +220,12 @@ func TestCmdDoResumeSpawnFailureKeepsSessionID(t *testing.T) {
 	old := iterm.Runner
 	iterm.Runner = func(args []string) error { return errors.New("simulated osascript failure") }
 	t.Cleanup(func() { iterm.Runner = old })
+
+	// Pin the spawner backend so ambient env vars (e.g. ZELLIJ) don't
+	// reroute SpawnTab away from iterm.Runner.
+	oldOverride := spawner.Override
+	spawner.Override = spawner.BackendITerm
+	t.Cleanup(func() { spawner.Override = oldOverride })
 
 	if rc := cmdDo([]string{"resume-fail-task"}); rc != 1 {
 		t.Errorf("cmdDo on resume spawn failure: got rc=%d, want 1", rc)

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -32,7 +32,7 @@ tasks, workdirs, session IDs) lives in a single SQLite database at
 "briefs" at `~/.flow/projects/<slug>/brief.md` and
 `~/.flow/tasks/<slug>/brief.md`. Progress notes accumulate as dated
 markdown files under each entity's `updates/` subdirectory. The user runs
-one long-lived Claude session per task in its own iTerm tab, resumed via
+one long-lived Claude session per task in its own terminal tab, resumed via
 `flow do <task>`.
 
 You are speaking inside one of those Claude sessions (or the user's
@@ -513,13 +513,13 @@ its own, it's the start of a two-or-more-step workflow.
 4. Pass `--fresh` ONLY if the user explicitly asked for a fresh session
    (e.g. "start over", "fresh session", "--fresh"). Never on your own.
 
-**After `flow do` succeeds** it has already spawned an iTerm tab and
+**After `flow do` succeeds** it has already spawned a terminal tab and
 exported the env vars. Your job is done. Report "opened tab: <title>"
 and stop. Do NOT:
 
 - Run diagnostic commands like `pgrep`, `ls ~/.claude/projects/...`,
   or `osascript` to try to verify the tab opened.
-- Try to spawn an iTerm tab yourself with osascript. `flow do` already
+- Try to spawn a terminal tab yourself with osascript or zellij. `flow do` already
   did this.
 - Re-run `flow do` unless the user explicitly asked for a retry.
 - Try to peek into the new session's activity. It's a separate
@@ -664,7 +664,7 @@ closure is a silent loss of durable knowledge.
    `AskUserQuestion` (header: "Closing note?", options:
    "Yes, save a note first" / "No, just mark done") to offer.
    On "Yes", run the §4.5 recipe first, then continue.
-3. Run `flow done <ref>`. **Do not close the iTerm tab** and **do
+3. Run `flow done <ref>`. **Do not close the terminal tab** and **do
    not kill the Claude session** — `flow done` deliberately leaves
    both intact. The session_id stays on the task row so a future
    reopen can still resume it. The close-out sweep runs after the
@@ -919,7 +919,7 @@ unfolds and intervene only when the evidence is strong. When you
 intervene, the surfacing mechanism is `AskUserQuestion` (never a
 prose "want me to...?" question). Its purpose is to keep a task's
 transcript and update log focused, instead of letting unrelated work
-pile up under whichever task happens to own the current iTerm tab.
+pile up under whichever task happens to own the current terminal tab.
 
 **When to consider firing:**
 
@@ -1057,7 +1057,7 @@ stop.
 2. Run: `flow run playbook <slug>` (with `--dangerously-skip-permissions`
    if chosen).
 3. The command creates a kind=playbook_run task, snapshots the brief,
-   and spawns an iTerm tab. The new tab will boot the flow skill via its
+   and spawns a terminal tab. The new tab will boot the flow skill via its
    bootstrap prompt and execute against the snapshotted brief.
 
 **Anti-pattern (per §8):** never auto-fire. Manual trigger only. Even if
@@ -1653,7 +1653,7 @@ instead.
 
 ## 9. The execution-session bootstrap contract
 
-When `flow do <task>` spawns a Claude session in a new iTerm tab, it
+When `flow do <task>` spawns a Claude session in a new terminal tab, it
 pre-allocates a UUID, writes it to `tasks.session_id` before spawning,
 and passes it to `claude --session-id <uuid>`. This makes the session's
 jsonl file appear at the deterministic path
@@ -1832,7 +1832,7 @@ them as workarounds for a bug in `flow do`; surface the bug instead.
 
 ## 10. Environment variables flow sets
 
-When `flow do <task>` spawns an iTerm tab, it attaches these env vars
+When `flow do <task>` spawns a terminal tab, it attaches these env vars
 to the `claude` process (inline on the command line — they do NOT
 persist in the tab's shell after claude exits):
 

--- a/internal/spawner/spawner.go
+++ b/internal/spawner/spawner.go
@@ -1,22 +1,25 @@
-// Package spawner picks a terminal backend (iTerm2 or macOS Terminal.app)
-// at runtime and forwards SpawnTab to it.
+// Package spawner picks a terminal backend (zellij, iTerm2, or macOS
+// Terminal.app) at runtime and forwards SpawnTab to it.
 //
-// Selection is driven by the TERM_PROGRAM env var that the host
-// terminal sets in every shell it spawns:
+// Selection priority:
 //
-//	TERM_PROGRAM=iTerm.app        → internal/iterm
-//	TERM_PROGRAM=Apple_Terminal   → internal/terminal
-//	anything else (or unset)      → internal/iterm  (historical default)
+//	$ZELLIJ set                       → internal/zellij
+//	TERM_PROGRAM=Apple_Terminal       → internal/terminal
+//	TERM_PROGRAM=iTerm.app            → internal/iterm
+//	anything else (or unset)          → internal/iterm  (historical default)
+//
+// $ZELLIJ wins over TERM_PROGRAM because if the user is inside a zellij
+// session, that's where their workflow lives — the host terminal is a
+// substrate detail.
 //
 // The Override var lets tests pin the backend deterministically without
-// having to set TERM_PROGRAM via t.Setenv. Existing tests that mock
-// iterm.Runner continue to work unchanged because the default fallback
-// is iTerm.
+// having to set TERM_PROGRAM via t.Setenv.
 package spawner
 
 import (
 	"flow/internal/iterm"
 	"flow/internal/terminal"
+	"flow/internal/zellij"
 	"os"
 )
 
@@ -26,6 +29,7 @@ type Backend string
 const (
 	BackendITerm    Backend = "iterm"
 	BackendTerminal Backend = "terminal"
+	BackendZellij   Backend = "zellij"
 )
 
 // Override, if non-empty, forces a backend regardless of TERM_PROGRAM.
@@ -38,6 +42,9 @@ var Override Backend
 func Detect() Backend {
 	if Override != "" {
 		return Override
+	}
+	if os.Getenv("ZELLIJ") != "" {
+		return BackendZellij
 	}
 	switch os.Getenv("TERM_PROGRAM") {
 	case "Apple_Terminal":
@@ -53,6 +60,8 @@ func Detect() Backend {
 // matches both iterm.SpawnTab and terminal.SpawnTab.
 func SpawnTab(title, cwd, command string, envVars map[string]string) error {
 	switch Detect() {
+	case BackendZellij:
+		return zellij.SpawnTab(title, cwd, command, envVars)
 	case BackendTerminal:
 		return terminal.SpawnTab(title, cwd, command, envVars)
 	default:

--- a/internal/spawner/spawner_test.go
+++ b/internal/spawner/spawner_test.go
@@ -3,6 +3,7 @@ package spawner
 import (
 	"flow/internal/iterm"
 	"flow/internal/terminal"
+	"flow/internal/zellij"
 	"strings"
 	"testing"
 )
@@ -22,6 +23,7 @@ func TestDetectFromEnv(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.termProgram, func(t *testing.T) {
+			t.Setenv("ZELLIJ", "")
 			t.Setenv("TERM_PROGRAM", tc.termProgram)
 			Override = ""
 			if got := Detect(); got != tc.want {
@@ -36,6 +38,7 @@ func TestDetectFromEnv(t *testing.T) {
 // pins the backend regardless of TERM_PROGRAM, so individual tests can
 // pin the dispatcher without relying on env-var mutation order.
 func TestOverrideBeatsEnv(t *testing.T) {
+	t.Setenv("ZELLIJ", "")
 	t.Setenv("TERM_PROGRAM", "iTerm.app")
 	t.Cleanup(func() { Override = "" })
 
@@ -49,13 +52,26 @@ func TestOverrideBeatsEnv(t *testing.T) {
 	}
 }
 
+// TestDetectZellij verifies the ZELLIJ env var beats TERM_PROGRAM.
+// zellij sets ZELLIJ in every shell it spawns, so its presence means
+// the user is inside a zellij session regardless of which terminal
+// hosts it.
+func TestDetectZellij(t *testing.T) {
+	t.Setenv("ZELLIJ", "0")
+	t.Setenv("TERM_PROGRAM", "iTerm.app") // proves ZELLIJ wins
+	Override = ""
+	if got := Detect(); got != BackendZellij {
+		t.Errorf("Detect() with ZELLIJ=0: got %q, want %q", got, BackendZellij)
+	}
+}
+
 // TestSpawnTabRoutesToITerm asserts the iterm Runner is the one called
 // when Detect() resolves to BackendITerm.
 func TestSpawnTabRoutesToITerm(t *testing.T) {
 	Override = BackendITerm
 	t.Cleanup(func() { Override = "" })
 
-	itermCalled, terminalCalled := stubBothRunners(t)
+	itermCalled, terminalCalled, zellijCalled := stubAllRunners(t)
 	if err := SpawnTab("title", "/tmp", "echo hi", nil); err != nil {
 		t.Fatalf("SpawnTab: %v", err)
 	}
@@ -65,6 +81,9 @@ func TestSpawnTabRoutesToITerm(t *testing.T) {
 	if *terminalCalled {
 		t.Error("did not expect terminal.Runner to be called")
 	}
+	if *zellijCalled {
+		t.Error("did not expect zellij.Runner to be called")
+	}
 }
 
 // TestSpawnTabRoutesToTerminal asserts the terminal Runner is the one
@@ -73,7 +92,7 @@ func TestSpawnTabRoutesToTerminal(t *testing.T) {
 	Override = BackendTerminal
 	t.Cleanup(func() { Override = "" })
 
-	itermCalled, terminalCalled := stubBothRunners(t)
+	itermCalled, terminalCalled, zellijCalled := stubAllRunners(t)
 	if err := SpawnTab("title", "/tmp", "echo hi", nil); err != nil {
 		t.Fatalf("SpawnTab: %v", err)
 	}
@@ -82,6 +101,30 @@ func TestSpawnTabRoutesToTerminal(t *testing.T) {
 	}
 	if !*terminalCalled {
 		t.Error("expected terminal.Runner to be called")
+	}
+	if *zellijCalled {
+		t.Error("did not expect zellij.Runner to be called")
+	}
+}
+
+// TestSpawnTabRoutesToZellij asserts the zellij Runner is the one
+// called when Detect() resolves to BackendZellij.
+func TestSpawnTabRoutesToZellij(t *testing.T) {
+	Override = BackendZellij
+	t.Cleanup(func() { Override = "" })
+
+	itermCalled, terminalCalled, zellijCalled := stubAllRunners(t)
+	if err := SpawnTab("title", "/tmp", "echo hi", nil); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+	if *itermCalled {
+		t.Error("did not expect iterm.Runner to be called")
+	}
+	if *terminalCalled {
+		t.Error("did not expect terminal.Runner to be called")
+	}
+	if !*zellijCalled {
+		t.Error("expected zellij.Runner to be called")
 	}
 }
 
@@ -96,17 +139,17 @@ func TestShellQuoteParity(t *testing.T) {
 	}
 }
 
-// stubBothRunners replaces both backends' Runner vars with no-op stubs
-// that flip a per-runner boolean when called. Restores originals on
-// test cleanup. Returns pointers so the caller can read post-call.
-func stubBothRunners(t *testing.T) (*bool, *bool) {
+// stubAllRunners replaces all three backend Runner vars with no-op
+// stubs that flip a per-runner boolean when called. Restores
+// originals on test cleanup. Returns pointers so callers can read
+// post-call.
+func stubAllRunners(t *testing.T) (*bool, *bool, *bool) {
 	t.Helper()
-	var itermCalled, terminalCalled bool
+	var itermCalled, terminalCalled, zellijCalled bool
 
 	oldITerm := iterm.Runner
 	iterm.Runner = func(args []string) error {
 		itermCalled = true
-		// Sanity-check: every iterm script targets iTerm2.
 		if len(args) >= 2 && !strings.Contains(args[1], "iTerm2") {
 			t.Errorf("iterm script does not target iTerm2: %s", args[1])
 		}
@@ -124,5 +167,15 @@ func stubBothRunners(t *testing.T) (*bool, *bool) {
 	}
 	t.Cleanup(func() { terminal.Runner = oldTerm })
 
-	return &itermCalled, &terminalCalled
+	oldZellij := zellij.Runner
+	zellij.Runner = func(args []string) error {
+		zellijCalled = true
+		if len(args) >= 1 && args[0] != "action" {
+			t.Errorf("zellij argv does not start with 'action': %v", args)
+		}
+		return nil
+	}
+	t.Cleanup(func() { zellij.Runner = oldZellij })
+
+	return &itermCalled, &terminalCalled, &zellijCalled
 }

--- a/internal/zellij/zellij.go
+++ b/internal/zellij/zellij.go
@@ -1,0 +1,70 @@
+// Package zellij provides zellij-session tab spawning via the `zellij`
+// CLI. Activated by spawner.Detect() when $ZELLIJ is set in the
+// environment (zellij sets this in every shell it spawns).
+//
+// Mechanism:
+//
+//  1. zellij action new-tab --name <title> --cwd <cwd>
+//  2. zellij action write-chars " <env-prefix><command>\n"
+//
+// Step 1 creates and focuses the new tab; step 2 types the command
+// into the new pane's PTY so the shell executes it. The leading space
+// triggers histignorespace on shells that have it on, matching the
+// iterm/terminal backends. The trailing newline submits the line.
+//
+// This file mirrors the contract of internal/iterm and internal/terminal
+// — same SpawnTab signature, same Runner mock var for tests, same
+// ShellQuote helper.
+package zellij
+
+import (
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// Runner is the function used to execute zellij.
+// Tests override this to capture argv without invoking the real CLI.
+var Runner = func(args []string) error {
+	cmd := exec.Command("zellij", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("zellij failed: %v: %s", err, string(out))
+	}
+	return nil
+}
+
+// SpawnTab opens a new zellij tab in the current session, sets its
+// name and cwd, and types `command` into the new pane's PTY.
+//
+// envVars are attached as an inline shell prefix to `command` only —
+// they are present in the command's environment but do NOT persist
+// in the tab's shell after the command exits.
+func SpawnTab(title, cwd, command string, envVars map[string]string) error {
+	if err := Runner([]string{"action", "new-tab", "--name", title, "--cwd", cwd}); err != nil {
+		return err
+	}
+
+	envPrefix := ""
+	if len(envVars) > 0 {
+		keys := make([]string, 0, len(envVars))
+		for k := range envVars {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		parts := make([]string, 0, len(envVars))
+		for _, k := range keys {
+			parts = append(parts, fmt.Sprintf("%s=%s", k, ShellQuote(envVars[k])))
+		}
+		envPrefix = strings.Join(parts, " ") + " "
+	}
+	line := " " + envPrefix + command + "\n"
+	return Runner([]string{"action", "write-chars", line})
+}
+
+// ShellQuote wraps s in single quotes with proper escaping. Same
+// implementation as iterm.ShellQuote and terminal.ShellQuote.
+func ShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/zellij/zellij.go
+++ b/internal/zellij/zellij.go
@@ -5,12 +5,22 @@
 // Mechanism:
 //
 //  1. zellij action new-tab --name <title> --cwd <cwd>
-//  2. zellij action write-chars " <env-prefix><command>\n"
+//  2. zellij action write-chars " <env-prefix><flattened-command>\n"
 //
 // Step 1 creates and focuses the new tab; step 2 types the command
 // into the new pane's PTY so the shell executes it. The leading space
 // triggers histignorespace on shells that have it on, matching the
 // iterm/terminal backends. The trailing newline submits the line.
+//
+// Newline handling: write-chars writes raw bytes to the new pane's
+// PTY, so any embedded `\n` in the command is interpreted by the
+// shell as Enter — submitting a partial line and dropping into a
+// continuation/error state instead of running the whole command.
+// `flow do`'s bootstrap prompt is a multi-line numbered list, which
+// would have its lines executed individually (and fail) without
+// flattening. We replace embedded newlines with spaces before
+// emitting the line; the bootstrap text is whitespace-insensitive
+// for the LLM, so this is lossless.
 //
 // This file mirrors the contract of internal/iterm and internal/terminal
 // — same SpawnTab signature, same Runner mock var for tests, same
@@ -59,7 +69,8 @@ func SpawnTab(title, cwd, command string, envVars map[string]string) error {
 		}
 		envPrefix = strings.Join(parts, " ") + " "
 	}
-	line := " " + envPrefix + command + "\n"
+	flat := strings.ReplaceAll(command, "\n", " ")
+	line := " " + envPrefix + flat + "\n"
 	return Runner([]string{"action", "write-chars", line})
 }
 

--- a/internal/zellij/zellij_test.go
+++ b/internal/zellij/zellij_test.go
@@ -3,6 +3,7 @@ package zellij
 import (
 	"errors"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -88,6 +89,40 @@ func TestSpawnTabPropagatesNewTabError(t *testing.T) {
 	}
 	if err.Error() != want.Error() {
 		t.Errorf("expected pass-through of new-tab error, got: %v", err)
+	}
+}
+
+// TestSpawnTabFlattensEmbeddedNewlines verifies that any `\n` inside
+// `command` is replaced with a space before write-chars. Without this,
+// zellij types each line into the PTY as a separate Enter-terminated
+// command, which breaks the bootstrap prompt (a multi-line numbered
+// list) — the shell ends up trying to execute "1. Invoke...",
+// "2. Run...", etc. as commands.
+func TestSpawnTabFlattensEmbeddedNewlines(t *testing.T) {
+	var captured []string
+	old := Runner
+	Runner = func(args []string) error {
+		if len(args) >= 3 && args[1] == "write-chars" {
+			captured = append(captured, args[2])
+		}
+		return nil
+	}
+	t.Cleanup(func() { Runner = old })
+
+	cmd := "claude --session-id abc 'line1\nline2\nline3'"
+	if err := SpawnTab("t", "/tmp", cmd, nil); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+	if len(captured) != 1 {
+		t.Fatalf("expected 1 write-chars call, got %d", len(captured))
+	}
+	want := " claude --session-id abc 'line1 line2 line3'\n"
+	if captured[0] != want {
+		t.Errorf("write-chars line = %q; want %q", captured[0], want)
+	}
+	// Only one newline (the line-submit terminator) should be present.
+	if got := strings.Count(captured[0], "\n"); got != 1 {
+		t.Errorf("write-chars line contains %d newlines; want exactly 1", got)
 	}
 }
 

--- a/internal/zellij/zellij_test.go
+++ b/internal/zellij/zellij_test.go
@@ -1,0 +1,108 @@
+package zellij
+
+import (
+	"errors"
+	"slices"
+	"testing"
+)
+
+// TestSpawnTabBasicNoEnv verifies the two-call argv sequence with no env vars:
+//  1) zellij action new-tab --name <title> --cwd <cwd>
+//  2) zellij action write-chars " <command>\n"   (leading space for histignorespace)
+func TestSpawnTabBasicNoEnv(t *testing.T) {
+	var calls [][]string
+	old := Runner
+	Runner = func(args []string) error {
+		calls = append(calls, append([]string(nil), args...))
+		return nil
+	}
+	t.Cleanup(func() { Runner = old })
+
+	if err := SpawnTab("my-task", "/tmp", "echo hi", nil); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d: %v", len(calls), calls)
+	}
+	wantNewTab := []string{"action", "new-tab", "--name", "my-task", "--cwd", "/tmp"}
+	if !slices.Equal(calls[0], wantNewTab) {
+		t.Errorf("call[0] = %v; want %v", calls[0], wantNewTab)
+	}
+	wantWrite := []string{"action", "write-chars", " echo hi\n"}
+	if !slices.Equal(calls[1], wantWrite) {
+		t.Errorf("call[1] = %v; want %v", calls[1], wantWrite)
+	}
+}
+
+// TestSpawnTabEnvVarsSorted verifies env vars are emitted alphabetically,
+// each value shell-quoted, all space-separated, before the command. This
+// matches the iterm/terminal env-prefix contract exactly.
+func TestSpawnTabEnvVarsSorted(t *testing.T) {
+	var captured []string
+	old := Runner
+	Runner = func(args []string) error {
+		if len(args) >= 3 && args[1] == "write-chars" {
+			captured = append(captured, args[2])
+		}
+		return nil
+	}
+	t.Cleanup(func() { Runner = old })
+
+	envVars := map[string]string{
+		"FLOW_TASK":    "my-task",
+		"FLOW_PROJECT": "flow",
+	}
+	if err := SpawnTab("flow/my-task", "/Users/me/repo", "claude --resume abc", envVars); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+	if len(captured) != 1 {
+		t.Fatalf("expected 1 write-chars call, got %d", len(captured))
+	}
+	want := " FLOW_PROJECT='flow' FLOW_TASK='my-task' claude --resume abc\n"
+	if captured[0] != want {
+		t.Errorf("write-chars line = %q; want %q", captured[0], want)
+	}
+}
+
+// TestSpawnTabPropagatesNewTabError verifies an error from the new-tab
+// call is returned and write-chars is NOT attempted.
+func TestSpawnTabPropagatesNewTabError(t *testing.T) {
+	calls := 0
+	want := errors.New("zellij failed: exit status 1: not in a session")
+	old := Runner
+	Runner = func(args []string) error {
+		calls++
+		if len(args) >= 2 && args[1] == "new-tab" {
+			return want
+		}
+		return nil
+	}
+	t.Cleanup(func() { Runner = old })
+
+	err := SpawnTab("t", "/tmp", "echo hi", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call (new-tab only), got %d", calls)
+	}
+	if err.Error() != want.Error() {
+		t.Errorf("expected pass-through of new-tab error, got: %v", err)
+	}
+}
+
+// TestShellQuote — same contract as iterm.ShellQuote / terminal.ShellQuote.
+func TestShellQuote(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"plain", "'plain'"},
+		{"with space", "'with space'"},
+		{"with'quote", `'with'\''quote'`},
+	}
+	for _, tc := range cases {
+		if got := ShellQuote(tc.in); got != tc.want {
+			t.Errorf("ShellQuote(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thanks for sending a PR. A few quick prompts to keep reviews tight.
-->

## What

<!-- One-line summary of what changes. -->
Add a `zellij` terminal backend to `flow do` so it spawns new tabs inside the user's current zellij session when `$ZELLIJ` is set, with no behaviour change for non-zellij users.

## Why

<!--
Why this change? Link an issue if there is one. If you're changing
behaviour the embedded skill (`internal/app/skill/SKILL.md`) describes,
mention it explicitly — the skill is part of the contract.
-->
macOS users running zellij (e.g. Alacritty + zellij, or any zellij-hosted shell) couldn't use `flow do` — `spawner.Detect()` only recognised `iTerm.app` / `Apple_Terminal` and fell through to an iTerm default that wasn't actually running. The change extends the existing `internal/spawner` abstraction with a third backend; iTerm/Terminal paths are untouched.

The embedded skill (`internal/app/skill/SKILL.md`) had hard-coded "iTerm tab" references that would lie when the zellij backend is active. They're updated to neutral "terminal tab" wording in the same PR. The Terminal.app Accessibility section is preserved — still backend-specific and accurate.

`CONTRIBUTING.md` previously listed zellij as out-of-scope; that line is updated to bring zellij into scope. tmux/wezterm/Windows Terminal stay out of scope.

## Test plan

- [x] `make test` passes
- [x] CI green (`go vet`, `go test ./...`, build on macOS + Ubuntu)
- [x] Manually exercised: `flow do <task>` from inside a zellij session opens a new tab and runs `claude --session-id <uuid>` correctly
- [x] Manually exercised: `flow do <task>` from iTerm2 (no `$ZELLIJ`) still opens an iTerm tab — fallback path preserved
- [x] Skill rebuild verified: `go build ./...` clean (the embedded skill compiles); no `flow skill update` needed by users since the skill content change is a wording tweak, not a contract change
- N/A — `hookCommand` in `internal/app/skill.go` is unchanged

## Notes

<!-- Anything reviewers should know — alternatives considered, things
deliberately left out, follow-ups planned. -->
**Mechanism choice.** The new backend uses `zellij action new-tab --name <title> --cwd <cwd>` followed by `zellij action write-chars " <env-prefix><command>\n"`. I considered (a) a tempfile KDL layout via `--layout` and (b) `bash -c` wrapping. `action new-tab` + `write-chars` was chosen because it preserves the existing `command string` contract used by iTerm/Terminal (the command is typed into the user's actual login shell, appears in scrollback as a literal command line, leading-space `histignorespace` trick still applies), avoids an extra subshell layer, and keeps the package small.

**Detection priority.** `$ZELLIJ` → `Apple_Terminal` → `iTerm.app` → iTerm-default. zellij wins because if you're inside a zellij session, that's where your workflow lives — the host terminal is a substrate detail.

**ShellQuote duplication.** `ShellQuote` is now duplicated across iterm/terminal/zellij (3 lines each). An extracted `internal/shellquote` package would save those lines but introduce a new package boundary. Happy to refactor if reviewers prefer.

**Minimum zellij version.** Requires zellij ≥ 0.40 (`action new-tab --name/--cwd` and `action write-chars` are both stable since then). Current Homebrew is 0.44; documented in the README zellij paragraph.

**Deliberately out of scope.** Pane support, layout files, configurable backend pinning, generic Linux iTerm/Terminal equivalents — pushed to future PRs.