### PR TITLE
fix: retire UserPromptSubmit hook (per-prompt token cost > value)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Removed
+
+- **UserPromptSubmit hook.** Per-prompt skill nudge in ad-hoc Claude
+  sessions retired — the ~200 words of `additionalContext` injected
+  on every user prompt cost more in tokens than it returned in
+  marginal §4.14 reliability over the SessionStart hook alone. The
+  command itself (`flow hook user-prompt-submit`) is now a permanent
+  no-op so any stale entry left behind in older `~/.claude/settings.json`
+  files doesn't error; both `flow skill install` and the auto-upgrade
+  path actively remove the entry, leaving any unrelated user-defined
+  hooks in the same event untouched.
+
 ## [0.1.0-alpha.6] — 2026-05-08
 
 ### Added

--- a/internal/app/hook.go
+++ b/internal/app/hook.go
@@ -169,39 +169,22 @@ func emitHookContext(event, ctx string) int {
 	return 0
 }
 
-// cmdHookUserPromptSubmit implements `flow hook user-prompt-submit`.
-// In ad-hoc sessions (FLOW_TASK unset) it emits a directive instructing
-// Claude to invoke the flow skill BEFORE responding and to apply
-// §4.14. No keyword gate — the directive fires on every prompt because
-// users describe substantive work in their own words ("help me build
-// X", "fix this bug") and won't say "create a task" themselves.
+// cmdHookUserPromptSubmit is a permanent no-op kept only for forward
+// compatibility with stale `~/.claude/settings.json` entries that
+// reference `flow hook user-prompt-submit`. The hook used to emit a
+// per-prompt skill nudge in ad-hoc sessions, but the per-turn token
+// cost of injecting ~200 words of additionalContext on every prompt
+// outweighed the marginal value over the SessionStart hook.
 //
-// In bound sessions (FLOW_TASK set) it exits 0 with no output. The
-// SessionStart hook already loaded full task context for those, and
-// repeating that on every prompt would be noisy and expensive.
+// `flow skill install` (and the auto-upgrade path) now actively
+// remove any UserPromptSubmit entry from settings.json, so this code
+// path should not be hit on upgraded installs. Kept here so users on
+// older binaries with stale settings entries don't see hook errors
+// in the meantime.
 func cmdHookUserPromptSubmit(args []string) int {
 	fs := flagSet("hook user-prompt-submit")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	if os.Getenv("FLOW_TASK") != "" {
-		// Bound session — no-op.
-		return 0
-	}
-	hint := "The user already tracks their work and knowledge in flow (a personal " +
-		"task/session manager with a central knowledge base of durable facts about " +
-		"them, their org, and their work) and this Claude session is unbound. Their " +
-		"tasks and KB already exist. Before responding: invoke the `flow` skill via " +
-		"the Skill tool if you haven't already this session — it is the operating " +
-		"manual for capturing work as flow tasks, logging progress, and keeping the " +
-		"user's KB current. When the user starts any work in this session, before " +
-		"doing it, confirm with them via AskUserQuestion: is this part of an existing " +
-		"flow task, or should we create a new one? The user's work belongs in flow — " +
-		"don't silently proceed in an unbound transcript. " +
-		"If the user's wording is non-standard or uses names/codenames/tools you " +
-		"don't recognize, consult flow's KB (~/.flow/kb/), project briefs " +
-		"(~/.flow/projects/), and task briefs (~/.flow/tasks/) before guessing or " +
-		"asking. The skill's §4.10 governs lazy-loading so you don't read everything " +
-		"every turn."
-	return emitHookContext("UserPromptSubmit", hint)
+	return 0
 }

--- a/internal/app/hook_test.go
+++ b/internal/app/hook_test.go
@@ -101,67 +101,22 @@ func TestHookSessionStartRequiresSkillInvocation(t *testing.T) {
 	}
 }
 
-// TestHookUserPromptSubmitAdHocEmitsSkillNudge pins the contract for
-// ad-hoc sessions (FLOW_TASK unset): every prompt must produce a
-// hookSpecificOutput payload that nudges Claude to invoke the flow
-// skill and apply §4.14 — without keyword gating, since users won't
-// say "create a task" themselves.
-func TestHookUserPromptSubmitAdHocEmitsSkillNudge(t *testing.T) {
-	t.Setenv("FLOW_TASK", "")
-	out := captureStdout(t, func() {
-		if rc := cmdHookUserPromptSubmit(nil); rc != 0 {
-			t.Fatalf("rc=%d", rc)
+// TestHookUserPromptSubmitIsNoOp pins the v0.1.0-alpha.7 contract:
+// the UserPromptSubmit hook is a permanent no-op — exits 0 with no
+// stdout regardless of FLOW_TASK state. Kept around only for forward
+// compatibility with stale settings.json entries on older installs.
+// `flow skill install` actively removes the entry on upgrade.
+func TestHookUserPromptSubmitIsNoOp(t *testing.T) {
+	for _, flowTask := range []string{"", "some-slug"} {
+		t.Setenv("FLOW_TASK", flowTask)
+		out := captureStdout(t, func() {
+			if rc := cmdHookUserPromptSubmit(nil); rc != 0 {
+				t.Fatalf("FLOW_TASK=%q: rc=%d", flowTask, rc)
+			}
+		})
+		if strings.TrimSpace(out) != "" {
+			t.Errorf("FLOW_TASK=%q: expected empty stdout, got:\n%s", flowTask, out)
 		}
-	})
-	var parsed struct {
-		HookSpecificOutput struct {
-			HookEventName     string `json:"hookEventName"`
-			AdditionalContext string `json:"additionalContext"`
-		} `json:"hookSpecificOutput"`
-	}
-	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
-		t.Fatalf("parse hook output: %v\nraw: %s", err, out)
-	}
-	if parsed.HookSpecificOutput.HookEventName != "UserPromptSubmit" {
-		t.Errorf("hookEventName = %q, want UserPromptSubmit",
-			parsed.HookSpecificOutput.HookEventName)
-	}
-	ctx := parsed.HookSpecificOutput.AdditionalContext
-	for _, want := range []string{
-		"already tracks",
-		"`flow` skill",
-		"Skill tool",
-		"knowledge base",
-		"AskUserQuestion",
-		"existing flow task",
-		"create a new one",
-		"~/.flow/kb/",
-		"don't recognize",
-	} {
-		if !strings.Contains(ctx, want) {
-			t.Errorf("UserPromptSubmit ambient hint missing %q; got:\n%s", want, ctx)
-		}
-	}
-	// Must NOT mention "substantive" — see SessionStart test for the
-	// rationale (don't prime Claude on the rejected gate).
-	if strings.Contains(ctx, "substantive") {
-		t.Errorf("UserPromptSubmit hint must not mention 'substantive'; got:\n%s", ctx)
-	}
-}
-
-// TestHookUserPromptSubmitBoundIsNoOp pins the bound-session contract:
-// when FLOW_TASK is set, the hook exits 0 with no output. The
-// SessionStart hook already loaded full task context; repeating it on
-// every prompt would be noisy and expensive.
-func TestHookUserPromptSubmitBoundIsNoOp(t *testing.T) {
-	t.Setenv("FLOW_TASK", "some-slug")
-	out := captureStdout(t, func() {
-		if rc := cmdHookUserPromptSubmit(nil); rc != 0 {
-			t.Fatalf("rc=%d", rc)
-		}
-	})
-	if strings.TrimSpace(out) != "" {
-		t.Errorf("expected empty stdout when FLOW_TASK is set, got:\n%s", out)
 	}
 }
 

--- a/internal/app/skill.go
+++ b/internal/app/skill.go
@@ -121,7 +121,10 @@ func maybeAutoUpgradeSkill() {
 	}
 	_ = writeSkillVersion(Version)
 	_, _ = installSessionStartHook()
-	_, _ = installUserPromptSubmitHook()
+	// UserPromptSubmit hook was removed in v0.1.0-alpha.7 — the
+	// per-prompt token cost wasn't worth the marginal value. Actively
+	// uninstall any stale entry left behind by older binaries.
+	_, _ = uninstallUserPromptSubmitHook()
 	fmt.Fprintf(os.Stderr, "flow: upgraded skill to %s\n", Version)
 }
 
@@ -194,14 +197,16 @@ func skillInstall(args []string, forceDefault bool) int {
 	} else {
 		fmt.Println("SessionStart hook already installed — leaving as is")
 	}
-	if added, err := installUserPromptSubmitHook(); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: could not install UserPromptSubmit hook: %v\n", err)
+	// UserPromptSubmit hook was removed in v0.1.0-alpha.7. Actively
+	// uninstall any stale entry left behind by older binaries so a
+	// fresh `flow skill install` (or `update`) leaves a clean
+	// settings.json.
+	if removed, err := uninstallUserPromptSubmitHook(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not remove stale UserPromptSubmit hook: %v\n", err)
 		return 0
-	} else if added {
+	} else if removed {
 		settings, _ := userSettingsPath()
-		fmt.Printf("installed UserPromptSubmit hook in %s (nudges flow skill on every ad-hoc prompt)\n", settings)
-	} else {
-		fmt.Println("UserPromptSubmit hook already installed — leaving as is")
+		fmt.Printf("removed stale UserPromptSubmit hook from %s (no longer used)\n", settings)
 	}
 	return 0
 }
@@ -261,17 +266,11 @@ func uninstallSessionStartHook() (bool, error) {
 	return uninstallClaudeHook("SessionStart", hookCommand)
 }
 
-// installUserPromptSubmitHook idempotently adds the flow
-// UserPromptSubmit hook. Fires on every user prompt; the hook command
-// itself decides whether to emit additionalContext (FLOW_TASK unset)
-// or no-op (FLOW_TASK set).
-func installUserPromptSubmitHook() (bool, error) {
-	// UserPromptSubmit doesn't take a matcher.
-	return installClaudeHook("UserPromptSubmit", "", userPromptSubmitHookCommand)
-}
-
-// uninstallUserPromptSubmitHook removes the flow UserPromptSubmit hook
-// entry. Thin wrapper around uninstallClaudeHook.
+// uninstallUserPromptSubmitHook removes any stale flow UserPromptSubmit
+// hook entry from ~/.claude/settings.json. The hook itself was
+// removed in v0.1.0-alpha.7 — see cmdHookUserPromptSubmit. Both
+// `flow skill install` and `maybeAutoUpgradeSkill` call this on every
+// upgrade so existing-user installs converge to a clean settings.json.
 func uninstallUserPromptSubmitHook() (bool, error) {
 	return uninstallClaudeHook("UserPromptSubmit", userPromptSubmitHookCommand)
 }

--- a/internal/app/skill_test.go
+++ b/internal/app/skill_test.go
@@ -158,10 +158,10 @@ func TestSkillUninstallIdempotent(t *testing.T) {
 	}
 }
 
-// TestSkillInstallWritesBothHooks verifies install wires up BOTH the
-// SessionStart hook (existing behavior) and the new UserPromptSubmit
-// hook into ~/.claude/settings.json.
-func TestSkillInstallWritesBothHooks(t *testing.T) {
+// TestSkillInstallWritesSessionStartHook verifies install wires up the
+// SessionStart hook into ~/.claude/settings.json. The UserPromptSubmit
+// hook was retired in v0.1.0-alpha.7 — install MUST NOT add it.
+func TestSkillInstallWritesSessionStartHook(t *testing.T) {
 	home := withTempHome(t)
 	if rc := cmdSkill([]string{"install"}); rc != 0 {
 		t.Fatalf("install rc=%d", rc)
@@ -174,14 +174,15 @@ func TestSkillInstallWritesBothHooks(t *testing.T) {
 	if !hookEventReferencesCommand(hooks, "SessionStart", "flow hook session-start") {
 		t.Errorf("SessionStart hook missing or wrong command: %#v", hooks["SessionStart"])
 	}
-	if !hookEventReferencesCommand(hooks, "UserPromptSubmit", "flow hook user-prompt-submit") {
-		t.Errorf("UserPromptSubmit hook missing or wrong command: %#v", hooks["UserPromptSubmit"])
+	// UserPromptSubmit must not be installed by fresh install.
+	if hookEventReferencesCommand(hooks, "UserPromptSubmit", "flow hook user-prompt-submit") {
+		t.Errorf("install should NOT add UserPromptSubmit hook; got %#v", hooks["UserPromptSubmit"])
 	}
 }
 
 // TestSkillInstallIsIdempotent verifies a second install --force does
-// not duplicate either hook entry. Past regressions append duplicates
-// silently; pin against that.
+// not duplicate the SessionStart entry. Past regressions append
+// duplicates silently; pin against that.
 func TestSkillInstallIsIdempotent(t *testing.T) {
 	home := withTempHome(t)
 	if rc := cmdSkill([]string{"install"}); rc != 0 {
@@ -192,17 +193,103 @@ func TestSkillInstallIsIdempotent(t *testing.T) {
 	}
 	settings := readSettings(t, filepath.Join(home, ".claude", "settings.json"))
 	hooks, _ := settings["hooks"].(map[string]any)
-	for _, event := range []string{"SessionStart", "UserPromptSubmit"} {
-		entries, _ := hooks[event].([]any)
-		if got := countMatchingHookEntries(entries, expectedCommand(event)); got != 1 {
-			t.Errorf("%s: got %d matching entries, want 1", event, got)
-		}
+	entries, _ := hooks["SessionStart"].([]any)
+	if got := countMatchingHookEntries(entries, expectedCommand("SessionStart")); got != 1 {
+		t.Errorf("SessionStart: got %d matching entries, want 1", got)
 	}
 }
 
-// TestSkillUninstallRemovesBothHooks verifies uninstall strips both
-// hook entries and ends with an empty hooks map (or no hooks key).
-func TestSkillUninstallRemovesBothHooks(t *testing.T) {
+// TestSkillInstallRemovesStaleUserPromptSubmit verifies the upgrade
+// path: an existing settings.json with a UserPromptSubmit hook entry
+// (legacy install from <= v0.1.0-alpha.6) gets that entry removed by
+// `flow skill install --force`, even on a fresh skill install.
+func TestSkillInstallRemovesStaleUserPromptSubmit(t *testing.T) {
+	home := withTempHome(t)
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stale := `{
+  "hooks": {
+    "UserPromptSubmit": [
+      {"hooks": [{"type": "command", "command": "flow hook user-prompt-submit"}]}
+    ]
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if rc := cmdSkill([]string{"install"}); rc != 0 {
+		t.Fatalf("install rc=%d", rc)
+	}
+	settings := readSettings(t, settingsPath)
+	hooks, _ := settings["hooks"].(map[string]any)
+	if hookEventReferencesCommand(hooks, "UserPromptSubmit", "flow hook user-prompt-submit") {
+		t.Errorf("install should remove stale UserPromptSubmit hook; got %#v", hooks["UserPromptSubmit"])
+	}
+	// SessionStart should still get installed normally.
+	if !hookEventReferencesCommand(hooks, "SessionStart", "flow hook session-start") {
+		t.Errorf("SessionStart hook missing after install: %#v", hooks["SessionStart"])
+	}
+}
+
+// TestSkillInstallPreservesUnrelatedHooks pins the safety property:
+// removing flow's UserPromptSubmit hook MUST NOT touch other commands
+// the user has wired under UserPromptSubmit (e.g. their own scripts),
+// and MUST NOT touch other event keys (SessionEnd, PreToolUse, etc.).
+func TestSkillInstallPreservesUnrelatedHooks(t *testing.T) {
+	home := withTempHome(t)
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mixed := `{
+  "hooks": {
+    "UserPromptSubmit": [
+      {"hooks": [{"type": "command", "command": "flow hook user-prompt-submit"}]},
+      {"hooks": [{"type": "command", "command": "my-custom-tool --watch"}]}
+    ],
+    "PreToolUse": [
+      {"matcher": "Bash", "hooks": [{"type": "command", "command": "user-pretool-script"}]}
+    ]
+  },
+  "someUnrelatedKey": "preserve-me"
+}`
+	if err := os.WriteFile(settingsPath, []byte(mixed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if rc := cmdSkill([]string{"install"}); rc != 0 {
+		t.Fatalf("install rc=%d", rc)
+	}
+	settings := readSettings(t, settingsPath)
+
+	// flow's UPS entry gone; user's UPS entry preserved.
+	hooks, _ := settings["hooks"].(map[string]any)
+	if hookEventReferencesCommand(hooks, "UserPromptSubmit", "flow hook user-prompt-submit") {
+		t.Errorf("flow UPS hook should be removed; got %#v", hooks["UserPromptSubmit"])
+	}
+	if !hookEventReferencesCommand(hooks, "UserPromptSubmit", "my-custom-tool --watch") {
+		t.Errorf("user's UPS hook MUST be preserved; got %#v", hooks["UserPromptSubmit"])
+	}
+
+	// PreToolUse untouched.
+	if !hookEventReferencesCommand(hooks, "PreToolUse", "user-pretool-script") {
+		t.Errorf("PreToolUse hook MUST be preserved; got %#v", hooks["PreToolUse"])
+	}
+
+	// Top-level non-hook key untouched.
+	if v, _ := settings["someUnrelatedKey"].(string); v != "preserve-me" {
+		t.Errorf("unrelated top-level key should be preserved, got %v", settings["someUnrelatedKey"])
+	}
+}
+
+// TestSkillUninstallRemovesSessionStartHook verifies uninstall strips
+// the SessionStart entry. (The UserPromptSubmit hook is no longer
+// installed, so its absence after uninstall is verified by the
+// install-side tests.)
+func TestSkillUninstallRemovesSessionStartHook(t *testing.T) {
 	home := withTempHome(t)
 	if rc := cmdSkill([]string{"install"}); rc != 0 {
 		t.Fatalf("install rc=%d", rc)


### PR DESCRIPTION
## Summary

The `UserPromptSubmit` hook (added in PR #16) injected ~200 words of `additionalContext` on every user prompt in **ad-hoc** Claude sessions to nudge Claude into invoking the flow skill and checking task binding via §4.14. Across long unbound sessions the per-prompt token cost adds up, and the SessionStart hook (which fires on startup + resume) already covers the same nudging at far lower cost. Net call: retire the hook.

## Changes

- **`cmdHookUserPromptSubmit` → permanent no-op.** Returns 0 with no stdout regardless of `FLOW_TASK` state. Kept (not deleted) so any stale `~/.claude/settings.json` entry from an older binary doesn't surface hook errors mid-session.
- **`flow skill install` (fresh and `--force`) + `maybeAutoUpgradeSkill` no longer install the hook.** Both paths now actively *uninstall* any pre-existing `flow hook user-prompt-submit` entry from `~/.claude/settings.json`, so existing users converge to a clean install on their next `flow skill install` / `update` / auto-upgrade pass.
- **Removed unused `installUserPromptSubmitHook`** helper. `uninstallUserPromptSubmitHook` retained (used by both the install and uninstall paths now).
- **Skill content untouched** — no SKILL.md edits needed; the skill never directly referenced the hook.

## Safety

The uninstall logic in `uninstallClaudeHook` matches by **exact** command-string equality (`strings.TrimSpace(cmd) == "flow hook user-prompt-submit"`):

- Other event keys (`SessionStart`, `PreToolUse`, etc.) are completely untouched.
- Other commands the user wired under `UserPromptSubmit` are preserved.
- Mixed entries (flow's command + user's command in the same `hooks` array) keep the user's command; only flow's line is filtered out.
- Top-level non-hook keys in `settings.json` are preserved.
- Malformed JSON entries pass through verbatim — we don't rewrite content we can't parse.

Two new tests pin these properties in CI:

- `TestSkillInstallPreservesUnrelatedHooks` — install on a `settings.json` with the flow UPS hook + a user's `my-custom-tool` UPS hook + a `PreToolUse` hook + an unrelated top-level key. Only flow's entry is removed; everything else stays.
- `TestSkillInstallRemovesStaleUserPromptSubmit` — pre-alpha.7 install with the legacy UPS entry gets cleaned up by `flow skill install`.

## Test plan

- [x] `go vet ./... && go test ./...` clean
- [x] `make build` produces a working binary
- [x] Existing `hook_test.go` reduced to `TestHookUserPromptSubmitIsNoOp` — covers both `FLOW_TASK` set and unset cases (both no-op now).
- [x] `skill_test.go`: existing `TestSkillInstallWritesBothHooks` renamed to `TestSkillInstallWritesSessionStartHook`, asserts the SessionStart hook IS installed and the UserPromptSubmit hook is NOT installed. Idempotent test now only checks SessionStart for duplicate-free.

## Rollout

- Merge → bump alpha (suggest `v0.1.0-alpha.7`).
- Existing users on alpha.6 or older binaries will keep emitting the hint until their next `flow` invocation triggers the auto-upgrade (released-binary path) or they explicitly run `flow skill update`. After that, settings.json is cleaned up automatically.
- Local dev builds (`Version == "dev"`) skip auto-upgrade by design — a `flow skill install --force` still does the cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)