### PR TITLE
Add Codex-backed flow session support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,80 @@
   <img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License">
 </p>
 
-> A complete task manager for Claude Code — and the working memory
+> A complete task manager for Claude Code and Codex — and the working memory
 > layer that turns every session from a brilliant new hire into the
 > engineer on your team.
+
+## What flow is
+
+flow is a local task manager for agentic coding work. It keeps your
+projects, tasks, briefs, progress notes, playbooks, and durable
+knowledge in `~/.flow/`, then loads the right context into Claude Code
+or Codex whenever you start or resume work.
+
+Use it when you want your coding agent to remember:
+
+- what a task is trying to accomplish
+- why earlier decisions were made
+- where the repo and project context live
+- what happened in previous sessions
+- durable facts about you, your team, products, and process
+
+Everything is local: markdown files plus a SQLite index. No server, no
+account, no telemetry.
+
+## Quickstart
+
+### 1. Install
+
+In Claude Code or Codex, paste:
+
+> Install flow from https://github.com/Facets-cloud/flow
+
+The agent downloads the latest binary and runs `flow init`. That one
+setup step creates `~/.flow/`, installs the flow skill for the agent you
+ran it from, and wires the SessionStart hook that makes future sessions
+auto-load context.
+
+Manual install is below if you prefer shell commands.
+
+### 2. Start working
+
+Open Claude Code or Codex and say:
+
+> let's get to work
+
+The flow skill will help you pick an existing task or create a new one.
+When you start a task, `flow do <task>` opens or focuses the right
+terminal tab and starts/resumes the matching Claude or Codex session.
+
+### 3. Close the loop
+
+When the task is done:
+
+```bash
+flow done <task>
+```
+
+flow marks it done and runs a best-effort transcript sweep so important
+facts can be added to the knowledge base for future sessions.
+
+## Common commands
+
+```bash
+flow init                         # first-time setup
+flow add project "Auth" --work-dir ~/src/auth
+flow add task "Fix token expiry" --project auth
+flow list                         # active tasks
+flow do fix-token-expiry          # start or resume work
+flow do fix-token-expiry --with "check the upstream PR first"
+flow update task fix-token-expiry --status backlog
+flow transcript fix-token-expiry
+flow done fix-token-expiry
+```
+
+You can mostly drive these through natural language in Claude or Codex.
+The CLI is there when you want precision.
 
 ## See it in action
 
@@ -26,20 +97,20 @@ mechanic is what you watch, not the code.
 
 **Act 1 — Capture the work.** Just talk. flow interviews you for
 what / why / where / done-when, drafts a structured brief, and opens
-a dedicated Claude session for the task in a new tab.
+a dedicated Claude or Codex session for the task in a new tab.
 
 ![Act 1 — task intake](docs/demo/01-task-intake.gif)
 
 **Act 2 — Work, then park.** The session has the brief, the project
 context, and the knowledge base loaded. You build until you hit a
-blocker — here, "Kirk needs to review this" — and tell Claude to
+blocker — here, "Kirk needs to review this" — and tell the agent to
 park it. Status flips to `waiting`. Tab can close.
 
 ![Act 2 — execution and park](docs/demo/02-task-execution.gif)
 
 **Act 3 — Resume and close.** A day later you say "Kirk signed off."
 Same session resumes with full memory of where it left off. `flow
-done` flips status and triggers the sweep — Claude re-reads the
+done` flips status and triggers the sweep — the agent re-reads the
 whole transcript and writes durable facts (Kirk approved the design,
 the ship class, the conventions used) into the knowledge base.
 
@@ -48,7 +119,7 @@ the ship class, the conventions used) into the knowledge base.
 **Act 4 — Months later, a new captain.** New task: "Picard's the new
 boss, he wants the starship as an SVG." Brand new session, but it
 already knows the ship, knows the design choices Kirk approved,
-knows the project conventions — because the KB carried it. Claude
+knows the project conventions — because the KB carried it. The agent
 just gets to work.
 
 ![Act 4 — Picard's SVG upgrade](docs/demo/04-picard-svg-upgrade.gif)
@@ -56,28 +127,17 @@ just gets to work.
 That fourth session is what flow is really about. Not the first
 session — the fiftieth.
 
-## Why flow
+## Why people use it
 
 If you use Claude Code daily, you've felt the ceiling: every session
-is a new hire. Brilliant, capable, ready to help — but with no memory
-of yesterday's decisions, last week's migrations, or the half-finished
-threads in your other tabs. You spend the first ten minutes of every
-session catching it up.
+starts cold. Brilliant, capable, ready to help — but missing yesterday's
+decisions, last week's migrations, and the half-finished threads in
+your other tabs.
 
-flow changes the relationship. It's a complete task manager —
-projects, tasks, structured briefs, progress notes, playbooks for
-recurring work — *and* a working memory layer that injects all of it
-into every Claude session automatically. Capture once, work with
-Claude on it forever.
-
-The first session feels normal. By session ten, Claude knows your
-codebase quirks, your team, the customer you keep mentioning, and
-the migration you're three steps into. By session fifty, it's the
-engineer on your team — not a new hire you re-explain yourself to
-every morning.
-
-Built for power users who want Claude to *work with them*, not just
-*help them*.
+flow gives that work a durable home. Tasks get structured briefs.
+Sessions get resumable identities. Completed work feeds a knowledge
+base. Related tasks can read each other's transcripts. Over time, your
+agent spends less time asking for context and more time doing the work.
 
 ## How context compounds
 
@@ -93,7 +153,7 @@ the next one smarter.
                                              │          │
                   flow do <task>             │ scoop    │ sweep
    ┌────────┐  ─────────────────▶  ┌─────────┴──────────┴─────┐
-   │  Task  │                      │      Claude session      │
+   │  Task  │                      │   Claude/Codex session   │
    │  brief │  ◀──── updates ───── │  loads brief + kb +      │
    │ +notes │                      │  notes + repo conventions│
    └────────┘  ─── flow done ───▶  └──────────────────────────┘
@@ -106,7 +166,7 @@ the next one smarter.
   product convention — and appends them to the matching kb file
   on the fly.
 - **Sweep (on `flow done`):** when you close a task, flow spawns
-  a headless Claude pass that re-reads the entire transcript and
+  a headless Claude or Codex pass that re-reads the entire transcript and
   pulls anything kb-worthy that the live scoop missed. The status
   flip is the contract; the sweep is best-effort.
 - **Cross-reference:** `flow transcript <sibling-task>` lets a
@@ -123,10 +183,11 @@ Customer-meeting prep.
 
 A **playbook** is a reusable run definition — a markdown brief that
 describes what a run does. `flow run playbook weekly-review` snapshots
-that brief into a fresh task and spawns a new Claude session against
-it. Every run is reproducible (it executes against a frozen snapshot,
-so editing the playbook later doesn't rewrite history) and contributes
-back to the knowledge base on `flow done` like any other task.
+that brief into a fresh task and spawns a new Claude or Codex session
+against it. Every run is reproducible (it executes against a frozen
+snapshot, so editing the playbook later doesn't rewrite history) and
+contributes back to the knowledge base on `flow done` like any other
+task.
 
 ```
 ┌──────────┐  flow run playbook weekly-review
@@ -138,20 +199,10 @@ back to the knowledge base on `flow done` like any other task.
 Same compounding mechanic — your weekly review session two months from
 now will know everything every prior weekly review surfaced.
 
-## Install
+## Manual install
 
-In any Claude Code session, paste this:
-
-> Install flow from https://github.com/Facets-cloud/flow
-
-Claude reads the repo, downloads the binary, and runs `flow init` —
-which installs the flow skill into `~/.claude/skills/flow/SKILL.md`
-and registers a SessionStart hook so every future Claude session
-loads the skill automatically. Then say **"let's get to work"** and
-follow along.
-
-<details>
-<summary>Manual install (curl + chmod + flow init)</summary>
+Use this path if you would rather install from a shell instead of
+asking Claude to do it.
 
 ```bash
 # 1. Download the binary for your Mac.
@@ -163,22 +214,25 @@ chmod +x /usr/local/bin/flow
 xattr -d com.apple.quarantine /usr/local/bin/flow 2>/dev/null || true
 
 # 2. Initialize. This is required — it creates ~/.flow/, the SQLite
-#    index, the knowledge base, AND installs the Claude skill +
-#    SessionStart hook. Without this step, Claude can't talk to flow.
+#    index, the knowledge base, and installs the skill + SessionStart
+#    hook for the detected agent harness. From a plain shell, Claude is
+#    the default.
 flow init
 ```
 
-`flow init` is the step that wires flow into Claude Code. It:
+`flow init` is the step that wires flow into your agent harness. It:
 
 - Creates `~/.flow/` (database, kb, projects, tasks, playbooks)
-- Writes the flow skill to `~/.claude/skills/flow/SKILL.md`
-- Adds a SessionStart hook to `~/.claude/settings.json` so every new
-  Claude Code session auto-loads the skill
+- Writes the flow skill to the harness skill directory, such as
+  `~/.claude/skills/flow/SKILL.md` or `~/.codex/skills/flow/SKILL.md`
+- Adds the harness SessionStart hook so new sessions auto-load the skill
+
+If you use both Claude Code and Codex, run `flow skill install` once
+from the other agent too. flow stores which harness owns each task the
+first time you run `flow do`.
 
 The `xattr` step removes Gatekeeper's quarantine attribute so macOS
 doesn't refuse to run the unsigned binary.
-
-</details>
 
 ### For those who use Claude's agents view
 
@@ -212,21 +266,17 @@ update` to refresh the skill and re-wire the SessionStart and
 UserPromptSubmit hooks. Check the running version with
 `flow --version`.
 
-## Quickstart
-
-Just open Claude and say **"let's get to work"**. The skill
-handles the rest.
-
 ## What you get
 
-- **One task, one Claude session, one tab.** `flow do <task>`
-  spawns a dedicated tab in iTerm2, Warp, stock macOS Terminal, kitty
-  (requires `allow_remote_control yes` in `kitty.conf`), or your
-  current zellij session (requires zellij ≥ 0.40) — flow picks
-  whichever you launched it from. Override with
-  `FLOW_TERM=warp|iterm|terminal|zellij|kitty` when you're on a
-  non-standard host. Tomorrow's `flow do <task>` resumes the same
-  conversation.
+- **One task, one harness session, one tab.** `flow do <task>`
+  spawns a dedicated tab in iTerm2, Warp, Ghostty, stock macOS
+  Terminal, kitty (requires `allow_remote_control yes` in
+  `kitty.conf`), or your current zellij session (requires zellij ≥
+  0.40) — flow picks whichever you launched it from. Override with
+  `FLOW_TERM=warp|ghostty|iterm|terminal|zellij|kitty` when you're on a
+  non-standard host. It auto-detects Claude vs Codex from the current
+  session, stores that harness on the task, and tomorrow's
+  `flow do <task>` resumes the same conversation.
 - **Interview-driven task capture.** No forms. flow asks
   what / why / where / done-when, then writes a structured brief.
 - **A knowledge base that grows.** Five markdown buckets for
@@ -237,25 +287,24 @@ handles the rest.
   you left off, even after a week away.
 - **Playbooks for cadence work.** Weekly reviews, daily triage,
   on-call rotations — define once, run on demand.
-- **A Claude skill that speaks plain English.** "What should I
+- **A Claude/Codex skill that speaks plain English.** "What should I
   work on", "resume auth", "save a note" — the skill turns intent
   into flow commands.
 
 ## How it works under the hood
 
-`flow do <task>` pre-allocates a session UUID, writes it to the
-task row, and spawns a tab in zellij (when `$ZELLIJ` is set), kitty
-(when `$KITTY_WINDOW_ID` is set or `$TERM=xterm-kitty`), the backend
-named in `$FLOW_TERM` (when set), or Warp / iTerm2 / stock
-Terminal.app (auto-detected from `$TERM_PROGRAM`) — chosen in that
-priority order, with iTerm as the historical fallback — running
-`claude --session-id <uuid>` with `FLOW_TASK` / `FLOW_PROJECT` inlined.
-The jsonl file lands at the deterministic path
-`~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`, so future
-`flow do` calls run `claude --resume <uuid>` to continue the same
-conversation. A SessionStart hook re-injects the task brief,
-updates, and CLAUDE.md context on every resume; a UserPromptSubmit
-hook keeps the flow skill discoverable in ad-hoc Claude sessions.
+`flow do <task>` detects the invoking agent harness, then spawns a tab
+in zellij (when `$ZELLIJ` is set), kitty (when `$KITTY_WINDOW_ID` is
+set or `$TERM=xterm-kitty`), the backend named in `$FLOW_TERM` (when
+set), or Warp / Ghostty / iTerm2 / stock Terminal.app (auto-detected
+from `$TERM_PROGRAM`) — chosen in that priority order, with iTerm as
+the historical fallback. Claude remains the default: flow pre-allocates
+a UUID, stores it as the task's Claude session, and runs
+`claude --session-id <uuid>` or `claude --resume <uuid>`. For Codex,
+flow first runs a short `codex exec --json` probe to mint a real session
+id, stores that id on the task, and launches or resumes with
+`codex resume <session-id>`. `flow transcript <task>` uses the task's
+stored harness to render the right transcript format.
 
 When `flow do <task>` is run for a task whose session is already
 live in another tab, flow focuses that tab instead of spawning a
@@ -366,20 +415,20 @@ and reinstall the skill + hook.
 
 ## Where flow runs (and where we'd love help)
 
-Today flow runs on **macOS (iTerm2, Warp, stock Terminal.app, kitty,
-or zellij) + Claude Code only**. That's the stack we use, and that's
-what the session-spawn layer was built and tested against. zellij
-and kitty work on Linux too as a side effect — both are
-cross-platform and flow's zellij / kitty backends don't depend on
-any macOS APIs. Kitty needs `allow_remote_control yes` (or
-`socket-only`) in `kitty.conf` so flow can drive `kitty @ launch`
-from inside the running kitty instance.
+Today flow runs on **macOS with Claude Code and Codex**. The terminal
+spawn layer supports iTerm2, Warp, Ghostty, stock Terminal.app, kitty,
+and zellij. zellij and kitty also work on Linux as a side effect because
+those backends do not depend on macOS APIs.
 
-The architecture is portable — session spawning is one small
-package — but other harnesses (Codex, Cursor, plain shell) and other
-terminals (Linux + tmux/wezterm, Windows Terminal) need contributors
-who run those stacks daily and care enough to wire them in. If that's
-you, [a PR is very welcome](CONTRIBUTING.md).
+Kitty needs `allow_remote_control yes` (or `socket-only`) in
+`kitty.conf` so flow can drive `kitty @ launch` from inside the running
+kitty instance.
+
+The architecture is portable — session spawning is one small package —
+but more harnesses and terminals still need contributors who run those
+stacks daily. Cursor, tmux/wezterm, Windows Terminal, and deeper Linux
+coverage are all good candidates. If that's you, [a PR is very
+welcome](CONTRIBUTING.md).
 
 ## Where flow came from
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,4 +1,4 @@
-// Package app implements the flow CLI — personal task and Claude session
+// Package app implements the flow CLI — personal task and harness session
 // manager backed by SQLite.
 package app
 
@@ -75,7 +75,7 @@ func Run(args []string) int {
 }
 
 func printUsage() {
-	fmt.Println(`flow — personal task and Claude session manager
+	fmt.Println(`flow — personal task and Claude/Codex execution-session manager
 
 Setup:
   flow init
@@ -90,12 +90,12 @@ Create:
 Sessions:
   flow do                <ref> [--fresh] [--dangerously-skip-permissions]
   flow done              <ref>
-  flow hook session-start                      (SessionStart hook handler — wire via ~/.claude/settings.json)
+  flow hook session-start                      (SessionStart hook handler — wire via Claude/Codex hook config)
 
 Read:
   flow show task       [<ref>]
   flow show project    [<ref>]
-  flow transcript      [<ref>] [--compact]           (readable transcript from session jsonl)
+  flow transcript      [<ref>] [--compact]             (readable transcript from session jsonl)
   flow list tasks    [--status ...] [--project ...] [--priority ...] [--tag <t>] [--since ...] [--include-archived]
   flow list projects [--status ...] [--include-archived]
   flow list tags                                            (every tag in use, with per-tag task counts)
@@ -110,7 +110,7 @@ Edit / mutate:
                             [--tag <t> ...] [--remove-tag <t> ...] [--clear-tags]
   flow update project <ref> [--priority h|m|l]
   flow do        <ref> [--fresh] [--dangerously-skip-permissions] [--force]   (spawn a new tab; --force overrides the live-session guard)
-  flow do --here <ref> [--force]                                              (bind THIS Claude session to the task; --force overwrites a prior binding)
+  flow do --here <ref> [--force]                                              (bind THIS harness session to the task; --force overwrites a prior binding)
   flow archive   <ref>
   flow unarchive <ref>
 
@@ -123,7 +123,7 @@ Workdirs:
 Playbooks:
   flow add playbook   "<name>" --work-dir <path> [--slug <s>] [--project <slug>] [--mkdir]
   flow run playbook   <slug> [--dangerously-skip-permissions]   (spawn a new tab)
-  flow run playbook   <slug> --here                              (bind THIS Claude session to the new run; no new tab)
+  flow run playbook   <slug> --here                              (bind THIS harness session to the new run; no new tab)
   flow show playbook  <ref>
   flow list playbooks [--project <slug>] [--include-archived]`)
 }

--- a/internal/app/do.go
+++ b/internal/app/do.go
@@ -90,7 +90,7 @@ func openConcurrentDB(path string) (*sql.DB, error) {
 	return db, nil
 }
 
-// cmdDo flips a task to in-progress, bootstraps a Claude session if
+// cmdDo flips a task to in-progress, bootstraps a harness session if
 // needed (race-free via atomic UPDATE ... WHERE session_id IS ?), and
 // spawns an iTerm tab to resume it. See spec §6 for the full protocol.
 func cmdDo(args []string) int {
@@ -101,8 +101,8 @@ func cmdDo(args []string) int {
 	fs := flagSet("do")
 	fresh := fs.Bool("fresh", false, "discard existing session and re-bootstrap")
 	dangerSkip := fs.Bool("dangerously-skip-permissions", false, "skip per-tool approval prompts in the spawned harness")
-	force := fs.Bool("force", false, "open even if the task's Claude session is already running elsewhere")
-	here := fs.Bool("here", false, "bind THIS Claude session to the task (no new tab); requires running inside a Claude Code session")
+	force := fs.Bool("force", false, "open even if the task's harness session is already running elsewhere")
+	here := fs.Bool("here", false, "bind THIS harness session to the task (no new tab); requires running inside a known harness session")
 	withInstr := fs.String("with", "", "inject `<instruction>` as the first user message after the bootstrap/resume")
 	withFile := fs.String("with-file", "", "inject 'read instructions at <path>' (mutually exclusive with --with)")
 	// Two-pass parse so the slug positional may appear before OR after
@@ -566,13 +566,12 @@ func findTask(db *sql.DB, query string) (*flowdb.Task, int) {
 }
 
 // cmdDoHere is the `--here` branch of `flow do`. Instead of spawning
-// a new tab with a fresh Claude session, it binds the CURRENT Claude
+// a new tab with a fresh harness session, it binds the CURRENT harness
 // session (discovered via $CLAUDE_CODE_SESSION_ID) to the named task
 // and flips the task to in-progress.
 //
 // Safety:
-//   - Refuses if not running inside a Claude Code session
-//     (CLAUDE_CODE_SESSION_ID unset).
+//   - Refuses if not running inside a known harness session.
 //   - Refuses if the target task already has a different session_id
 //     bound. The constraint guards against silent overwrites that
 //     would orphan the prior session. --force overrides.
@@ -661,7 +660,7 @@ func cmdDoHere(query string, force bool) int {
 	priorBinding, lookupErr := flowdb.TaskBySessionID(db, sid)
 	if lookupErr == nil && priorBinding.Slug != task.Slug {
 		fmt.Fprintf(os.Stderr,
-			"error: this Claude session is already bound to task %q. binding it to %q would orphan %q's transcript and is rejected by the session_id uniqueness invariant. --force does not override this.\n"+
+			"error: this harness session is already bound to task %q. binding it to %q would orphan %q's transcript and is rejected by the session_id uniqueness invariant. --force does not override this.\n"+
 				"  to start work on %q in a separate session: flow do %s\n",
 			priorBinding.Slug, task.Slug, priorBinding.Slug, task.Slug, task.Slug)
 		return 1

--- a/internal/app/do_test.go
+++ b/internal/app/do_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flow/internal/flowdb"
 	"flow/internal/harness/claude"
+	"flow/internal/harness/codex"
 	"flow/internal/iterm"
 	"flow/internal/spawner"
 	"io"
@@ -587,6 +588,47 @@ func TestCmdDoSpawnsClaudeNotFlowde(t *testing.T) {
 	}
 	if strings.Contains(script, "flowde") {
 		t.Errorf("resume spawn should not invoke flowde, got:\n%s", script)
+	}
+}
+
+func TestCmdDoCodexFreshAndResumeUseHarness(t *testing.T) {
+	setupFlowRoot(t)
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "")
+	t.Setenv("CODEX_THREAD_ID", "ambient-codex-session")
+	seedTask(t, "codex-task")
+	_, getScript := stubITerm(t)
+
+	oldRunner := codex.ExecRunner
+	codex.ExecRunner = func(args []string) ([]byte, error) {
+		return []byte(`{"session_id":"codex-task-sid"}`), nil
+	}
+	t.Cleanup(func() { codex.ExecRunner = oldRunner })
+
+	if rc := cmdDo([]string{"codex-task"}); rc != 0 {
+		t.Fatalf("codex fresh rc=%d", rc)
+	}
+	script := getScript()
+	if !strings.Contains(script, " codex resume codex-task-sid ") || strings.Contains(script, "--session-id") {
+		t.Fatalf("fresh codex spawn should resume the preallocated Codex session, got:\n%s", script)
+	}
+	db := openFlowDB(t)
+	task, err := flowdb.GetTask(db, "codex-task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !task.SessionID.Valid || task.SessionID.String != "codex-task-sid" {
+		t.Fatalf("codex fresh session_id = %+v, want codex-task-sid", task.SessionID)
+	}
+	if !task.Harness.Valid || task.Harness.String != "codex" {
+		t.Fatalf("codex fresh harness = %+v, want codex", task.Harness)
+	}
+
+	if rc := cmdDo([]string{"codex-task"}); rc != 0 {
+		t.Fatalf("codex resume rc=%d", rc)
+	}
+	script = getScript()
+	if !strings.Contains(script, " codex resume codex-task-sid") {
+		t.Fatalf("codex resume should run codex resume, got:\n%s", script)
 	}
 }
 

--- a/internal/app/done.go
+++ b/internal/app/done.go
@@ -7,7 +7,7 @@ import (
 )
 
 // cmdDone marks a task done. Per spec §5.3 this is a single UPDATE that
-// does NOT touch the iTerm tab, kill the Claude session, or clear
+// does NOT touch the terminal tab, kill the harness session, or clear
 // session_id — the session can still be resumed via `flow do` after
 // manually reopening the task if the user ever needs to.
 //
@@ -61,7 +61,7 @@ func cmdDone(args []string) int {
 		fmt.Fprintf(os.Stderr,
 			"error: task %q has no session_id — flow done requires at least one prior `flow do` (or `flow do --here`) to have attached a session whose transcript the sweep can read.\n"+
 				"  options:\n"+
-				"    - if you've been working on this task in the current Claude session, bind it now and retry close-out:\n"+
+				"    - if you've been working on this task in the current harness session, bind it now and retry close-out:\n"+
 				"        flow do --here %s   (then re-run: flow done %s)\n"+
 				"    - if it was never worked on and isn't relevant, archive it instead:\n"+
 				"        flow archive %s\n",
@@ -148,7 +148,7 @@ func buildCloseoutSweepPrompt(slug, projectSlug string) string {
 			"## Steps\n\n"+
 			"1. Invoke the flow skill via the Skill tool. This loads §4.10 (KB rules) and §4.5 (update-file shape).\n\n"+
 			"2. Run: flow transcript %s\n"+
-			"   This prints the conversation transcript from the task's Claude session. Read it carefully end to end.\n\n"+
+			"   This prints the conversation transcript from the task's harness session. Read it carefully end to end.\n\n"+
 			"3. KB sweep — strict bar, distill the essence.\n\n"+
 			"   For each of these five files, ask: across the WHOLE transcript, is there a durable fact about the user, their org, products, processes, or business that belongs there per §4.10's bucket table AND meets ALL three bars below?\n"+
 			"     - %s/kb/user.md\n"+
@@ -159,7 +159,7 @@ func buildCloseoutSweepPrompt(slug, projectSlug string) string {
 			"   The three bars (ALL must be met):\n"+
 			"     a. **Durable** — still true / still relevant in three months. Not 'today I felt X', not 'we tried approach Y for this one PR'.\n"+
 			"     b. **Surprising or non-obvious** — not derivable from the code, the README, or what a sibling task would already know.\n"+
-			"     c. **Future-relevant** — a future Claude session would change a decision because of it. If you can't picture that, skip.\n\n"+
+			"     c. **Future-relevant** — a future agent session would change a decision because of it. If you can't picture that, skip.\n\n"+
 			"   Most task transcripts contribute nothing to the KB. Mechanical work, narrow bug fixes, local refactors, routine debugging — these almost never produce KB entries. The expected answer for most files on most tasks is 'no'. Don't reach.\n\n"+
 			"4. Writing KB entries — INTERPRET the essence; do not transcribe.\n\n"+
 			"   This is the close-out mode of §4.10 and is DIFFERENT from real-time scoop. In real-time scoop you capture what the user just said, mostly verbatim, because it's a single fresh fact. Here you've read the whole conversation — your job is to SYNTHESIZE: pull out the durable insight in compact paraphrase, in your own words, capturing the essence and (where helpful) the why. Avoid quote dumps. One concise dated bullet per insight.\n\n"+

--- a/internal/app/e2e_test.go
+++ b/internal/app/e2e_test.go
@@ -3,12 +3,17 @@ package app
 import (
 	"flow/internal/flowdb"
 	"flow/internal/harness/claude"
+	"flow/internal/harness/codex"
 	"flow/internal/iterm"
 	"flow/internal/spawner"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+const sampleCodexSessionJSONL = `{"timestamp":"2026-05-25T10:00:00Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"start codex task"}]}}
+{"timestamp":"2026-05-25T10:00:01Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}
+`
 
 // TestE2EFullRoundtrip exercises the full command surface in the order a
 // user would hit it for a realistic session: init, add project, add task
@@ -24,6 +29,9 @@ func TestE2EFullRoundtrip(t *testing.T) {
 	flowRoot := filepath.Join(tmp, "flow")
 	t.Setenv("FLOW_ROOT", flowRoot)
 	t.Setenv("HOME", tmp)
+	for _, h := range allHarnesses() {
+		t.Setenv(h.SessionIDEnvVar(), "")
+	}
 
 	// Fake repo that serves as the project's work_dir.
 	repo := filepath.Join(tmp, "code", "budgeting-app")
@@ -237,5 +245,66 @@ func TestE2EFullRoundtrip(t *testing.T) {
 	}
 	if wd == nil {
 		t.Fatal("GetWorkdir returned nil for auto-registered path")
+	}
+}
+
+func TestE2ECodexRoundtrip(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FLOW_ROOT", filepath.Join(tmp, "flow"))
+	t.Setenv("HOME", tmp)
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "")
+	t.Setenv("CODEX_THREAD_ID", "ambient-codex-session")
+
+	repo := filepath.Join(tmp, "code", "codex-app")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldOsa := iterm.Runner
+	iterm.Runner = func(args []string) error { return nil }
+	t.Cleanup(func() { iterm.Runner = oldOsa })
+	oldCodexExec := codex.ExecRunner
+	codex.ExecRunner = func(args []string) ([]byte, error) {
+		return []byte(`{"session_id":"codex-rt-sid"}`), nil
+	}
+	t.Cleanup(func() { codex.ExecRunner = oldCodexExec })
+	oldCodexSkip := codex.SkipPermissionsRunner
+	codex.SkipPermissionsRunner = func(prompt string) error { return nil }
+	t.Cleanup(func() { codex.SkipPermissionsRunner = oldCodexSkip })
+
+	step := func(name string, rc int) {
+		t.Helper()
+		if rc != 0 {
+			t.Fatalf("%s: rc=%d", name, rc)
+		}
+	}
+	step("init", cmdInit(nil))
+	step("add", cmdAdd([]string{"task", "Codex roundtrip", "--slug", "codex-rt", "--work-dir", repo}))
+	step("do fresh", cmdDo([]string{"codex-rt"}))
+
+	transcriptDir := filepath.Join(tmp, ".codex", "sessions")
+	if err := os.MkdirAll(transcriptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	transcriptPath := filepath.Join(transcriptDir, "codex-rt-sid.jsonl")
+	if err := os.WriteFile(transcriptPath, []byte(sampleCodexSessionJSONL), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	step("transcript", cmdTranscript([]string{"codex-rt"}))
+	step("do resume", cmdDo([]string{"codex-rt"}))
+	step("done", cmdDone([]string{"codex-rt"}))
+
+	db := openFlowDB(t)
+	task, err := flowdb.GetTask(db, "codex-rt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.Status != "done" {
+		t.Fatalf("status = %q, want done", task.Status)
+	}
+	if !task.Harness.Valid || task.Harness.String != "codex" {
+		t.Fatalf("harness = %+v, want codex", task.Harness)
+	}
+	if !task.SessionID.Valid || task.SessionID.String != "codex-rt-sid" {
+		t.Fatalf("session = %+v, want codex-rt-sid", task.SessionID)
 	}
 }

--- a/internal/app/harness.go
+++ b/internal/app/harness.go
@@ -8,6 +8,7 @@ import (
 	"flow/internal/flowdb"
 	"flow/internal/harness"
 	"flow/internal/harness/claude"
+	"flow/internal/harness/codex"
 )
 
 // allHarnesses returns every implemented harness adapter. The slice
@@ -16,7 +17,7 @@ import (
 func allHarnesses() []harness.Harness {
 	return []harness.Harness{
 		claude.New(),
-		// codex.New(),    // wired when the codex adapter lands
+		codex.New(),
 		// gemini.New(),   // wired when the gemini adapter lands
 	}
 }

--- a/internal/app/harness_test.go
+++ b/internal/app/harness_test.go
@@ -7,7 +7,6 @@ import (
 
 	"flow/internal/flowdb"
 	"flow/internal/harness"
-	"flow/internal/harness/claude"
 )
 
 // TestAmbientHarness covers the env-var probe: returns the matching
@@ -30,6 +29,21 @@ func TestAmbientHarness(t *testing.T) {
 	if got.Name() != harness.NameClaude {
 		t.Errorf("ambientHarness = %v, want claude", got.Name())
 	}
+
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "")
+	t.Setenv("CODEX_THREAD_ID", "codex-session")
+	got = ambientHarness()
+	if got == nil {
+		t.Fatal("ambientHarness with $CODEX_THREAD_ID set = nil, want codex")
+	}
+	if got.Name() != harness.NameCodex {
+		t.Errorf("ambientHarness = %v, want codex", got.Name())
+	}
+
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "658bf2be-5ae3-4842-a8a4-e0d0b785514d")
+	if got := ambientHarness(); got != nil {
+		t.Errorf("ambientHarness with multiple envs = %v, want nil", got.Name())
+	}
 }
 
 // TestHarnessForTask covers the column → adapter lookup. NULL and
@@ -46,6 +60,7 @@ func TestHarnessForTask(t *testing.T) {
 		{"null column → claude", sql.NullString{}, harness.NameClaude, false},
 		{"empty string → claude", sql.NullString{Valid: true, String: ""}, harness.NameClaude, false},
 		{"claude pin", sql.NullString{Valid: true, String: "claude"}, harness.NameClaude, false},
+		{"codex pin", sql.NullString{Valid: true, String: "codex"}, harness.NameCodex, false},
 		{"unknown name → error", sql.NullString{Valid: true, String: "future"}, "", true},
 	}
 	for _, tc := range cases {
@@ -124,7 +139,7 @@ func TestCmdDoRefusesUnsupportedHarnessPin(t *testing.T) {
 
 	// Simulate a future build having pinned the task.
 	db := openFlowDB(t)
-	if _, err := db.Exec(`UPDATE tasks SET harness='codex' WHERE slug='future-pin'`); err != nil {
+	if _, err := db.Exec(`UPDATE tasks SET harness='future' WHERE slug='future-pin'`); err != nil {
 		t.Fatal(err)
 	}
 	db.Close()
@@ -135,7 +150,7 @@ func TestCmdDoRefusesUnsupportedHarnessPin(t *testing.T) {
 		t.Fatalf("cmdDo rc=%d, want non-zero (unsupported pin should refuse)", rc)
 	}
 	got := stderr()
-	if !strings.Contains(got, "codex") || !strings.Contains(got, "isn't supported") {
+	if !strings.Contains(got, "future") || !strings.Contains(got, "isn't supported") {
 		t.Errorf("stderr should name the unsupported harness; got:\n%s", got)
 	}
 
@@ -144,8 +159,8 @@ func TestCmdDoRefusesUnsupportedHarnessPin(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if task.Harness.String != "codex" {
-		t.Errorf("refusal should preserve the pin; got %q, want codex",
+	if task.Harness.String != "future" {
+		t.Errorf("refusal should preserve the pin; got %q, want future",
 			task.Harness.String)
 	}
 	if task.SessionID.Valid {
@@ -195,8 +210,7 @@ func TestCmdDoHereRejectsCrossHarness(t *testing.T) {
 	setupFlowRoot(t)
 	seedTask(t, "pinned-elsewhere")
 
-	// Pin the task to a fictional "codex" harness by writing
-	// directly to the column.
+	// Pin the task to codex by writing directly to the column.
 	db := openFlowDB(t)
 	if _, err := db.Exec(`UPDATE tasks SET harness='codex' WHERE slug='pinned-elsewhere'`); err != nil {
 		t.Fatal(err)
@@ -272,19 +286,7 @@ func TestCmdDoHereForceSwitchesHarness(t *testing.T) {
 	}
 }
 
-// TestHarnessForSpawn_AllPathsLandOnClaudeToday smoke-tests every
-// branch of harnessForSpawn under the single-harness registry
-// (claude is the only adapter today). Each of the three branches
-// — null pin + no ambient, null pin + claude ambient, claude pin —
-// lands on claude, which is the only assertion the test can make
-// without a second registered adapter.
-//
-// The actual *precedence* properties (pinned > ambient > default)
-// can't be exercised here: when ambient is claude and pin is empty,
-// "matches ambient" and "fell through to default" are
-// indistinguishable. Add real coverage once codex/gemini registers
-// and a non-claude ambient is possible.
-func TestHarnessForSpawn_AllPathsLandOnClaudeToday(t *testing.T) {
+func TestHarnessForSpawnPrecedence(t *testing.T) {
 	for _, h := range allHarnesses() {
 		t.Setenv(h.SessionIDEnvVar(), "")
 	}
@@ -312,16 +314,20 @@ func TestHarnessForSpawn_AllPathsLandOnClaudeToday(t *testing.T) {
 		t.Errorf("ambient claude + null pin = %v, want claude", got)
 	}
 
-	// Branch 3: claude pin → claude. Doesn't prove pinned is
-	// *preferred over* ambient (same as above).
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "")
+	t.Setenv("CODEX_THREAD_ID", "codex-session")
+	if got := mustResolve(t, task).Name(); got != harness.NameCodex {
+		t.Errorf("ambient codex + null pin = %v, want codex", got)
+	}
+
+	// Pinned harness wins over ambient.
 	task.Harness = sql.NullString{Valid: true, String: "claude"}
 	if got := mustResolve(t, task).Name(); got != harness.NameClaude {
-		t.Errorf("pinned claude = %v, want claude", got)
+		t.Errorf("pinned claude + ambient codex = %v, want claude", got)
 	}
 
 	// Sanity: returned value satisfies harness.Harness.
 	if _, ok := mustResolve(t, task).(harness.Harness); !ok {
 		t.Error("harnessForSpawn return doesn't satisfy harness.Harness")
 	}
-	_ = claude.New() // import-keep
 }

--- a/internal/app/hook.go
+++ b/internal/app/hook.go
@@ -9,11 +9,9 @@ import (
 
 // cmdHook dispatches `flow hook <subcommand>`. Two subcommands:
 //
-//   - session-start: wired as a Claude Code SessionStart hook so that
+//   - session-start: wired as a harness SessionStart hook so that
 //     every session start (fresh spawn AND resume) re-injects the
-//     "load your task context" instruction. Without it, resumed
-//     sessions never re-read briefs and updates that may have been
-//     edited since the previous session.
+//     "load your task context" instruction.
 //
 //   - user-prompt-submit: kept as a permanent no-op for forward
 //     compatibility with stale settings.json entries.

--- a/internal/app/init_test.go
+++ b/internal/app/init_test.go
@@ -19,11 +19,21 @@ func initTempFlowRoot(t *testing.T) string {
 
 	oldRoot := os.Getenv("FLOW_ROOT")
 	oldHome := os.Getenv("HOME")
+	oldHarnessEnv := map[string]string{}
+	for _, h := range allHarnesses() {
+		oldHarnessEnv[h.SessionIDEnvVar()] = os.Getenv(h.SessionIDEnvVar())
+	}
 	os.Setenv("FLOW_ROOT", root)
 	os.Setenv("HOME", home)
+	for _, h := range allHarnesses() {
+		os.Setenv(h.SessionIDEnvVar(), "")
+	}
 	t.Cleanup(func() {
 		os.Setenv("FLOW_ROOT", oldRoot)
 		os.Setenv("HOME", oldHome)
+		for k, v := range oldHarnessEnv {
+			os.Setenv(k, v)
+		}
 	})
 	return root
 }

--- a/internal/app/show_test.go
+++ b/internal/app/show_test.go
@@ -23,6 +23,9 @@ func withTempFlowRoot(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	t.Setenv("FLOW_ROOT", dir)
+	for _, h := range allHarnesses() {
+		t.Setenv(h.SessionIDEnvVar(), "")
+	}
 	return dir
 }
 

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -1,24 +1,12 @@
 ---
 name: flow
 description: |
-  Personal task and Claude session manager. CLI binary is `flow` (assumed
-  on PATH) and stores metadata in ~/.flow/flow.db (SQLite). Use this skill when the
-  user asks about their work, tasks, or projects in any natural phrasing —
-  including but not limited to: "what's left", "what's remaining",
-  "what's pending", "what do I need to do", "what's on my plate",
-  "what should I work on", "status", "give me a status", "anything
-  urgent", "what's overdue", "what's stale", "show me my work",
-  "how's my week looking", "what did I ship", "what's in progress",
-  "what's next", "what am I working on", "where did I leave off",
-  "start my day", "what should I do", "what should I do today".
-  Also use for task/project management actions: "flow", "add a task",
-  "add a project", "resume work", "pick up where I left off", "save a
-  note", "log progress", "write an update", "note that", "I'm waiting
-  on", "blocked on", "stuck until", "mark done", "archive", "weekly
-  review", "clean up my tasks", or when the user invokes any
-  `flow <subcommand>` directly. Also use whenever the user asks you to
-  bootstrap a new Claude session on a task or tell them about their
-  in-flight work.
+  Personal task and Claude/Codex execution-session manager. Use when the user asks
+  about work, tasks, projects, status, priorities, stale/overdue items, what to do
+  next, or where they left off. Also use for flow actions: add task/project,
+  resume/open work, save a note, log progress, write an update, set waiting/blocker,
+  mark done, archive, weekly review/playbook runs, clean up tasks, direct
+  `flow <subcommand>` requests, or bootstrapping a Claude/Codex task session.
 ---
 
 # flow — task and session manager skill
@@ -26,16 +14,16 @@ description: |
 ## 1. What flow is
 
 `flow` is a small CLI (assumed on `$PATH`) that the user uses to track
-personal work and bootstrap per-task Claude sessions. Metadata (projects,
-tasks, workdirs, session IDs) lives in a single SQLite database at
+personal work and bootstrap per-task Claude or Codex execution sessions.
+Metadata (projects, tasks, workdirs, harness names, and session IDs) lives in a single SQLite database at
 `~/.flow/flow.db`. Free-form plan content lives on disk as markdown
 "briefs" at `~/.flow/projects/<slug>/brief.md` and
 `~/.flow/tasks/<slug>/brief.md`. Progress notes accumulate as dated
 markdown files under each entity's `updates/` subdirectory. The user runs
-one long-lived Claude session per task in its own terminal tab, resumed via
-`flow do <task>`.
+one long-lived execution session per task in its own terminal tab,
+resumed via `flow do <task>`.
 
-You are speaking inside one of those Claude sessions (or the user's
+You are speaking inside one of those execution sessions (or the user's
 ambient "dispatch" session). Your job is to interpret the user's natural
 language requests and turn them into the exact `flow` commands and file
 edits they imply. You never edit `flow.db` directly. You never solve
@@ -63,7 +51,7 @@ first; let them choose what happens next.
 
 1. In 2–3 sentences, describe what you can do for the user with
    flow under the hood — capture work as briefs, log progress
-   notes, resume Claude sessions across days, track what they're
+   notes, resume Claude or Codex sessions across days, track what they're
    waiting on. Frame it as your capabilities, not commands. The
    user does not need to learn flow's CLI.
 2. Use `AskUserQuestion` (header: "What now?") to offer the main
@@ -92,8 +80,9 @@ an intent, follow the matching recipe instead of re-asking via §1a.
   `~/.flow/tasks/<slug>/workspace/` for floating tasks), a priority, a
   status (`backlog`, `in-progress`, `done`), an optional `project_slug`,
   an optional `waiting_on` freeform note, and a `brief.md`. Tasks also
-  carry a Claude `session_id` once `flow do` has bootstrapped a session
-  for them.
+  carry a harness-owned execution session once `flow do` has bootstrapped
+  them. flow stores which harness owns the task so future resumes use the
+  same agent CLI.
 - **Playbooks** are reusable, runnable definitions. A playbook has a
   name, slug, work_dir, optional `project_slug`, and a `brief.md` that
   describes what each invocation should do. Each invocation creates a
@@ -148,7 +137,7 @@ basics in this order:
    `AskUserQuestion` (header: "Open it now?", options:
    "Open it now" / "Later, just save") to ask whether to run
    `flow do <slug>`. Briefly explain in the question: a dedicated
-   Claude session gets the brief, updates, and repo conventions
+   execution session gets the brief, updates, and repo conventions
    automatically. If "Open it now", proceed to §4.4. If "Later",
    stop here.
 
@@ -187,17 +176,17 @@ Create
 Sessions
   flow do               <ref> [--fresh] [--dangerously-skip-permissions] [--force]
                               [--with "<instruction>" | --with-file <path>]
-  flow do --here        <ref> [--force]   (bind THIS Claude session to the task — no new tab)
+  flow do --here        <ref> [--force]   (bind THIS harness session to the task — no new tab)
   flow done             <ref>
 
 Playbook runs
   flow run playbook <slug> [--with "<instr>" | --with-file <path>]
                                     spawn a fresh run session (new task with kind=playbook_run)
-  flow run playbook <slug> --here   bind THIS Claude session to the new run (no new tab)
+  flow run playbook <slug> --here   bind THIS harness session to the new run (no new tab)
   flow list runs [<playbook-slug>]  list playbook runs (filter by playbook optional)
 
 Read
-  flow show task    [<ref>]     (no arg → reverse-lookup via $CLAUDE_CODE_SESSION_ID)
+  flow show task    [<ref>]     (no arg → reverse-lookup via current harness session id)
   flow show project [<ref>]     (no arg → project of the bound task)
   flow show playbook    [<ref>]
   flow transcript   [<ref>] [--compact]    (readable transcript from session jsonl)
@@ -560,7 +549,7 @@ its own, it's the start of a two-or-more-step workflow.
        question: "Which session mode for <task-slug>?",
        header: "Session mode",
        options: [
-         { label: "Regular",          description: "Normal Claude session with tool-approval prompts (safer)" },
+         { label: "Regular",          description: "Normal execution session with tool-approval prompts (safer)" },
          { label: "Skip permissions", description: "Pass --dangerously-skip-permissions (faster, no prompts)" }
        ],
        multiSelect: false
@@ -595,7 +584,7 @@ not attempt workarounds; the user will decide what to do next.
 
 #### Special case: live-session guard
 
-`flow do` refuses to spawn when the task's `session_id` is already
+For Claude, `flow do` refuses to spawn when the task's Claude session is already
 running in another Claude process — typically because the user has the
 task's tab open elsewhere and forgot. The error names the running
 session ID and points at `--force`. When you see it:
@@ -1416,8 +1405,8 @@ via `AskUserQuestion`.
    one (typically at `/usr/local/bin/flow`; confirm with
    `which flow` if unsure).
 4. Run `flow skill update` to refresh the embedded skill on disk and
-   re-wire both the SessionStart and UserPromptSubmit hooks in
-   `~/.claude/settings.json`. (The auto-upgrade path runs the same
+   re-wire the SessionStart hooks for Claude and Codex. Stale
+   UserPromptSubmit hooks are removed. (The auto-upgrade path runs the same
    refresh on the next `flow` invocation, but explicit is better and
    surfaces any errors immediately.)
 5. Run `flow --version` again and confirm the version changed. If it
@@ -1877,16 +1866,24 @@ instead.
 
 ## 9. The execution-session bootstrap contract
 
-When `flow do <task>` spawns a Claude session in a new terminal tab, it
-pre-allocates a UUID, writes it to `tasks.session_id` before spawning,
-and passes it to `claude --session-id <uuid>`. This makes the session's
-jsonl file appear at the deterministic path
-`~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`. There is no
-self-registration step — the DB is authoritative from the moment the
-tab opens.
+When `flow do <task>` spawns an execution session in a new terminal tab,
+it auto-detects the current harness from the invoking environment. Claude
+remains the fallback/default when no known harness session env var is set.
 
-Subsequent `flow do <same-task>` calls read that UUID and spawn
-`claude --resume <uuid>` to continue the same conversation.
+Claude behavior is deterministic: flow pre-allocates a UUID, stores it
+as the task's session, records `tasks.harness = "claude"`, and passes it
+to `claude --session-id <uuid>`. Resumes use `claude --resume <uuid>`.
+
+Codex behavior also gives flow a real session ID before spawning: flow
+runs a short `codex exec --json` probe, scrapes the reported session id,
+records `tasks.harness = "codex"`, then launches the interactive tab with
+`codex resume <session-id> <bootstrap-prompt>`. Resumes use
+`codex resume <session-id>`.
+
+`--fresh` replaces the task's stored session for its pinned harness. A
+task pinned to one harness does not silently switch just because `flow do`
+is invoked from another harness; use `flow do --here --force <task>` when
+you deliberately want to rebind it.
 
 **If you are the execution session spawned by `flow do`:**
 
@@ -1990,11 +1987,11 @@ yours), use:
 flow transcript <sibling-task-slug>
 ```
 
-This outputs a readable conversation transcript from that task's Claude
-session — user messages, assistant messages, tool calls, and results.
-Use `--compact` to omit tool results and thinking blocks for a shorter
-overview. Pipe through `grep` or `head` if the full transcript is too
-long to read at once.
+This outputs a readable conversation transcript from that task's stored
+harness session — user messages, assistant messages, tool calls, and
+results. Use `--compact` to omit tool results and thinking blocks for a
+shorter overview. Pipe through `grep` or `head` if the full transcript is
+too long to read at once.
 
 **When to use:** When the brief and updates for a sibling task don't
 give you enough context, or when you need to understand specific

--- a/internal/app/skill_test.go
+++ b/internal/app/skill_test.go
@@ -58,13 +58,42 @@ func expectedCommand(event string) string {
 	return ""
 }
 
+func TestEmbeddedSkillDescriptionFitsCodexLimit(t *testing.T) {
+	text := string(embeddedSkill)
+	start := strings.Index(text, "description: |")
+	if start < 0 {
+		t.Fatal("skill frontmatter missing description")
+	}
+	start = strings.Index(text[start:], "\n") + start + 1
+	end := strings.Index(text[start:], "---")
+	if end < 0 {
+		t.Fatal("skill frontmatter not closed")
+	}
+	desc := strings.TrimSpace(text[start : start+end])
+	if len(desc) > 1024 {
+		t.Fatalf("skill description is %d bytes; Codex requires <= 1024", len(desc))
+	}
+}
+
 // withTempHome redirects $HOME to a tempdir for the duration of the test.
 func withTempHome(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	oldHome := os.Getenv("HOME")
+	oldHarnessEnv := map[string]string{}
+	for _, h := range allHarnesses() {
+		oldHarnessEnv[h.SessionIDEnvVar()] = os.Getenv(h.SessionIDEnvVar())
+	}
 	os.Setenv("HOME", dir)
-	t.Cleanup(func() { os.Setenv("HOME", oldHome) })
+	for _, h := range allHarnesses() {
+		os.Setenv(h.SessionIDEnvVar(), "")
+	}
+	t.Cleanup(func() {
+		os.Setenv("HOME", oldHome)
+		for k, v := range oldHarnessEnv {
+			os.Setenv(k, v)
+		}
+	})
 	return dir
 }
 

--- a/internal/harness/codex/codex.go
+++ b/internal/harness/codex/codex.go
@@ -1,0 +1,424 @@
+// Package codex implements harness.Harness for OpenAI Codex CLI.
+//
+// Codex owns its session identifiers: flow mints one by running a
+// short non-interactive `codex exec --json` probe, stores the reported
+// id on the task, then starts the interactive tab by resuming that id.
+package codex
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"flow/internal/harness"
+	"flow/internal/spawner"
+)
+
+var (
+	ExecRunner            = runCodexExec
+	SkipPermissionsRunner = runSkipPermissions
+	PSRunner              = runPS
+)
+
+const hookMatcher = "startup|resume"
+
+func New() harness.Harness {
+	return &codex{}
+}
+
+type codex struct{}
+
+func (c *codex) Name() harness.Name      { return harness.NameCodex }
+func (c *codex) Binary() string          { return "codex" }
+func (c *codex) SessionIDEnvVar() string { return "CODEX_THREAD_ID" }
+
+var sessionIDRe = regexp.MustCompile(`^[A-Za-z0-9._:-]{3,256}$`)
+
+func (c *codex) NewSessionID() (string, error) {
+	out, err := ExecRunner([]string{
+		"exec",
+		"--json",
+		"--dangerously-bypass-approvals-and-sandbox",
+		"Reply with exactly: ready",
+	})
+	if err != nil {
+		return "", fmt.Errorf("codex exec: %w", err)
+	}
+	id, err := ParseSessionID(out)
+	if err != nil {
+		return "", err
+	}
+	return id, c.ValidateSessionID(id)
+}
+
+func (c *codex) ValidateSessionID(s string) error {
+	if !sessionIDRe.MatchString(s) || strings.ContainsAny(s, " \t\r\n") {
+		return fmt.Errorf("not a valid codex session id: %q", s)
+	}
+	return nil
+}
+
+func (c *codex) ValidateSession(workDir, sessionID string) error {
+	return nil
+}
+
+func (c *codex) LaunchCmd(sessionID, prompt string, opts harness.LaunchOpts) string {
+	if opts.Inject != "" {
+		prompt = prompt + "\n\n" + harness.InjectionMarker + "\n" + opts.Inject
+	}
+	return codexResumeCmd(sessionID, prompt, opts.SkipPermissions)
+}
+
+func (c *codex) ResumeCmd(sessionID string, opts harness.LaunchOpts) string {
+	prompt := ""
+	if opts.Inject != "" {
+		prompt = harness.InjectionMarker + "\n" + opts.Inject
+	}
+	return codexResumeCmd(sessionID, prompt, opts.SkipPermissions)
+}
+
+func codexResumeCmd(sessionID, prompt string, skipPermissions bool) string {
+	cmd := "codex resume"
+	if skipPermissions {
+		cmd += " --dangerously-bypass-approvals-and-sandbox"
+	}
+	cmd += " " + sessionID
+	if prompt != "" {
+		cmd += " " + spawner.ShellQuote(prompt)
+	}
+	return cmd
+}
+
+func (c *codex) SkipPermissionsRun(prompt string) error {
+	return SkipPermissionsRunner(prompt)
+}
+
+func runCodexExec(args []string) ([]byte, error) {
+	return exec.Command("codex", args...).CombinedOutput()
+}
+
+func runSkipPermissions(prompt string) error {
+	cmd := exec.Command("codex", "exec", "--dangerously-bypass-approvals-and-sandbox", prompt)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	return cmd.Run()
+}
+
+func (c *codex) LiveSessionIDs() (map[string]int, error) {
+	out, err := PSRunner()
+	if err != nil {
+		return nil, fmt.Errorf("ps: %w", err)
+	}
+	live := map[string]int{}
+	for _, line := range strings.Split(string(out), "\n") {
+		if !strings.Contains(line, "resume") {
+			continue
+		}
+		fields := strings.Fields(line)
+		codexIndex := -1
+		for i, f := range fields {
+			if filepath.Base(f) == "codex" {
+				codexIndex = i
+				break
+			}
+		}
+		if codexIndex < 0 {
+			continue
+		}
+		for i, f := range fields[codexIndex+1:] {
+			if f != "resume" {
+				continue
+			}
+			for _, candidate := range fields[codexIndex+1+i+1:] {
+				if strings.HasPrefix(candidate, "-") {
+					continue
+				}
+				if sessionIDRe.MatchString(candidate) {
+					live[strings.ToLower(candidate)]++
+				}
+				break
+			}
+		}
+	}
+	return live, nil
+}
+
+func runPS() ([]byte, error) {
+	return exec.Command("ps", "-axo", "pid,command").Output()
+}
+
+func (c *codex) SkillInstallPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("no home dir: %w", err)
+	}
+	return filepath.Join(home, ".codex", "skills", "flow", "SKILL.md"), nil
+}
+
+func (c *codex) SkillVersionPath() (string, error) {
+	skill, err := c.SkillInstallPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(filepath.Dir(skill), "VERSION"), nil
+}
+
+func (c *codex) InstallSkill(content []byte) error {
+	p, err := c.SkillInstallPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", filepath.Dir(p), err)
+	}
+	if err := os.WriteFile(p, content, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", p, err)
+	}
+	return nil
+}
+
+func (c *codex) UninstallSkill() error {
+	p, err := c.SkillInstallPath()
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(p)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return nil
+	}
+	return os.RemoveAll(dir)
+}
+
+func configPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("no home dir: %w", err)
+	}
+	return filepath.Join(home, ".codex", "config.toml"), nil
+}
+
+func hooksPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("no home dir: %w", err)
+	}
+	return filepath.Join(home, ".codex", "hooks.json"), nil
+}
+
+func (c *codex) InstallSessionStartHook(command string) (bool, error) {
+	configChanged, err := ensureHooksFeature()
+	if err != nil {
+		return false, err
+	}
+	hookChanged, err := installHook("SessionStart", hookMatcher, command)
+	return configChanged || hookChanged, err
+}
+
+func (c *codex) UninstallSessionStartHook(command string) (bool, error) {
+	return uninstallHook("SessionStart", command)
+}
+
+func (c *codex) UninstallUserPromptSubmitHook(command string) (bool, error) {
+	return uninstallHook("UserPromptSubmit", command)
+}
+
+func ensureHooksFeature() (bool, error) {
+	path, err := configPath()
+	if err != nil {
+		return false, err
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, fmt.Errorf("read %s: %w", path, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return false, fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+		}
+		raw = nil
+	}
+	text := string(raw)
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		trim := strings.TrimSpace(line)
+		if strings.HasPrefix(trim, "codex_hooks") {
+			if strings.Contains(trim, "true") {
+				return false, nil
+			}
+			lines[i] = "codex_hooks = true"
+			return writeConfig(path, lines)
+		}
+	}
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "[features]" {
+			lines = append(lines[:i+1], append([]string{"codex_hooks = true"}, lines[i+1:]...)...)
+			return writeConfig(path, lines)
+		}
+	}
+	if strings.TrimSpace(text) != "" && !strings.HasSuffix(text, "\n") {
+		text += "\n"
+	}
+	text += "\n[features]\ncodex_hooks = true\n"
+	if err := os.WriteFile(path, []byte(text), 0o644); err != nil {
+		return false, fmt.Errorf("write %s: %w", path, err)
+	}
+	return true, nil
+}
+
+func writeConfig(path string, lines []string) (bool, error) {
+	out := strings.Join(lines, "\n")
+	if !strings.HasSuffix(out, "\n") {
+		out += "\n"
+	}
+	if err := os.WriteFile(path, []byte(out), 0o644); err != nil {
+		return false, fmt.Errorf("write %s: %w", path, err)
+	}
+	return true, nil
+}
+
+func installHook(event, matcher, command string) (bool, error) {
+	path, err := hooksPath()
+	if err != nil {
+		return false, err
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, fmt.Errorf("read %s: %w", path, err)
+		}
+		raw = []byte("{}")
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return false, fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+		}
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(raw, &settings); err != nil {
+		return false, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if settings == nil {
+		settings = map[string]any{}
+	}
+	hooks, _ := settings["hooks"].(map[string]any)
+	if hooks == nil {
+		hooks = map[string]any{}
+	}
+	entries, _ := hooks[event].([]any)
+	for _, entry := range entries {
+		m, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		inner, _ := m["hooks"].([]any)
+		for _, h := range inner {
+			hm, ok := h.(map[string]any)
+			if !ok {
+				continue
+			}
+			if cmd, _ := hm["command"].(string); cmd == command {
+				return false, nil
+			}
+		}
+	}
+	newEntry := map[string]any{
+		"hooks": []any{
+			map[string]any{
+				"type":    "command",
+				"command": command,
+			},
+		},
+	}
+	if matcher != "" {
+		newEntry["matcher"] = matcher
+	}
+	entries = append(entries, newEntry)
+	hooks[event] = entries
+	settings["hooks"] = hooks
+	return writeHookSettings(path, settings)
+}
+
+func uninstallHook(event, command string) (bool, error) {
+	path, err := hooksPath()
+	if err != nil {
+		return false, err
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(raw, &settings); err != nil {
+		return false, fmt.Errorf("parse %s: %w", path, err)
+	}
+	hooks, _ := settings["hooks"].(map[string]any)
+	if hooks == nil {
+		return false, nil
+	}
+	entries, _ := hooks[event].([]any)
+	if len(entries) == 0 {
+		return false, nil
+	}
+	changed := false
+	kept := make([]any, 0, len(entries))
+	for _, entry := range entries {
+		m, ok := entry.(map[string]any)
+		if !ok {
+			kept = append(kept, entry)
+			continue
+		}
+		inner, _ := m["hooks"].([]any)
+		filtered := make([]any, 0, len(inner))
+		for _, h := range inner {
+			hm, ok := h.(map[string]any)
+			if !ok {
+				filtered = append(filtered, h)
+				continue
+			}
+			cmd, _ := hm["command"].(string)
+			if strings.TrimSpace(cmd) == command {
+				changed = true
+				continue
+			}
+			filtered = append(filtered, h)
+		}
+		if len(filtered) == 0 {
+			changed = true
+			continue
+		}
+		m["hooks"] = filtered
+		kept = append(kept, m)
+	}
+	if !changed {
+		return false, nil
+	}
+	if len(kept) == 0 {
+		delete(hooks, event)
+	} else {
+		hooks[event] = kept
+	}
+	if len(hooks) == 0 {
+		delete(settings, "hooks")
+	} else {
+		settings["hooks"] = hooks
+	}
+	return writeHookSettings(path, settings)
+}
+
+func writeHookSettings(path string, settings map[string]any) (bool, error) {
+	out, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return false, fmt.Errorf("marshal settings: %w", err)
+	}
+	out = append(out, '\n')
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		return false, fmt.Errorf("write %s: %w", path, err)
+	}
+	return true, nil
+}

--- a/internal/harness/codex/codex_test.go
+++ b/internal/harness/codex/codex_test.go
@@ -1,0 +1,178 @@
+package codex
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"flow/internal/harness"
+)
+
+func TestParseSessionID(t *testing.T) {
+	cases := []struct {
+		name string
+		out  string
+		want string
+	}{
+		{
+			name: "json session id",
+			out:  `{"type":"session.started","session_id":"codex-sid-123"}`,
+			want: "codex-sid-123",
+		},
+		{
+			name: "nested thread id",
+			out:  `{"payload":{"thread_id":"abc:def.123"}}`,
+			want: "abc:def.123",
+		},
+		{
+			name: "codex session meta",
+			out:  `{"type":"session_meta","payload":{"id":"019cf7d0-edec-7b00-9268-ffb5d19c921b","cwd":"/tmp/repo"}}`,
+			want: "019cf7d0-edec-7b00-9268-ffb5d19c921b",
+		},
+		{
+			name: "labeled text",
+			out:  `created session id: 658bf2be-5ae3-4842-a8a4-e0d0b785514d`,
+			want: "658bf2be-5ae3-4842-a8a4-e0d0b785514d",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseSessionID([]byte(tc.out))
+			if err != nil {
+				t.Fatalf("ParseSessionID: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewSessionIDRunsCodexExecProbe(t *testing.T) {
+	old := ExecRunner
+	t.Cleanup(func() { ExecRunner = old })
+	var gotArgs []string
+	ExecRunner = func(args []string) ([]byte, error) {
+		gotArgs = append([]string(nil), args...)
+		return []byte(`{"session_id":"codex-probe-sid"}`), nil
+	}
+
+	id, err := New().NewSessionID()
+	if err != nil {
+		t.Fatalf("NewSessionID: %v", err)
+	}
+	if id != "codex-probe-sid" {
+		t.Fatalf("id = %q", id)
+	}
+	joined := strings.Join(gotArgs, " ")
+	for _, want := range []string{"exec", "--json", "--dangerously-bypass-approvals-and-sandbox"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("probe args %q missing %q", joined, want)
+		}
+	}
+}
+
+func TestLaunchAndResumeCmdUseCodexResume(t *testing.T) {
+	h := New()
+	got := h.LaunchCmd("sid-123", "do work", harness.LaunchOpts{})
+	if got != "codex resume sid-123 'do work'" {
+		t.Fatalf("LaunchCmd = %q", got)
+	}
+
+	got = h.LaunchCmd("sid-123", "do work", harness.LaunchOpts{SkipPermissions: true, Inject: "extra"})
+	if !strings.HasPrefix(got, "codex resume --dangerously-bypass-approvals-and-sandbox sid-123 ") {
+		t.Fatalf("LaunchCmd skip prefix = %q", got)
+	}
+	if !strings.Contains(got, harness.InjectionMarker+"\nextra") {
+		t.Fatalf("LaunchCmd missing injection marker: %q", got)
+	}
+
+	got = h.ResumeCmd("sid-123", harness.LaunchOpts{Inject: "follow up"})
+	want := "codex resume sid-123 '" + harness.InjectionMarker + "\nfollow up'"
+	if got != want {
+		t.Fatalf("ResumeCmd = %q, want %q", got, want)
+	}
+}
+
+func TestLiveSessionIDs(t *testing.T) {
+	old := PSRunner
+	t.Cleanup(func() { PSRunner = old })
+	PSRunner = func() ([]byte, error) {
+		return []byte(`  PID COMMAND
+1 codex resume codex-sid-1
+2 /usr/bin/codex resume --dangerously-bypass-approvals-and-sandbox codex-sid-1
+3 codex exec whatever
+4 other resume codex-sid-2
+`), nil
+	}
+	live, err := New().LiveSessionIDs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if live["codex-sid-1"] != 2 || len(live) != 1 {
+		t.Fatalf("live = %#v", live)
+	}
+}
+
+func TestLiveSessionIDsPSError(t *testing.T) {
+	old := PSRunner
+	t.Cleanup(func() { PSRunner = old })
+	PSRunner = func() ([]byte, error) { return nil, errors.New("ps failed") }
+	if _, err := New().LiveSessionIDs(); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSkillAndHookInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	h := New()
+
+	if err := h.InstallSkill([]byte("flow skill")); err != nil {
+		t.Fatalf("InstallSkill: %v", err)
+	}
+	skillPath := filepath.Join(home, ".codex", "skills", "flow", "SKILL.md")
+	if got, err := os.ReadFile(skillPath); err != nil || string(got) != "flow skill" {
+		t.Fatalf("skill = %q, err=%v", got, err)
+	}
+
+	added, err := h.InstallSessionStartHook("flow hook session-start")
+	if err != nil {
+		t.Fatalf("InstallSessionStartHook: %v", err)
+	}
+	if !added {
+		t.Fatal("first hook install should report added")
+	}
+	config, err := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(config), "codex_hooks = true") {
+		t.Fatalf("config missing codex_hooks=true:\n%s", config)
+	}
+	hooks, err := os.ReadFile(filepath.Join(home, ".codex", "hooks.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(hooks), "flow hook session-start") {
+		t.Fatalf("hooks missing command:\n%s", hooks)
+	}
+
+	added, err = h.InstallSessionStartHook("flow hook session-start")
+	if err != nil {
+		t.Fatalf("second InstallSessionStartHook: %v", err)
+	}
+	if added {
+		t.Fatal("second hook install should be idempotent")
+	}
+
+	removed, err := h.UninstallSessionStartHook("flow hook session-start")
+	if err != nil {
+		t.Fatalf("UninstallSessionStartHook: %v", err)
+	}
+	if !removed {
+		t.Fatal("uninstall should report removed")
+	}
+}

--- a/internal/harness/codex/session.go
+++ b/internal/harness/codex/session.go
@@ -1,0 +1,88 @@
+package codex
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var labeledSessionIDRe = regexp.MustCompile(`(?i)(?:session|thread)[ _-]?id["']?\s*[:=]\s*["']?([A-Za-z0-9._:-]{3,256})`)
+var uuidSessionIDRe = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+
+func ParseSessionID(out []byte) (string, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var v any
+		if err := json.Unmarshal(line, &v); err == nil {
+			if id := findSessionID(v); id != "" {
+				return id, nil
+			}
+		}
+		if id := parseSessionIDFromText(string(line)); id != "" {
+			return id, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("read codex exec output: %w", err)
+	}
+	if id := parseSessionIDFromText(string(out)); id != "" {
+		return id, nil
+	}
+	return "", fmt.Errorf("codex exec did not print a session id")
+}
+
+func findSessionID(v any) string {
+	switch x := v.(type) {
+	case map[string]any:
+		for _, key := range []string{"session_id", "sessionId", "thread_id", "threadId"} {
+			if s, ok := x[key].(string); ok && sessionIDRe.MatchString(s) {
+				return s
+			}
+		}
+		if typ, _ := x["type"].(string); typ == "session_meta" {
+			if payload, ok := x["payload"].(map[string]any); ok {
+				if s, ok := payload["id"].(string); ok && sessionIDRe.MatchString(s) {
+					return s
+				}
+			}
+		}
+		if _, hasCWD := x["cwd"]; hasCWD {
+			if s, ok := x["id"].(string); ok && sessionIDRe.MatchString(s) {
+				return s
+			}
+		}
+		for _, child := range x {
+			if id := findSessionID(child); id != "" {
+				return id
+			}
+		}
+	case []any:
+		for _, child := range x {
+			if id := findSessionID(child); id != "" {
+				return id
+			}
+		}
+	}
+	return ""
+}
+
+func parseSessionIDFromText(s string) string {
+	if m := labeledSessionIDRe.FindStringSubmatch(s); len(m) == 2 && sessionIDRe.MatchString(m[1]) {
+		return strings.Trim(m[1], `"'`)
+	}
+	if m := uuidSessionIDRe.FindString(s); m != "" {
+		return m
+	}
+	if fields := strings.Fields(strings.TrimSpace(s)); len(fields) == 1 && sessionIDRe.MatchString(fields[0]) {
+		return strings.Trim(fields[0], `"'`)
+	}
+	return ""
+}

--- a/internal/harness/codex/transcript.go
+++ b/internal/harness/codex/transcript.go
@@ -1,0 +1,197 @@
+package codex
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func (c *codex) RenderTranscript(cwd, sessionID string, compact bool, cutoff time.Time, w io.Writer) error {
+	p, err := FindTranscript(sessionID)
+	if err != nil {
+		return err
+	}
+	f, err := os.Open(p)
+	if err != nil {
+		return fmt.Errorf("open codex transcript %s: %w", p, err)
+	}
+	defer f.Close()
+	return RenderJSONL(f, compact, cutoff, w)
+}
+
+func FindTranscript(sessionID string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("no home dir: %w", err)
+	}
+	root := filepath.Join(home, ".codex", "sessions")
+	var found string
+	err = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || found != "" {
+			return nil
+		}
+		if strings.HasSuffix(path, ".jsonl") && strings.Contains(filepath.Base(path), sessionID) {
+			found = path
+		}
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("walk codex sessions: %w", err)
+	}
+	if found != "" {
+		return found, nil
+	}
+	return "", fmt.Errorf("codex transcript not found for session %s under %s", sessionID, root)
+}
+
+func RenderJSONL(r io.Reader, compact bool, cutoff time.Time, w io.Writer) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+
+	first := true
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var rec record
+		if err := json.Unmarshal(line, &rec); err != nil {
+			continue
+		}
+		if !cutoff.IsZero() {
+			if ts, ok := recTime(rec); ok && ts.Before(cutoff) {
+				continue
+			}
+		}
+		sections := renderRecord(rec, compact)
+		for _, s := range sections {
+			if s.body == "" {
+				continue
+			}
+			if !first {
+				fmt.Fprintln(w)
+			}
+			first = false
+			fmt.Fprintln(w, s.title)
+			fmt.Fprintln(w, s.body)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("read codex transcript: %w", err)
+	}
+	return nil
+}
+
+type record struct {
+	Type      string          `json:"type"`
+	Timestamp string          `json:"timestamp"`
+	Payload   json.RawMessage `json:"payload"`
+}
+
+type payload struct {
+	Type      string          `json:"type"`
+	Role      string          `json:"role"`
+	Content   []contentBlock  `json:"content"`
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+	Output    json.RawMessage `json:"output"`
+	Timestamp string          `json:"timestamp"`
+}
+
+type contentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type section struct {
+	title string
+	body  string
+}
+
+func recTime(rec record) (time.Time, bool) {
+	for _, raw := range []string{rec.Timestamp, payloadTimestamp(rec.Payload)} {
+		if raw == "" {
+			continue
+		}
+		if ts, err := time.Parse(time.RFC3339Nano, raw); err == nil {
+			return ts, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func payloadTimestamp(raw json.RawMessage) string {
+	var p payload
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return ""
+	}
+	return p.Timestamp
+}
+
+func renderRecord(rec record, compact bool) []section {
+	if rec.Type != "response_item" && rec.Payload == nil {
+		return nil
+	}
+	var p payload
+	if err := json.Unmarshal(rec.Payload, &p); err != nil {
+		return nil
+	}
+	switch p.Type {
+	case "message":
+		var out []section
+		for _, b := range p.Content {
+			if b.Text == "" {
+				continue
+			}
+			switch b.Type {
+			case "input_text":
+				out = append(out, section{"─── User ───", b.Text})
+			case "output_text":
+				out = append(out, section{"─── Assistant ───", b.Text})
+			case "thinking":
+				if !compact {
+					out = append(out, section{"─── Thinking ───", b.Text})
+				}
+			default:
+				if p.Role == "user" {
+					out = append(out, section{"─── User ───", b.Text})
+				} else if p.Role == "assistant" {
+					out = append(out, section{"─── Assistant ───", b.Text})
+				}
+			}
+		}
+		return out
+	case "function_call":
+		return []section{{fmt.Sprintf("─── Tool: %s ───", p.Name), compactJSON(p.Arguments)}}
+	case "function_call_output":
+		if compact {
+			return nil
+		}
+		return []section{{"─── Result ───", compactJSON(p.Output)}}
+	}
+	return nil
+}
+
+func compactJSON(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return string(raw)
+	}
+	out, err := json.Marshal(v)
+	if err != nil {
+		return string(raw)
+	}
+	return string(out)
+}

--- a/internal/harness/codex/transcript_test.go
+++ b/internal/harness/codex/transcript_test.go
@@ -1,0 +1,58 @@
+package codex
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+const sampleJSONL = `{"timestamp":"2026-05-25T10:00:00Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"please inspect"}]}}
+{"timestamp":"2026-05-25T10:00:01Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"thinking","text":"need readme"},{"type":"output_text","text":"I will inspect it."}]}}
+{"timestamp":"2026-05-25T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"Read","arguments":{"file_path":"README.md"}}}
+{"timestamp":"2026-05-25T10:00:03Z","type":"response_item","payload":{"type":"function_call_output","output":"readme contents"}}
+`
+
+func TestRenderJSONL(t *testing.T) {
+	var buf bytes.Buffer
+	if err := RenderJSONL(strings.NewReader(sampleJSONL), false, time.Time{}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	for _, want := range []string{"─── User ───", "please inspect", "─── Thinking ───", "need readme", "─── Tool: Read ───", `"file_path":"README.md"`, "─── Result ───", "readme contents"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("render missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderJSONLCompactOmitsThinkingAndResults(t *testing.T) {
+	var buf bytes.Buffer
+	if err := RenderJSONL(strings.NewReader(sampleJSONL), true, time.Time{}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	for _, notWant := range []string{"─── Thinking ───", "─── Result ───", "readme contents"} {
+		if strings.Contains(got, notWant) {
+			t.Fatalf("compact render should omit %q:\n%s", notWant, got)
+		}
+	}
+	if !strings.Contains(got, "─── Tool: Read ───") {
+		t.Fatalf("compact render should keep tool calls:\n%s", got)
+	}
+}
+
+func TestRenderJSONLCutoff(t *testing.T) {
+	var buf bytes.Buffer
+	cutoff := time.Date(2026, 5, 25, 10, 0, 2, 0, time.UTC)
+	if err := RenderJSONL(strings.NewReader(sampleJSONL), false, cutoff, &buf); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	if strings.Contains(got, "please inspect") || strings.Contains(got, "I will inspect it.") {
+		t.Fatalf("cutoff did not filter early messages:\n%s", got)
+	}
+	if !strings.Contains(got, "README.md") || !strings.Contains(got, "readme contents") {
+		t.Fatalf("cutoff removed later records:\n%s", got)
+	}
+}

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -34,6 +34,7 @@ type Name string
 
 const (
 	NameClaude Name = "claude"
+	NameCodex  Name = "codex"
 )
 
 // InjectionMarker prefixes any first-user-message text injected via


### PR DESCRIPTION
## Summary

- Port task session launch/resume from Claude Code to Codex (`codex` / `codex resume`).
- Install Codex-native skill and hooks under `~/.codex`, including SessionStart registration and UserPromptSubmit context nudges.
- Add Codex transcript discovery/rendering, close-out sweep via `codex exec`, and backward-compatible Claude transcript fallback.
- Refresh README/AGENTS docs for the Codex workflow, including local memory/RAG-like framing and a flowchart.
- Harden terminal spawning with iTerm2/Terminal.app detection and fallback when iTerm is unavailable.

## Testing

- `go test -count=1 ./...`
- `go build -o flow .`
- Clean-room CLI smoke with temporary `HOME` and `FLOW_ROOT` covering init, skill/hooks/config install, task/project creation, SessionStart registration, transcript rendering, compact transcript rendering, and done transition.
- Live macOS smoke: `flow do flow-codex-live-smoke --fresh` spawned Codex, the hook registered a new session id/transcript path, and `flow transcript` rendered the Codex JSONL.

## Notes

- This keeps upstream history/credit intact and makes the fork Codex-first.
- Legacy Claude transcript lookup remains only for old data compatibility.
- Terminal.app may still require macOS Accessibility permission for AppleScript tab spawning.