### PR TITLE
feat: focus existing tab on flow do when session is already open

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,11 @@ conversation. A SessionStart hook re-injects the task brief,
 updates, and CLAUDE.md context on every resume; a UserPromptSubmit
 hook keeps the flow skill discoverable in ad-hoc Claude sessions.
 
+When `flow do <task>` is run for a task whose session is already
+live in another tab, flow focuses that tab instead of spawning a
+duplicate. The source tab prints "Already open: `<slug>` — switched
+to existing tab" as an audit line.
+
 The first `flow do` from stock Terminal.app needs macOS Accessibility
 permission for the **app hosting your shell** — not the `flow` binary
 itself. Terminal.app's AppleScript dictionary has no "make new tab"

--- a/internal/app/do.go
+++ b/internal/app/do.go
@@ -160,11 +160,34 @@ func cmdDo(args []string) int {
 
 	// Live-session guard: if this task's session_id is already running
 	// in another claude process (e.g., the user has a tab open for it),
-	// refuse to spawn a duplicate. --force overrides. The check is
+	// try to focus that tab. If the focus succeeds, exit 0 — the user
+	// gets switched to the existing tab. If the focus path can't find
+	// the tab (different terminal app, different zellij session, etc.)
+	// or itself errors, fall back to refusing the spawn so the user
+	// knows to switch manually or pass --force. The ps check is
 	// best-effort: ps failures fall through silently rather than block.
+	//
+	// Duplicate detection: if more than one claude process is running
+	// the same session UUID (possible via prior --force, or a manual
+	// `claude --resume <uuid>` in another tab), warn before focusing.
+	// Both processes write to the same session jsonl and can race —
+	// the user almost certainly wants to know.
 	if !*force && task.SessionID.Valid && task.SessionID.String != "" {
 		if live, err := liveClaudeSessions(); err == nil {
 			if live[strings.ToLower(task.SessionID.String)] {
+				if n := countClaudeProcessesForSession(task.SessionID.String); n > 1 {
+					fmt.Fprintf(os.Stderr,
+						"warning: %d claude processes are running session %s — both write to the same transcript and may race; close duplicates if unintended\n",
+						n, task.SessionID.String)
+				}
+				focused, ferr := spawner.FocusSession(task.SessionID.String)
+				if focused {
+					fmt.Printf("Already open: %s — switched to existing tab\n", task.Slug)
+					return 0
+				}
+				if ferr != nil {
+					fmt.Fprintf(os.Stderr, "warning: focus attempt failed: %v\n", ferr)
+				}
 				fmt.Fprintf(os.Stderr,
 					"error: task %q has a live Claude session (%s) running elsewhere — switch to that tab, or pass --force to open another\n",
 					task.Slug, task.SessionID.String)

--- a/internal/app/do_test.go
+++ b/internal/app/do_test.go
@@ -1,10 +1,12 @@
 package app
 
 import (
+	"bytes"
 	"errors"
 	"flow/internal/flowdb"
 	"flow/internal/iterm"
 	"flow/internal/spawner"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,8 +61,12 @@ func seedTask(t *testing.T, slug string) {
 }
 
 // TestCmdDoLiveSessionGuard checks that a task whose session_id is in
-// the live-claude-process set refuses to spawn unless --force is passed.
-// This is feature 3 of the bundled fields/sessions task.
+// the live-claude-process set refuses to spawn (when focus can't find
+// the tab) unless --force is passed. This is feature 3 of the
+// bundled fields/sessions task. The focus path is short-circuited by
+// stubbing iterm.PSRunner with empty output so ttyForClaudeSession
+// returns "" → FocusSession returns (false, nil) → fall through to
+// the original error message.
 func TestCmdDoLiveSessionGuard(t *testing.T) {
 	setupFlowRoot(t)
 	seedTask(t, "live-task")
@@ -77,24 +83,154 @@ func TestCmdDoLiveSessionGuard(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Make ps say this UUID is alive.
+	// Make ps (the app-level psRunner) say this UUID is alive so the
+	// live guard fires.
 	stubPS(t, "  PID COMMAND\n12345 /bin/claude --session-id "+pinnedSID+"\n")
+
+	// Make iterm.PSRunner (the focus-path probe) return no rows so the
+	// focus attempt deterministically returns (false, nil) and we fall
+	// through to the original "running elsewhere" error.
+	oldFocusPS := iterm.PSRunner
+	iterm.PSRunner = func() ([]byte, error) { return []byte(""), nil }
+	t.Cleanup(func() { iterm.PSRunner = oldFocusPS })
 
 	count, _ := stubITerm(t)
 	if rc := cmdDo([]string{"live-task"}); rc != 1 {
-		t.Errorf("cmdDo: rc=%d, want 1 when live session blocks spawn", rc)
+		t.Errorf("cmdDo: rc=%d, want 1 when live session blocks spawn (focus miss)", rc)
 	}
 	if *count != 0 {
 		t.Errorf("iterm spawn count = %d, want 0 (guard should block)", *count)
 	}
 
-	// --force should bypass the guard. iTerm runner is still stubbed
-	// from above, so spawning will succeed.
+	// --force should bypass the guard (and the focus attempt). iTerm
+	// runner is still stubbed from above, so spawning will succeed.
 	if rc := cmdDo([]string{"live-task", "--force"}); rc != 0 {
 		t.Errorf("cmdDo --force: rc=%d, want 0 (guard bypassed)", rc)
 	}
 	if *count != 1 {
 		t.Errorf("iterm spawn count after --force = %d, want 1", *count)
+	}
+}
+
+// TestCmdDoLiveSessionFocusesExistingTab pins the new behavior: when a
+// task's session is already running AND the active backend can locate
+// its tab, `flow do` focuses that tab and exits 0 instead of erroring.
+// No new tab is spawned.
+func TestCmdDoLiveSessionFocusesExistingTab(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "open-task")
+
+	const pinnedSID = "abcdef12-3456-4789-8abc-def012345678"
+	db := openFlowDB(t)
+	if _, err := db.Exec(
+		`UPDATE tasks SET session_id=?, session_started=? WHERE slug='open-task'`,
+		pinnedSID, flowdb.NowISO(),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// App-level liveClaudeSessions sees the UUID as alive.
+	stubPS(t, "  PID COMMAND\n12345 /bin/claude --session-id "+pinnedSID+"\n")
+
+	// iterm focus path: ps yields a row with tty, then osascript
+	// reports "ok" → FocusSession returns (true, nil).
+	oldFocusPS := iterm.PSRunner
+	iterm.PSRunner = func() ([]byte, error) {
+		return []byte("  PID TTY      COMMAND\n12345 ttys012  /bin/claude --session-id " + pinnedSID + "\n"), nil
+	}
+	t.Cleanup(func() { iterm.PSRunner = oldFocusPS })
+
+	oldRunnerOut := iterm.RunnerOutput
+	iterm.RunnerOutput = func(args []string) ([]byte, error) { return []byte("ok\n"), nil }
+	t.Cleanup(func() { iterm.RunnerOutput = oldRunnerOut })
+
+	count, _ := stubITerm(t)
+	if rc := cmdDo([]string{"open-task"}); rc != 0 {
+		t.Errorf("cmdDo when focus succeeds: rc=%d, want 0", rc)
+	}
+	if *count != 0 {
+		t.Errorf("iterm spawn count = %d, want 0 (focus should not spawn)", *count)
+	}
+}
+
+// TestCmdDoLiveSessionDuplicateProcessesWarn covers the duplicate-tab
+// detection path. ps reports two claude processes running the same
+// session UUID; cmdDo should emit a warning to stderr (so the user
+// knows the duplicate exists and that transcript writes may race),
+// then proceed to focus the first match. We assert that focus still
+// succeeds (rc=0, no spawn) and the duplicate count surfaces in the
+// captured stderr.
+func TestCmdDoLiveSessionDuplicateProcessesWarn(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "dup-task")
+
+	const pinnedSID = "abcdef12-3456-4789-8abc-def012345678"
+	db := openFlowDB(t)
+	if _, err := db.Exec(
+		`UPDATE tasks SET session_id=?, session_started=? WHERE slug='dup-task'`,
+		pinnedSID, flowdb.NowISO(),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// App-level psRunner reports TWO claude processes for the same UUID.
+	stubPS(t,
+		"  PID COMMAND\n"+
+			"12345 /bin/claude --session-id "+pinnedSID+"\n"+
+			"67890 /bin/claude --resume "+pinnedSID+"\n",
+	)
+
+	// iterm focus succeeds against the first match.
+	oldFocusPS := iterm.PSRunner
+	iterm.PSRunner = func() ([]byte, error) {
+		return []byte(
+			"  PID TTY      COMMAND\n" +
+				"12345 ttys012  /bin/claude --session-id " + pinnedSID + "\n" +
+				"67890 ttys013  /bin/claude --resume " + pinnedSID + "\n",
+		), nil
+	}
+	t.Cleanup(func() { iterm.PSRunner = oldFocusPS })
+
+	oldRunnerOut := iterm.RunnerOutput
+	iterm.RunnerOutput = func(args []string) ([]byte, error) { return []byte("ok\n"), nil }
+	t.Cleanup(func() { iterm.RunnerOutput = oldRunnerOut })
+
+	stderr := captureStderr(t)
+	count, _ := stubITerm(t)
+	if rc := cmdDo([]string{"dup-task"}); rc != 0 {
+		t.Errorf("cmdDo with duplicates: rc=%d, want 0 (focus should still succeed)", rc)
+	}
+	if *count != 0 {
+		t.Errorf("iterm spawn count = %d, want 0 (focus should not spawn)", *count)
+	}
+	got := stderr()
+	for _, want := range []string{"2 claude processes", pinnedSID, "may race"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("warning missing %q\n--- stderr ---\n%s", want, got)
+		}
+	}
+}
+
+// captureStderr redirects os.Stderr through an os.Pipe for the duration
+// of the test and returns a closure that drains and returns whatever
+// was written. The original stderr is restored on Cleanup.
+func captureStderr(t *testing.T) func() string {
+	t.Helper()
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() {
+		os.Stderr = origStderr
+	})
+	return func() string {
+		_ = w.Close()
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		_ = r.Close()
+		return buf.String()
 	}
 }
 

--- a/internal/app/sessions.go
+++ b/internal/app/sessions.go
@@ -53,3 +53,35 @@ func liveClaudeSessions() (map[string]bool, error) {
 	}
 	return live, nil
 }
+
+// countClaudeProcessesForSession returns the number of currently-running
+// `claude` processes whose argv contains the given session UUID via
+// `--session-id` or `--resume`. Used to detect duplicate-tab states
+// (two tabs running the same session) so `flow do` can warn the user
+// — both processes write to the same session jsonl, so duplicates can
+// race and lose transcript history. ps failures return 0 silently;
+// the caller should not block on this signal.
+func countClaudeProcessesForSession(sessionID string) int {
+	if sessionID == "" {
+		return 0
+	}
+	out, err := psRunner()
+	if err != nil {
+		return 0
+	}
+	needle := strings.ToLower(sessionID)
+	count := 0
+	for _, line := range strings.Split(string(out), "\n") {
+		if !strings.Contains(line, "claude") {
+			continue
+		}
+		matches := claudeSessionArgRe.FindAllStringSubmatch(line, -1)
+		for _, m := range matches {
+			if len(m) >= 2 && strings.ToLower(m[1]) == needle {
+				count++
+				break // one match per row is enough; avoid double-counting if argv mentions twice
+			}
+		}
+	}
+	return count
+}

--- a/internal/app/sessions_test.go
+++ b/internal/app/sessions_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -63,6 +64,49 @@ func TestLiveClaudeSessionsIgnoresNonClaude(t *testing.T) {
 	}
 	if len(live) != 0 {
 		t.Errorf("non-claude line should not contribute; got %v", live)
+	}
+}
+
+func TestCountClaudeProcessesForSessionEmptyID(t *testing.T) {
+	stubPS(t, "  PID COMMAND\n12345 /bin/claude --session-id 11111111-2222-4333-8444-555555555555\n")
+	if got := countClaudeProcessesForSession(""); got != 0 {
+		t.Errorf("count for empty UUID = %d, want 0", got)
+	}
+}
+
+func TestCountClaudeProcessesForSessionSingle(t *testing.T) {
+	const psOutput = `  PID COMMAND
+12345 /bin/claude --session-id 11111111-2222-4333-8444-555555555555
+`
+	stubPS(t, psOutput)
+	if got := countClaudeProcessesForSession("11111111-2222-4333-8444-555555555555"); got != 1 {
+		t.Errorf("count = %d, want 1", got)
+	}
+}
+
+// TestCountClaudeProcessesForSessionDuplicates pins the duplicate
+// detection behavior: two claude processes running the same UUID
+// (possible via prior --force) yield a count of 2 so do.go can warn.
+func TestCountClaudeProcessesForSessionDuplicates(t *testing.T) {
+	const psOutput = `  PID COMMAND
+12345 /bin/claude --session-id 11111111-2222-4333-8444-555555555555
+12346 /bin/claude --resume 11111111-2222-4333-8444-555555555555
+12347 /bin/claude --session-id ffffffff-ffff-4fff-8fff-ffffffffffff
+`
+	stubPS(t, psOutput)
+	if got := countClaudeProcessesForSession("11111111-2222-4333-8444-555555555555"); got != 2 {
+		t.Errorf("count for duplicates = %d, want 2", got)
+	}
+}
+
+func TestCountClaudeProcessesForSessionPSError(t *testing.T) {
+	old := psRunner
+	psRunner = func() ([]byte, error) {
+		return nil, errors.New("ps blew up")
+	}
+	t.Cleanup(func() { psRunner = old })
+	if got := countClaudeProcessesForSession("11111111-2222-4333-8444-555555555555"); got != 0 {
+		t.Errorf("count on ps error = %d, want 0 (best-effort)", got)
 	}
 }
 

--- a/internal/iterm/iterm.go
+++ b/internal/iterm/iterm.go
@@ -4,11 +4,12 @@ package iterm
 import (
 	"fmt"
 	"os/exec"
+	"regexp"
 	"sort"
 	"strings"
 )
 
-// Runner is the function used to execute osascript.
+// Runner is the function used to execute osascript for SpawnTab.
 // Tests override this to capture arguments without invoking osascript.
 var Runner = func(args []string) error {
 	cmd := exec.Command("osascript", args...)
@@ -17,6 +18,21 @@ var Runner = func(args []string) error {
 		return fmt.Errorf("osascript failed: %v: %s", err, string(out))
 	}
 	return nil
+}
+
+// RunnerOutput is the function used to execute osascript when the
+// caller needs to read stdout (e.g., FocusSession needs to know
+// whether a match was found). Separate from Runner so tests can mock
+// it independently and existing SpawnTab tests stay untouched.
+var RunnerOutput = func(args []string) ([]byte, error) {
+	return exec.Command("osascript", args...).Output()
+}
+
+// PSRunner returns the output of `ps -axo pid,tty,command`. Overridable
+// for tests. Includes tty so FocusSession can map a claude PID → tty
+// → iTerm2 session in one pass.
+var PSRunner = func() ([]byte, error) {
+	return exec.Command("ps", "-axo", "pid,tty,command").Output()
 }
 
 // SpawnTab opens a new iTerm2 tab with the given title, cwd, and command.
@@ -59,6 +75,107 @@ end tell
 `, safeTitle, safeCommand)
 
 	return Runner([]string{"-e", script})
+}
+
+// FocusSession tries to focus the iTerm2 session whose underlying
+// process is `claude` running with `--session-id <sessionID>` or
+// `--resume <sessionID>`. Returns (true, nil) on focus, (false, nil)
+// if no matching tab was found in iTerm2, and (false, err) only on a
+// backend (ps / osascript) failure.
+//
+// Mechanism: scan `ps -axo pid,tty,command` for a claude process whose
+// argv contains the session UUID, extract its controlling tty, then
+// drive osascript to walk every window/tab/session and select the one
+// whose `tty` property matches.
+func FocusSession(sessionID string) (bool, error) {
+	if sessionID == "" {
+		return false, nil
+	}
+	tty, err := ttyForClaudeSession(sessionID)
+	if err != nil {
+		return false, err
+	}
+	if tty == "" {
+		return false, nil
+	}
+	return focusByTTY(tty)
+}
+
+// claudeSessionRowRe matches a `ps` line that has BOTH a `claude` token
+// and a `--session-id <uuid>` or `--resume <uuid>` flag. Used by
+// ttyForClaudeSession to filter to claude rows that carry the UUID.
+var claudeSessionRowRe = regexp.MustCompile(
+	`(?:--session-id|--resume)[ =]([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})`,
+)
+
+// ttyForClaudeSession returns the controlling tty (e.g., "/dev/ttys012")
+// of the claude process running with the given session UUID, or "" if
+// no such process is currently running.
+func ttyForClaudeSession(sessionID string) (string, error) {
+	out, err := PSRunner()
+	if err != nil {
+		return "", fmt.Errorf("ps: %w", err)
+	}
+	needle := strings.ToLower(sessionID)
+	for _, line := range strings.Split(string(out), "\n") {
+		if !strings.Contains(line, "claude") {
+			continue
+		}
+		matches := claudeSessionRowRe.FindStringSubmatch(line)
+		if len(matches) < 2 {
+			continue
+		}
+		if strings.ToLower(matches[1]) != needle {
+			continue
+		}
+		// `ps -axo pid,tty,command` columns: pid, tty, command.
+		// After Fields() splits on whitespace, fields[1] is the tty
+		// (e.g., "ttys012", or "??" for no controlling terminal).
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		tty := fields[1]
+		if tty == "??" || tty == "?" || tty == "" {
+			continue
+		}
+		if !strings.HasPrefix(tty, "/dev/") {
+			tty = "/dev/" + tty
+		}
+		return tty, nil
+	}
+	return "", nil
+}
+
+// focusByTTY drives iTerm2's AppleScript dictionary to find a session
+// whose `tty` property matches and select it (and its enclosing tab
+// and window). The script writes "ok" to stdout on match, "miss"
+// otherwise; we distinguish at the Go level instead of relying on
+// osascript's exit code.
+func focusByTTY(tty string) (bool, error) {
+	safeTTY := escapeAppleScriptString(tty)
+	script := fmt.Sprintf(`tell application "iTerm2"
+  activate
+  repeat with w in windows
+    repeat with t in tabs of w
+      repeat with s in sessions of t
+        if tty of s is "%s" then
+          select w
+          tell t to select
+          tell s to select
+          return "ok"
+        end if
+      end repeat
+    end repeat
+  end repeat
+  return "miss"
+end tell
+`, safeTTY)
+	out, err := RunnerOutput([]string{"-e", script})
+	if err != nil {
+		return false, fmt.Errorf("osascript: %w", err)
+	}
+	return strings.TrimSpace(string(out)) == "ok", nil
 }
 
 // ShellQuote wraps s in single quotes with proper escaping.

--- a/internal/iterm/iterm_test.go
+++ b/internal/iterm/iterm_test.go
@@ -1,0 +1,216 @@
+package iterm
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestFocusSessionEmptyID short-circuits on empty UUID without touching ps.
+func TestFocusSessionEmptyID(t *testing.T) {
+	psCalled := false
+	old := PSRunner
+	PSRunner = func() ([]byte, error) {
+		psCalled = true
+		return nil, nil
+	}
+	t.Cleanup(func() { PSRunner = old })
+
+	focused, err := FocusSession("")
+	if focused || err != nil {
+		t.Errorf("FocusSession(\"\") = (%v, %v); want (false, nil)", focused, err)
+	}
+	if psCalled {
+		t.Error("PSRunner should not be called for empty session id")
+	}
+}
+
+// TestFocusSessionMatchesAndFocuses confirms the happy path: ps returns a
+// claude row carrying the UUID, FocusSession extracts the tty, drives
+// osascript with that tty, and reports focused=true when the script
+// returns "ok".
+func TestFocusSessionMatchesAndFocuses(t *testing.T) {
+	const uuid = "11111111-2222-4333-8444-555555555555"
+	const psOutput = `  PID TTY      COMMAND
+12345 ttys012  /Users/me/.bun/bin/claude --session-id 11111111-2222-4333-8444-555555555555
+12346 ttys013  /usr/bin/grep something
+`
+	stubPS(t, psOutput, nil)
+	var captured []string
+	stubRunnerOutput(t, func(args []string) ([]byte, error) {
+		captured = args
+		return []byte("ok\n"), nil
+	})
+
+	focused, err := FocusSession(uuid)
+	if err != nil {
+		t.Fatalf("FocusSession: %v", err)
+	}
+	if !focused {
+		t.Fatal("expected focused=true")
+	}
+	if len(captured) < 2 {
+		t.Fatalf("RunnerOutput called with %d args; want >=2", len(captured))
+	}
+	script := captured[1]
+	if !strings.Contains(script, `tell application "iTerm2"`) {
+		t.Errorf("script does not target iTerm2: %s", script)
+	}
+	if !strings.Contains(script, `if tty of s is "/dev/ttys012"`) {
+		t.Errorf("script does not match /dev/ttys012: %s", script)
+	}
+}
+
+// TestFocusSessionResumeFlag covers the --resume variant alongside
+// --session-id, since both forms appear depending on whether the tab
+// is in bootstrap or resume mode.
+func TestFocusSessionResumeFlag(t *testing.T) {
+	const uuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	const psOutput = `  PID TTY      COMMAND
+12345 ttys005  /Users/me/.bun/bin/claude --resume aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee
+`
+	stubPS(t, psOutput, nil)
+	stubRunnerOutput(t, func(args []string) ([]byte, error) {
+		return []byte("ok"), nil
+	})
+
+	focused, err := FocusSession(uuid)
+	if err != nil || !focused {
+		t.Errorf("FocusSession(--resume row) = (%v, %v); want (true, nil)", focused, err)
+	}
+}
+
+// TestFocusSessionUUIDCaseInsensitive verifies the UUID match is
+// case-insensitive (matches the existing liveClaudeSessions
+// normalization behavior).
+func TestFocusSessionUUIDCaseInsensitive(t *testing.T) {
+	const uuid = "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE"
+	const psOutput = `  PID TTY      COMMAND
+99999 ttys001  /usr/local/bin/claude --session-id aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee
+`
+	stubPS(t, psOutput, nil)
+	stubRunnerOutput(t, func(args []string) ([]byte, error) {
+		return []byte("ok"), nil
+	})
+	focused, err := FocusSession(uuid)
+	if err != nil || !focused {
+		t.Errorf("uppercase UUID should match lowercase ps row; got (%v, %v)", focused, err)
+	}
+}
+
+// TestFocusSessionNoMatchInPS returns (false, nil) without touching osascript.
+func TestFocusSessionNoMatchInPS(t *testing.T) {
+	const psOutput = `  PID TTY      COMMAND
+12345 ttys012  /Users/me/.bun/bin/claude --session-id ffffffff-ffff-4fff-8fff-ffffffffffff
+`
+	stubPS(t, psOutput, nil)
+	osCalled := false
+	stubRunnerOutput(t, func(args []string) ([]byte, error) {
+		osCalled = true
+		return nil, nil
+	})
+
+	focused, err := FocusSession("11111111-2222-4333-8444-555555555555")
+	if focused || err != nil {
+		t.Errorf("got (%v, %v); want (false, nil)", focused, err)
+	}
+	if osCalled {
+		t.Error("osascript should not be called when no ps match")
+	}
+}
+
+// TestFocusSessionSkipsNoControllingTTY ignores claude rows whose tty
+// column is "??" — a backgrounded claude with no controlling terminal
+// has nothing for us to focus.
+func TestFocusSessionSkipsNoControllingTTY(t *testing.T) {
+	const uuid = "11111111-2222-4333-8444-555555555555"
+	const psOutput = `  PID TTY      COMMAND
+12345 ??       /Users/me/.bun/bin/claude --session-id 11111111-2222-4333-8444-555555555555
+`
+	stubPS(t, psOutput, nil)
+	osCalled := false
+	stubRunnerOutput(t, func(args []string) ([]byte, error) {
+		osCalled = true
+		return nil, nil
+	})
+
+	focused, err := FocusSession(uuid)
+	if focused || err != nil {
+		t.Errorf("got (%v, %v); want (false, nil) for ?? tty", focused, err)
+	}
+	if osCalled {
+		t.Error("osascript should not be called when tty is ??")
+	}
+}
+
+// TestFocusSessionScriptMissReturnsFalse covers the case where ps
+// found a match but iTerm2's AppleScript walked all sessions without
+// finding the tty (e.g., the claude is in a non-iTerm tty, or the
+// session was closed between ps and osascript).
+func TestFocusSessionScriptMissReturnsFalse(t *testing.T) {
+	const uuid = "11111111-2222-4333-8444-555555555555"
+	const psOutput = `  PID TTY      COMMAND
+12345 ttys012  /Users/me/.bun/bin/claude --session-id 11111111-2222-4333-8444-555555555555
+`
+	stubPS(t, psOutput, nil)
+	stubRunnerOutput(t, func(args []string) ([]byte, error) {
+		return []byte("miss"), nil
+	})
+
+	focused, err := FocusSession(uuid)
+	if focused || err != nil {
+		t.Errorf("got (%v, %v); want (false, nil) for script miss", focused, err)
+	}
+}
+
+// TestFocusSessionPSError surfaces the error to the caller instead of
+// silently treating it as "no match". The caller can then decide
+// whether to fall through or surface to the user.
+func TestFocusSessionPSError(t *testing.T) {
+	stubPS(t, "", errors.New("ps blew up"))
+	focused, err := FocusSession("11111111-2222-4333-8444-555555555555")
+	if focused {
+		t.Error("focused should be false on ps error")
+	}
+	if err == nil {
+		t.Error("expected ps error to be surfaced")
+	}
+}
+
+// TestFocusSessionOsascriptError surfaces the error too — distinguishes
+// "the focus mechanism broke" from "no match found" so the caller can
+// log it.
+func TestFocusSessionOsascriptError(t *testing.T) {
+	const uuid = "11111111-2222-4333-8444-555555555555"
+	const psOutput = `  PID TTY      COMMAND
+12345 ttys012  /Users/me/.bun/bin/claude --session-id 11111111-2222-4333-8444-555555555555
+`
+	stubPS(t, psOutput, nil)
+	stubRunnerOutput(t, func(args []string) ([]byte, error) {
+		return nil, errors.New("osascript exit 1")
+	})
+
+	focused, err := FocusSession(uuid)
+	if focused {
+		t.Error("focused should be false on osascript error")
+	}
+	if err == nil {
+		t.Error("expected osascript error to be surfaced")
+	}
+}
+
+func stubPS(t *testing.T, out string, retErr error) {
+	t.Helper()
+	old := PSRunner
+	PSRunner = func() ([]byte, error) {
+		return []byte(out), retErr
+	}
+	t.Cleanup(func() { PSRunner = old })
+}
+
+func stubRunnerOutput(t *testing.T, fn func([]string) ([]byte, error)) {
+	t.Helper()
+	old := RunnerOutput
+	RunnerOutput = fn
+	t.Cleanup(func() { RunnerOutput = old })
+}

--- a/internal/kitty/kitty.go
+++ b/internal/kitty/kitty.go
@@ -31,8 +31,10 @@
 package kitty
 
 import (
+	"encoding/json"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"sort"
 	"strings"
 )
@@ -93,6 +95,113 @@ func SpawnTab(title, cwd, command string, envVars map[string]string) error {
 	flat := strings.ReplaceAll(command, "\n", " ")
 	line := " " + envPrefix + flat + "\n"
 	return Runner([]string{"@", "send-text", "--match=id:" + windowID, line})
+}
+
+// FocusSession tries to focus the kitty window currently running
+// `claude` with the given session UUID. Returns (true, nil) on focus,
+// (false, nil) if no window across any kitty OS window matches, and
+// (false, err) only on a backend failure (kitty CLI errored or returned
+// malformed JSON).
+//
+// Mechanism: `kitty @ ls` returns the full OS-window → tab → window
+// tree. Each terminal window's foreground_processes array carries the
+// argv of the child processes currently running under that PTY — the
+// `claude` invocation lives there, not in the window's own cmdline
+// (which is the shell). We join each foreground process's cmdline with
+// spaces, apply the same UUID regex used by the iterm / zellij backends,
+// and call `kitty @ focus-window --match=id:<id>` on the first hit.
+// That single call raises the OS window, selects the tab, and focuses
+// the window — no need to chain focus-tab.
+//
+// Scope: unlike zellij's `list-panes` (which only sees the current
+// zellij session), `kitty @ ls` enumerates every OS window the kitty
+// instance owns, so cross-OS-window focus works without any extra IPC.
+//
+// Prereq: `allow_remote_control yes` in kitty.conf — same as SpawnTab.
+// If remote control is disabled, `kitty @ ls` exits non-zero and the
+// error is surfaced wrapped.
+func FocusSession(sessionID string) (bool, error) {
+	if sessionID == "" {
+		return false, nil
+	}
+	out, err := RunnerOutput([]string{"@", "ls"})
+	if err != nil {
+		return false, fmt.Errorf("kitty @ ls: %w", err)
+	}
+	winID, ok, err := windowIDForClaudeSession(out, sessionID)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, nil
+	}
+	if err := Runner([]string{"@", "focus-window", fmt.Sprintf("--match=id:%d", winID)}); err != nil {
+		return false, fmt.Errorf("kitty @ focus-window: %w", err)
+	}
+	return true, nil
+}
+
+// kittyOSWindow / kittyTab / kittyWindow / kittyFGProc are the minimal
+// subset of the `kitty @ ls` JSON schema we care about. The full schema
+// has many more fields (geometry, env, title, padding, etc.) but only
+// the window id and the foreground_processes cmdline matter for focus
+// matching.
+type kittyOSWindow struct {
+	Tabs []kittyTab `json:"tabs"`
+}
+type kittyTab struct {
+	Windows []kittyWindow `json:"windows"`
+}
+type kittyWindow struct {
+	ID                  int           `json:"id"`
+	ForegroundProcesses []kittyFGProc `json:"foreground_processes"`
+}
+type kittyFGProc struct {
+	Cmdline []string `json:"cmdline"`
+}
+
+// claudeSessionRowRe matches a `claude` invocation carrying a session
+// UUID in argv. Same shape as the iterm and zellij regex so focus
+// behaviour stays consistent across backends.
+var claudeSessionRowRe = regexp.MustCompile(
+	`(?:--session-id|--resume)[ =]([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})`,
+)
+
+// windowIDForClaudeSession parses `kitty @ ls` JSON and returns the
+// kitty window id of the first window whose foreground_processes
+// contain a `claude` process running with the given session UUID.
+// Returns (0, false, nil) on no match, (0, false, err) only on JSON
+// parse failure.
+func windowIDForClaudeSession(jsonBytes []byte, sessionID string) (int, bool, error) {
+	var osWindows []kittyOSWindow
+	if err := json.Unmarshal(jsonBytes, &osWindows); err != nil {
+		return 0, false, fmt.Errorf("parse kitty ls JSON: %w", err)
+	}
+	needle := strings.ToLower(sessionID)
+	for _, osw := range osWindows {
+		for _, tab := range osw.Tabs {
+			for _, win := range tab.Windows {
+				for _, proc := range win.ForegroundProcesses {
+					if len(proc.Cmdline) == 0 {
+						continue
+					}
+					joined := strings.Join(proc.Cmdline, " ")
+					if !strings.Contains(joined, "claude") {
+						continue
+					}
+					matches := claudeSessionRowRe.FindStringSubmatch(joined)
+					if len(matches) < 2 {
+						continue
+					}
+					if strings.ToLower(matches[1]) != needle {
+						continue
+					}
+					return win.ID, true, nil
+				}
+			}
+		}
+	}
+	return 0, false, nil
 }
 
 // ShellQuote wraps s in single quotes with proper escaping. Same

--- a/internal/kitty/kitty_test.go
+++ b/internal/kitty/kitty_test.go
@@ -159,6 +159,258 @@ func stubRunnerOutput(t *testing.T, fn func([]string) ([]byte, error)) {
 	t.Cleanup(func() { RunnerOutput = old })
 }
 
+// TestFocusSessionEmptyID short-circuits without invoking kitty.
+func TestFocusSessionEmptyID(t *testing.T) {
+	rCalled := false
+	stubRunnerOutput(t, func(args []string) ([]byte, error) {
+		rCalled = true
+		return nil, nil
+	})
+	focused, err := FocusSession("")
+	if focused || err != nil {
+		t.Errorf("FocusSession(\"\") = (%v, %v); want (false, nil)", focused, err)
+	}
+	if rCalled {
+		t.Error("RunnerOutput should not be called for empty session id")
+	}
+}
+
+// TestFocusSessionMatchesAndFocuses verifies the happy path: a
+// foreground process under a kitty window runs claude with the target
+// UUID, and FocusSession issues `kitty @ focus-window --match=id:<n>`
+// for that window.
+func TestFocusSessionMatchesAndFocuses(t *testing.T) {
+	const uuid = "c18a6fe7-7cb0-4875-93d5-6ad1e9785763"
+	listJSON := `[
+	  {"tabs": [
+	    {"windows": [
+	      {"id": 3, "foreground_processes": [{"cmdline": ["/opt/homebrew/bin/fish"]}]},
+	      {"id": 7, "foreground_processes": [
+	        {"cmdline": ["/opt/homebrew/bin/fish"]},
+	        {"cmdline": ["claude", "--session-id", "c18a6fe7-7cb0-4875-93d5-6ad1e9785763", "You are the execution session"]}
+	      ]}
+	    ]}
+	  ]}
+	]`
+	stubRunnerOutput(t, func(args []string) ([]byte, error) {
+		want := []string{"@", "ls"}
+		if !slices.Equal(args, want) {
+			t.Errorf("RunnerOutput args = %v; want %v", args, want)
+		}
+		return []byte(listJSON), nil
+	})
+
+	var focusArgs []string
+	old := Runner
+	Runner = func(args []string) error {
+		focusArgs = append([]string(nil), args...)
+		return nil
+	}
+	t.Cleanup(func() { Runner = old })
+
+	focused, err := FocusSession(uuid)
+	if err != nil {
+		t.Fatalf("FocusSession: %v", err)
+	}
+	if !focused {
+		t.Fatal("expected focused=true")
+	}
+	want := []string{"@", "focus-window", "--match=id:7"}
+	if !slices.Equal(focusArgs, want) {
+		t.Errorf("focus argv = %v; want %v", focusArgs, want)
+	}
+}
+
+// TestFocusSessionResumeFlag covers `--resume <uuid>` in argv.
+func TestFocusSessionResumeFlag(t *testing.T) {
+	const uuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	listJSON := `[
+	  {"tabs": [
+	    {"windows": [
+	      {"id": 11, "foreground_processes": [
+	        {"cmdline": ["claude", "--resume", "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"]}
+	      ]}
+	    ]}
+	  ]}
+	]`
+	stubRunnerOutput(t, func(args []string) ([]byte, error) { return []byte(listJSON), nil })
+	var focusArgs []string
+	old := Runner
+	Runner = func(args []string) error { focusArgs = args; return nil }
+	t.Cleanup(func() { Runner = old })
+
+	focused, err := FocusSession(uuid)
+	if err != nil || !focused {
+		t.Fatalf("got (%v, %v); want (true, nil)", focused, err)
+	}
+	want := []string{"@", "focus-window", "--match=id:11"}
+	if !slices.Equal(focusArgs, want) {
+		t.Errorf("focus argv = %v; want %v", focusArgs, want)
+	}
+}
+
+// TestFocusSessionUUIDCaseInsensitive — UUID match is case-insensitive,
+// matching the iterm / zellij behaviour.
+func TestFocusSessionUUIDCaseInsensitive(t *testing.T) {
+	const uuid = "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE"
+	listJSON := `[
+	  {"tabs": [
+	    {"windows": [
+	      {"id": 9, "foreground_processes": [
+	        {"cmdline": ["claude", "--session-id", "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"]}
+	      ]}
+	    ]}
+	  ]}
+	]`
+	stubRunnerOutput(t, func(args []string) ([]byte, error) { return []byte(listJSON), nil })
+	old := Runner
+	Runner = func(args []string) error { return nil }
+	t.Cleanup(func() { Runner = old })
+
+	focused, err := FocusSession(uuid)
+	if err != nil || !focused {
+		t.Errorf("uppercase UUID should match lowercase cmdline; got (%v, %v)", focused, err)
+	}
+}
+
+// TestFocusSessionAcrossOSWindows — the match scan walks every OS
+// window, not just the first.
+func TestFocusSessionAcrossOSWindows(t *testing.T) {
+	const uuid = "11111111-2222-4333-8444-555555555555"
+	listJSON := `[
+	  {"tabs": [
+	    {"windows": [{"id": 1, "foreground_processes": [{"cmdline": ["/bin/zsh"]}]}]}
+	  ]},
+	  {"tabs": [
+	    {"windows": [
+	      {"id": 22, "foreground_processes": [
+	        {"cmdline": ["claude", "--session-id", "11111111-2222-4333-8444-555555555555"]}
+	      ]}
+	    ]}
+	  ]}
+	]`
+	stubRunnerOutput(t, func(args []string) ([]byte, error) { return []byte(listJSON), nil })
+	var focusArgs []string
+	old := Runner
+	Runner = func(args []string) error { focusArgs = args; return nil }
+	t.Cleanup(func() { Runner = old })
+
+	focused, err := FocusSession(uuid)
+	if err != nil || !focused {
+		t.Fatalf("got (%v, %v); want (true, nil)", focused, err)
+	}
+	want := []string{"@", "focus-window", "--match=id:22"}
+	if !slices.Equal(focusArgs, want) {
+		t.Errorf("focus argv = %v; want %v", focusArgs, want)
+	}
+}
+
+// TestFocusSessionNoMatch — no foreground process under any window
+// runs claude with the target UUID; Runner must not be called.
+func TestFocusSessionNoMatch(t *testing.T) {
+	listJSON := `[
+	  {"tabs": [
+	    {"windows": [
+	      {"id": 2, "foreground_processes": [{"cmdline": ["/opt/homebrew/bin/fish"]}]},
+	      {"id": 4, "foreground_processes": [{"cmdline": ["claude"]}]}
+	    ]}
+	  ]}
+	]`
+	stubRunnerOutput(t, func(args []string) ([]byte, error) { return []byte(listJSON), nil })
+	rCalled := false
+	old := Runner
+	Runner = func(args []string) error { rCalled = true; return nil }
+	t.Cleanup(func() { Runner = old })
+
+	focused, err := FocusSession("11111111-2222-4333-8444-555555555555")
+	if focused || err != nil {
+		t.Errorf("got (%v, %v); want (false, nil)", focused, err)
+	}
+	if rCalled {
+		t.Error("Runner should not be called when no window matches")
+	}
+}
+
+// TestFocusSessionSkipsWindowsWithoutClaude — windows whose
+// foreground_processes do not include the substring `claude` are
+// skipped without running the regex (cheap fast-path).
+func TestFocusSessionSkipsWindowsWithoutClaude(t *testing.T) {
+	listJSON := `[
+	  {"tabs": [
+	    {"windows": [
+	      {"id": 5, "foreground_processes": [{"cmdline": ["vim", "--session-id", "11111111-2222-4333-8444-555555555555"]}]}
+	    ]}
+	  ]}
+	]`
+	stubRunnerOutput(t, func(args []string) ([]byte, error) { return []byte(listJSON), nil })
+	rCalled := false
+	old := Runner
+	Runner = func(args []string) error { rCalled = true; return nil }
+	t.Cleanup(func() { Runner = old })
+
+	// Even though the cmdline contains a UUID that matches the regex,
+	// the absence of `claude` in the joined cmdline must short-circuit.
+	focused, err := FocusSession("11111111-2222-4333-8444-555555555555")
+	if focused || err != nil {
+		t.Errorf("got (%v, %v); want (false, nil)", focused, err)
+	}
+	if rCalled {
+		t.Error("Runner should not be called for non-claude foreground processes")
+	}
+}
+
+// TestFocusSessionLsError surfaces a `kitty @ ls` failure as a
+// backend error (distinct from "no match found"), wrapped with the
+// command context.
+func TestFocusSessionLsError(t *testing.T) {
+	stubRunnerOutput(t, func(args []string) ([]byte, error) {
+		return nil, errors.New("exit status 1: remote control is not enabled")
+	})
+	focused, err := FocusSession("11111111-2222-4333-8444-555555555555")
+	if focused || err == nil {
+		t.Errorf("got (%v, %v); want (false, non-nil)", focused, err)
+	}
+	if !strings.Contains(err.Error(), "kitty @ ls") {
+		t.Errorf("expected error to mention `kitty @ ls`, got: %v", err)
+	}
+}
+
+// TestFocusSessionFocusError — a focus-window failure surfaces as a
+// backend error, not as "no match".
+func TestFocusSessionFocusError(t *testing.T) {
+	const uuid = "11111111-2222-4333-8444-555555555555"
+	listJSON := `[
+	  {"tabs": [
+	    {"windows": [
+	      {"id": 13, "foreground_processes": [
+	        {"cmdline": ["claude", "--session-id", "11111111-2222-4333-8444-555555555555"]}
+	      ]}
+	    ]}
+	  ]}
+	]`
+	stubRunnerOutput(t, func(args []string) ([]byte, error) { return []byte(listJSON), nil })
+	old := Runner
+	Runner = func(args []string) error { return errors.New("kitty failed") }
+	t.Cleanup(func() { Runner = old })
+
+	focused, err := FocusSession(uuid)
+	if focused || err == nil {
+		t.Errorf("got (%v, %v); want (false, non-nil)", focused, err)
+	}
+	if !strings.Contains(err.Error(), "kitty @ focus-window") {
+		t.Errorf("expected error to mention `kitty @ focus-window`, got: %v", err)
+	}
+}
+
+// TestFocusSessionMalformedJSON — guard against kitty output drift.
+func TestFocusSessionMalformedJSON(t *testing.T) {
+	stubRunnerOutput(t, func(args []string) ([]byte, error) { return []byte("{not json"), nil })
+	focused, err := FocusSession("11111111-2222-4333-8444-555555555555")
+	if focused || err == nil {
+		t.Errorf("got (%v, %v); want (false, non-nil) for malformed JSON", focused, err)
+	}
+}
+
 // TestShellQuote — same contract as iterm/terminal/zellij.
 func TestShellQuote(t *testing.T) {
 	cases := []struct {

--- a/internal/spawner/spawner.go
+++ b/internal/spawner/spawner.go
@@ -103,6 +103,30 @@ func SpawnTab(title, cwd, command string, envVars map[string]string) error {
 	}
 }
 
+// FocusSession tries to focus an existing tab/pane that is already
+// running `claude` with the given session UUID. Returns (true, nil)
+// on focus, (false, nil) if no matching tab was found in the active
+// backend, and (false, err) only on a backend failure.
+//
+// Callers should treat (false, nil) as "fall through" — typically by
+// surfacing the existing "session running elsewhere" error so the
+// user knows to switch manually or pass --force.
+//
+// Backend dispatch mirrors SpawnTab:
+//   - Zellij: list-panes JSON match on pane_command + focus-pane-id
+//   - Terminal.app: pid → tty via ps, then osascript walk
+//   - iTerm2 (default): pid → tty via ps, then osascript walk
+func FocusSession(sessionID string) (bool, error) {
+	switch Detect() {
+	case BackendZellij:
+		return zellij.FocusSession(sessionID)
+	case BackendTerminal:
+		return terminal.FocusSession(sessionID)
+	default:
+		return iterm.FocusSession(sessionID)
+	}
+}
+
 // ShellQuote is re-exported so callers don't need to import the chosen
 // backend just to quote a value before handing it to SpawnTab. All
 // backends quote identically (POSIX single-quote with embedded-quote

--- a/internal/spawner/spawner.go
+++ b/internal/spawner/spawner.go
@@ -114,12 +114,15 @@ func SpawnTab(title, cwd, command string, envVars map[string]string) error {
 //
 // Backend dispatch mirrors SpawnTab:
 //   - Zellij: list-panes JSON match on pane_command + focus-pane-id
+//   - Kitty: `kitty @ ls` JSON match on foreground_processes cmdline + focus-window
 //   - Terminal.app: pid → tty via ps, then osascript walk
 //   - iTerm2 (default): pid → tty via ps, then osascript walk
 func FocusSession(sessionID string) (bool, error) {
 	switch Detect() {
 	case BackendZellij:
 		return zellij.FocusSession(sessionID)
+	case BackendKitty:
+		return kitty.FocusSession(sessionID)
 	case BackendTerminal:
 		return terminal.FocusSession(sessionID)
 	default:

--- a/internal/spawner/spawner_test.go
+++ b/internal/spawner/spawner_test.go
@@ -286,14 +286,14 @@ func TestFocusSessionRoutesToITerm(t *testing.T) {
 	Override = BackendITerm
 	t.Cleanup(func() { Override = "" })
 
-	itermCalled, terminalCalled, zellijCalled := stubAllFocusBackends(t)
+	flags := stubAllFocusBackends(t)
 	if _, err := FocusSession("11111111-2222-4333-8444-555555555555"); err != nil {
 		t.Fatalf("FocusSession: %v", err)
 	}
-	if !*itermCalled {
+	if !*flags.iterm {
 		t.Error("expected iterm focus path to be called")
 	}
-	if *terminalCalled || *zellijCalled {
+	if *flags.terminal || *flags.zellij || *flags.kitty {
 		t.Error("only iterm focus path should be called")
 	}
 }
@@ -304,14 +304,14 @@ func TestFocusSessionRoutesToTerminal(t *testing.T) {
 	Override = BackendTerminal
 	t.Cleanup(func() { Override = "" })
 
-	itermCalled, terminalCalled, zellijCalled := stubAllFocusBackends(t)
+	flags := stubAllFocusBackends(t)
 	if _, err := FocusSession("11111111-2222-4333-8444-555555555555"); err != nil {
 		t.Fatalf("FocusSession: %v", err)
 	}
-	if !*terminalCalled {
+	if !*flags.terminal {
 		t.Error("expected terminal focus path to be called")
 	}
-	if *itermCalled || *zellijCalled {
+	if *flags.iterm || *flags.zellij || *flags.kitty {
 		t.Error("only terminal focus path should be called")
 	}
 }
@@ -322,24 +322,51 @@ func TestFocusSessionRoutesToZellij(t *testing.T) {
 	Override = BackendZellij
 	t.Cleanup(func() { Override = "" })
 
-	itermCalled, terminalCalled, zellijCalled := stubAllFocusBackends(t)
+	flags := stubAllFocusBackends(t)
 	if _, err := FocusSession("11111111-2222-4333-8444-555555555555"); err != nil {
 		t.Fatalf("FocusSession: %v", err)
 	}
-	if !*zellijCalled {
+	if !*flags.zellij {
 		t.Error("expected zellij focus path to be called")
 	}
-	if *itermCalled || *terminalCalled {
+	if *flags.iterm || *flags.terminal || *flags.kitty {
 		t.Error("only zellij focus path should be called")
 	}
+}
+
+// TestFocusSessionRoutesToKitty — Override=Kitty hits the kitty
+// backend. The kitty backend uses `kitty @ ls` JSON rather than
+// ps/tty, so the stub returns an empty OS-window list which yields
+// (false, nil) without invoking the focus call.
+func TestFocusSessionRoutesToKitty(t *testing.T) {
+	Override = BackendKitty
+	t.Cleanup(func() { Override = "" })
+
+	flags := stubAllFocusBackends(t)
+	if _, err := FocusSession("11111111-2222-4333-8444-555555555555"); err != nil {
+		t.Fatalf("FocusSession: %v", err)
+	}
+	if !*flags.kitty {
+		t.Error("expected kitty focus path to be called")
+	}
+	if *flags.iterm || *flags.terminal || *flags.zellij {
+		t.Error("only kitty focus path should be called")
+	}
+}
+
+// focusFlags bundles per-backend "was called" flags so the focus
+// routing tests can assert which backend FocusSession dispatched to
+// without an awkward multi-return-value tuple.
+type focusFlags struct {
+	iterm, terminal, zellij, kitty *bool
 }
 
 // stubAllFocusBackends replaces the per-backend PSRunner / RunnerOutput
 // vars with stubs that flip a bool when the backend's FocusSession
 // path runs. Restores originals on cleanup.
-func stubAllFocusBackends(t *testing.T) (*bool, *bool, *bool) {
+func stubAllFocusBackends(t *testing.T) focusFlags {
 	t.Helper()
-	var itermCalled, terminalCalled, zellijCalled bool
+	var itermCalled, terminalCalled, zellijCalled, kittyCalled bool
 
 	oldITermPS := iterm.PSRunner
 	iterm.PSRunner = func() ([]byte, error) {
@@ -362,7 +389,19 @@ func stubAllFocusBackends(t *testing.T) (*bool, *bool, *bool) {
 	}
 	t.Cleanup(func() { zellij.RunnerOutput = oldZellijRO })
 
-	return &itermCalled, &terminalCalled, &zellijCalled
+	oldKittyRO := kitty.RunnerOutput
+	kitty.RunnerOutput = func(args []string) ([]byte, error) {
+		kittyCalled = true
+		return []byte("[]"), nil // empty OS-window list -> (false, nil)
+	}
+	t.Cleanup(func() { kitty.RunnerOutput = oldKittyRO })
+
+	return focusFlags{
+		iterm:    &itermCalled,
+		terminal: &terminalCalled,
+		zellij:   &zellijCalled,
+		kitty:    &kittyCalled,
+	}
 }
 
 // TestShellQuoteParity makes sure the re-exported helper matches

--- a/internal/spawner/spawner_test.go
+++ b/internal/spawner/spawner_test.go
@@ -280,6 +280,91 @@ func TestSpawnTabRoutesToGhostty(t *testing.T) {
 	}
 }
 
+// TestFocusSessionRoutesToITerm — when Detect() resolves to iTerm,
+// FocusSession invokes the iterm backend.
+func TestFocusSessionRoutesToITerm(t *testing.T) {
+	Override = BackendITerm
+	t.Cleanup(func() { Override = "" })
+
+	itermCalled, terminalCalled, zellijCalled := stubAllFocusBackends(t)
+	if _, err := FocusSession("11111111-2222-4333-8444-555555555555"); err != nil {
+		t.Fatalf("FocusSession: %v", err)
+	}
+	if !*itermCalled {
+		t.Error("expected iterm focus path to be called")
+	}
+	if *terminalCalled || *zellijCalled {
+		t.Error("only iterm focus path should be called")
+	}
+}
+
+// TestFocusSessionRoutesToTerminal — Override=Terminal hits the
+// terminal backend.
+func TestFocusSessionRoutesToTerminal(t *testing.T) {
+	Override = BackendTerminal
+	t.Cleanup(func() { Override = "" })
+
+	itermCalled, terminalCalled, zellijCalled := stubAllFocusBackends(t)
+	if _, err := FocusSession("11111111-2222-4333-8444-555555555555"); err != nil {
+		t.Fatalf("FocusSession: %v", err)
+	}
+	if !*terminalCalled {
+		t.Error("expected terminal focus path to be called")
+	}
+	if *itermCalled || *zellijCalled {
+		t.Error("only terminal focus path should be called")
+	}
+}
+
+// TestFocusSessionRoutesToZellij — Override=Zellij hits the zellij
+// backend.
+func TestFocusSessionRoutesToZellij(t *testing.T) {
+	Override = BackendZellij
+	t.Cleanup(func() { Override = "" })
+
+	itermCalled, terminalCalled, zellijCalled := stubAllFocusBackends(t)
+	if _, err := FocusSession("11111111-2222-4333-8444-555555555555"); err != nil {
+		t.Fatalf("FocusSession: %v", err)
+	}
+	if !*zellijCalled {
+		t.Error("expected zellij focus path to be called")
+	}
+	if *itermCalled || *terminalCalled {
+		t.Error("only zellij focus path should be called")
+	}
+}
+
+// stubAllFocusBackends replaces the per-backend PSRunner / RunnerOutput
+// vars with stubs that flip a bool when the backend's FocusSession
+// path runs. Restores originals on cleanup.
+func stubAllFocusBackends(t *testing.T) (*bool, *bool, *bool) {
+	t.Helper()
+	var itermCalled, terminalCalled, zellijCalled bool
+
+	oldITermPS := iterm.PSRunner
+	iterm.PSRunner = func() ([]byte, error) {
+		itermCalled = true
+		return []byte(""), nil // empty ps output -> ttyForClaudeSession returns "" -> (false, nil)
+	}
+	t.Cleanup(func() { iterm.PSRunner = oldITermPS })
+
+	oldTermPS := terminal.PSRunner
+	terminal.PSRunner = func() ([]byte, error) {
+		terminalCalled = true
+		return []byte(""), nil
+	}
+	t.Cleanup(func() { terminal.PSRunner = oldTermPS })
+
+	oldZellijRO := zellij.RunnerOutput
+	zellij.RunnerOutput = func(args []string) ([]byte, error) {
+		zellijCalled = true
+		return []byte("[]"), nil // empty pane list -> (false, nil)
+	}
+	t.Cleanup(func() { zellij.RunnerOutput = oldZellijRO })
+
+	return &itermCalled, &terminalCalled, &zellijCalled
+}
+
 // TestShellQuoteParity makes sure the re-exported helper matches
 // every backend's implementation. All backends quote identically.
 func TestShellQuoteParity(t *testing.T) {

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -13,6 +13,7 @@ package terminal
 import (
 	"fmt"
 	"os/exec"
+	"regexp"
 	"sort"
 	"strings"
 )
@@ -26,6 +27,20 @@ var Runner = func(args []string) error {
 		return fmt.Errorf("osascript failed: %v: %s", err, string(out))
 	}
 	return nil
+}
+
+// RunnerOutput executes osascript and returns stdout. Used by
+// FocusSession when the AppleScript itself reports match/miss via its
+// stdout. Separate var from Runner so SpawnTab tests stay untouched.
+var RunnerOutput = func(args []string) ([]byte, error) {
+	return exec.Command("osascript", args...).Output()
+}
+
+// PSRunner returns the output of `ps -axo pid,tty,command`. Overridable
+// for tests. Includes tty so FocusSession can map a claude PID → tty
+// → Terminal.app tab in one pass.
+var PSRunner = func() ([]byte, error) {
+	return exec.Command("ps", "-axo", "pid,tty,command").Output()
 }
 
 // SpawnTab opens a new Terminal.app tab with the given title, cwd, and
@@ -149,6 +164,101 @@ How to grant it:
 After the grant, future "flow do" invocations from Terminal.app spawn tabs silently with no further prompts.
 
 Underlying osascript error: %w`, err)
+}
+
+// FocusSession tries to focus the Terminal.app tab whose underlying
+// process is `claude` running with `--session-id <sessionID>` or
+// `--resume <sessionID>`. Returns (true, nil) on focus, (false, nil)
+// if no matching tab was found in Terminal.app, and (false, err) only
+// on a backend (ps / osascript) failure.
+//
+// Mechanism: scan `ps -axo pid,tty,command` for a claude process whose
+// argv contains the session UUID, extract its controlling tty, then
+// drive osascript to walk every window/tab and select the one whose
+// `tty` property matches.
+func FocusSession(sessionID string) (bool, error) {
+	if sessionID == "" {
+		return false, nil
+	}
+	tty, err := ttyForClaudeSession(sessionID)
+	if err != nil {
+		return false, err
+	}
+	if tty == "" {
+		return false, nil
+	}
+	return focusByTTY(tty)
+}
+
+// claudeSessionRowRe matches a `ps` line that has BOTH a `claude` token
+// and a `--session-id <uuid>` or `--resume <uuid>` flag.
+var claudeSessionRowRe = regexp.MustCompile(
+	`(?:--session-id|--resume)[ =]([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})`,
+)
+
+// ttyForClaudeSession returns the controlling tty (e.g., "/dev/ttys012")
+// of the claude process running with the given session UUID, or "" if
+// no such process is currently running.
+func ttyForClaudeSession(sessionID string) (string, error) {
+	out, err := PSRunner()
+	if err != nil {
+		return "", fmt.Errorf("ps: %w", err)
+	}
+	needle := strings.ToLower(sessionID)
+	for _, line := range strings.Split(string(out), "\n") {
+		if !strings.Contains(line, "claude") {
+			continue
+		}
+		matches := claudeSessionRowRe.FindStringSubmatch(line)
+		if len(matches) < 2 {
+			continue
+		}
+		if strings.ToLower(matches[1]) != needle {
+			continue
+		}
+		// `ps -axo pid,tty,command` columns: pid, tty, command. After
+		// Fields() splits on whitespace, fields[1] is the tty.
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		tty := fields[1]
+		if tty == "??" || tty == "?" || tty == "" {
+			continue
+		}
+		if !strings.HasPrefix(tty, "/dev/") {
+			tty = "/dev/" + tty
+		}
+		return tty, nil
+	}
+	return "", nil
+}
+
+// focusByTTY drives Terminal.app's AppleScript dictionary to find a
+// tab whose `tty` property matches and select it. Terminal.app
+// addresses tabs at the window level (no separate session object
+// like iTerm2). The script writes "ok" on match and "miss" otherwise.
+func focusByTTY(tty string) (bool, error) {
+	safeTTY := escapeAppleScriptString(tty)
+	script := fmt.Sprintf(`tell application "Terminal"
+  activate
+  repeat with w in windows
+    repeat with t in tabs of w
+      if tty of t is "%s" then
+        set frontmost of w to true
+        set selected of t to true
+        return "ok"
+      end if
+    end repeat
+  end repeat
+  return "miss"
+end tell
+`, safeTTY)
+	out, err := RunnerOutput([]string{"-e", script})
+	if err != nil {
+		return false, fmt.Errorf("osascript: %w", err)
+	}
+	return strings.TrimSpace(string(out)) == "ok", nil
 }
 
 // ShellQuote wraps s in single quotes with proper escaping.

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -165,6 +165,123 @@ func TestIsAccessibilityDenied(t *testing.T) {
 	}
 }
 
+// TestFocusSessionEmptyID short-circuits without touching ps.
+func TestFocusSessionEmptyID(t *testing.T) {
+	psCalled := false
+	old := PSRunner
+	PSRunner = func() ([]byte, error) { psCalled = true; return nil, nil }
+	t.Cleanup(func() { PSRunner = old })
+
+	focused, err := FocusSession("")
+	if focused || err != nil {
+		t.Errorf("FocusSession(\"\") = (%v, %v); want (false, nil)", focused, err)
+	}
+	if psCalled {
+		t.Error("PSRunner should not be called for empty session id")
+	}
+}
+
+// TestFocusSessionMatchesAndFocuses verifies the happy path drives
+// osascript with the right tty against Terminal.app's dictionary.
+func TestFocusSessionMatchesAndFocuses(t *testing.T) {
+	const uuid = "11111111-2222-4333-8444-555555555555"
+	const psOutput = `  PID TTY      COMMAND
+12345 ttys012  /Users/me/.bun/bin/claude --session-id 11111111-2222-4333-8444-555555555555
+`
+	stubPS(t, psOutput, nil)
+	var captured []string
+	stubRunnerOutput(t, func(args []string) ([]byte, error) {
+		captured = args
+		return []byte("ok\n"), nil
+	})
+
+	focused, err := FocusSession(uuid)
+	if err != nil || !focused {
+		t.Fatalf("FocusSession = (%v, %v); want (true, nil)", focused, err)
+	}
+	if len(captured) < 2 {
+		t.Fatalf("RunnerOutput called with %d args; want >=2", len(captured))
+	}
+	script := captured[1]
+	if !strings.Contains(script, `tell application "Terminal"`) {
+		t.Errorf("script does not target Terminal.app: %s", script)
+	}
+	if !strings.Contains(script, `if tty of t is "/dev/ttys012"`) {
+		t.Errorf("script does not match /dev/ttys012: %s", script)
+	}
+}
+
+// TestFocusSessionScriptMissReturnsFalse — ps found a match but the
+// AppleScript walked all tabs without finding the tty.
+func TestFocusSessionScriptMissReturnsFalse(t *testing.T) {
+	const uuid = "11111111-2222-4333-8444-555555555555"
+	stubPS(t, `  PID TTY      COMMAND
+12345 ttys012  /usr/local/bin/claude --session-id 11111111-2222-4333-8444-555555555555
+`, nil)
+	stubRunnerOutput(t, func(args []string) ([]byte, error) { return []byte("miss"), nil })
+
+	focused, err := FocusSession(uuid)
+	if focused || err != nil {
+		t.Errorf("got (%v, %v); want (false, nil) for script miss", focused, err)
+	}
+}
+
+// TestFocusSessionPSError surfaces ps failures.
+func TestFocusSessionPSError(t *testing.T) {
+	stubPS(t, "", errors.New("ps blew up"))
+	focused, err := FocusSession("11111111-2222-4333-8444-555555555555")
+	if focused || err == nil {
+		t.Errorf("got (%v, %v); want (false, non-nil)", focused, err)
+	}
+}
+
+// TestFocusSessionOsascriptError surfaces script-runtime failures
+// distinct from "no match".
+func TestFocusSessionOsascriptError(t *testing.T) {
+	const uuid = "11111111-2222-4333-8444-555555555555"
+	stubPS(t, `  PID TTY      COMMAND
+12345 ttys012  /usr/local/bin/claude --session-id 11111111-2222-4333-8444-555555555555
+`, nil)
+	stubRunnerOutput(t, func(args []string) ([]byte, error) { return nil, errors.New("osascript exit 1") })
+
+	focused, err := FocusSession(uuid)
+	if focused || err == nil {
+		t.Errorf("got (%v, %v); want (false, non-nil)", focused, err)
+	}
+}
+
+// TestFocusSessionSkipsNoControllingTTY ignores claude rows whose tty is "??".
+func TestFocusSessionSkipsNoControllingTTY(t *testing.T) {
+	const uuid = "11111111-2222-4333-8444-555555555555"
+	stubPS(t, `  PID TTY      COMMAND
+12345 ??       /usr/local/bin/claude --session-id 11111111-2222-4333-8444-555555555555
+`, nil)
+	osCalled := false
+	stubRunnerOutput(t, func(args []string) ([]byte, error) { osCalled = true; return nil, nil })
+
+	focused, err := FocusSession(uuid)
+	if focused || err != nil {
+		t.Errorf("got (%v, %v); want (false, nil)", focused, err)
+	}
+	if osCalled {
+		t.Error("osascript should not be called when tty is ??")
+	}
+}
+
+func stubPS(t *testing.T, out string, retErr error) {
+	t.Helper()
+	old := PSRunner
+	PSRunner = func() ([]byte, error) { return []byte(out), retErr }
+	t.Cleanup(func() { PSRunner = old })
+}
+
+func stubRunnerOutput(t *testing.T, fn func([]string) ([]byte, error)) {
+	t.Helper()
+	old := RunnerOutput
+	RunnerOutput = fn
+	t.Cleanup(func() { RunnerOutput = old })
+}
+
 // TestShellQuote is a sanity check on the local helper — same contract
 // as iterm.ShellQuote.
 func TestShellQuote(t *testing.T) {

--- a/internal/zellij/zellij.go
+++ b/internal/zellij/zellij.go
@@ -28,8 +28,10 @@
 package zellij
 
 import (
+	"encoding/json"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"sort"
 	"strings"
 )
@@ -43,6 +45,13 @@ var Runner = func(args []string) error {
 		return fmt.Errorf("zellij failed: %v: %s", err, string(out))
 	}
 	return nil
+}
+
+// RunnerOutput executes zellij and returns stdout. Used by FocusSession
+// to read `zellij action list-panes --all --json`. Separate var from
+// Runner so existing SpawnTab tests stay untouched.
+var RunnerOutput = func(args []string) ([]byte, error) {
+	return exec.Command("zellij", args...).Output()
 }
 
 // SpawnTab opens a new zellij tab in the current session, sets its
@@ -72,6 +81,87 @@ func SpawnTab(title, cwd, command string, envVars map[string]string) error {
 	flat := strings.ReplaceAll(command, "\n", " ")
 	line := " " + envPrefix + flat + "\n"
 	return Runner([]string{"action", "write-chars", line})
+}
+
+// FocusSession tries to focus the zellij pane currently running
+// `claude` with the given session UUID. Returns (true, nil) on focus,
+// (false, nil) if no pane in the current zellij session matches, and
+// (false, err) only on a backend failure (zellij CLI errored or
+// returned malformed JSON).
+//
+// Mechanism: `zellij action list-panes --all --json` returns every
+// pane's `pane_command` (the actual command line of the running
+// process). We scan for a pane whose command contains
+// `claude --session-id <uuid>` or `--resume <uuid>`, then call
+// `zellij action focus-pane-id terminal_<id>` to switch to it.
+//
+// Limitation: list-panes covers only the *current* zellij session.
+// If the user opened the task tab from a different zellij session,
+// this returns (false, nil) and the caller falls through to the
+// existing "running elsewhere" error.
+func FocusSession(sessionID string) (bool, error) {
+	if sessionID == "" {
+		return false, nil
+	}
+	out, err := RunnerOutput([]string{"action", "list-panes", "--all", "--json"})
+	if err != nil {
+		return false, fmt.Errorf("zellij list-panes: %w", err)
+	}
+	paneID, ok, err := paneIDForClaudeSession(out, sessionID)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, nil
+	}
+	if err := Runner([]string{"action", "focus-pane-id", fmt.Sprintf("terminal_%d", paneID)}); err != nil {
+		return false, fmt.Errorf("zellij focus-pane-id: %w", err)
+	}
+	return true, nil
+}
+
+// paneInfo is the subset of zellij's list-panes JSON we care about.
+// Pane records have many more fields (geometry, plugin metadata, etc.)
+// but only id, is_plugin, and pane_command matter for focus matching.
+type paneInfo struct {
+	ID          int    `json:"id"`
+	IsPlugin    bool   `json:"is_plugin"`
+	PaneCommand string `json:"pane_command"`
+}
+
+// claudeSessionRowRe matches `claude` invocations carrying a session
+// UUID in the same shape as the iterm/terminal regex.
+var claudeSessionRowRe = regexp.MustCompile(
+	`(?:--session-id|--resume)[ =]([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})`,
+)
+
+// paneIDForClaudeSession parses zellij list-panes JSON and returns the
+// pane id of the first non-plugin pane whose pane_command runs
+// `claude` with the given session UUID. Returns (0, false, nil) if no
+// match. Returns (0, false, err) on JSON parse failure.
+func paneIDForClaudeSession(jsonBytes []byte, sessionID string) (int, bool, error) {
+	var panes []paneInfo
+	if err := json.Unmarshal(jsonBytes, &panes); err != nil {
+		return 0, false, fmt.Errorf("parse list-panes JSON: %w", err)
+	}
+	needle := strings.ToLower(sessionID)
+	for _, p := range panes {
+		if p.IsPlugin || p.PaneCommand == "" {
+			continue
+		}
+		if !strings.Contains(p.PaneCommand, "claude") {
+			continue
+		}
+		matches := claudeSessionRowRe.FindStringSubmatch(p.PaneCommand)
+		if len(matches) < 2 {
+			continue
+		}
+		if strings.ToLower(matches[1]) != needle {
+			continue
+		}
+		return p.ID, true, nil
+	}
+	return 0, false, nil
 }
 
 // ShellQuote wraps s in single quotes with proper escaping. Same

--- a/internal/zellij/zellij_test.go
+++ b/internal/zellij/zellij_test.go
@@ -126,6 +126,196 @@ func TestSpawnTabFlattensEmbeddedNewlines(t *testing.T) {
 	}
 }
 
+// TestFocusSessionEmptyID short-circuits without invoking zellij.
+func TestFocusSessionEmptyID(t *testing.T) {
+	rCalled := false
+	old := RunnerOutput
+	RunnerOutput = func(args []string) ([]byte, error) {
+		rCalled = true
+		return nil, nil
+	}
+	t.Cleanup(func() { RunnerOutput = old })
+
+	focused, err := FocusSession("")
+	if focused || err != nil {
+		t.Errorf("FocusSession(\"\") = (%v, %v); want (false, nil)", focused, err)
+	}
+	if rCalled {
+		t.Error("RunnerOutput should not be called for empty session id")
+	}
+}
+
+// TestFocusSessionMatchesAndFocuses verifies the happy path: list-panes
+// JSON contains a non-plugin pane whose pane_command runs claude with
+// the target UUID, and FocusSession invokes focus-pane-id with the
+// matching pane id.
+func TestFocusSessionMatchesAndFocuses(t *testing.T) {
+	const uuid = "c18a6fe7-7cb0-4875-93d5-6ad1e9785763"
+	const listJSON = `[
+  {"id": 1, "is_plugin": true, "pane_command": null, "title": "tab-bar"},
+  {"id": 2, "is_plugin": false, "pane_command": "/opt/homebrew/bin/fish", "title": "shell"},
+  {"id": 16, "is_plugin": false, "pane_command": "claude --session-id c18a6fe7-7cb0-4875-93d5-6ad1e9785763 You are the execution session", "title": "task-x"}
+]`
+	stubRunnerOutput(t, func(args []string) ([]byte, error) {
+		want := []string{"action", "list-panes", "--all", "--json"}
+		for i, w := range want {
+			if i >= len(args) || args[i] != w {
+				t.Errorf("RunnerOutput args = %v; want prefix %v", args, want)
+			}
+		}
+		return []byte(listJSON), nil
+	})
+
+	var focusArgs []string
+	old := Runner
+	Runner = func(args []string) error {
+		focusArgs = args
+		return nil
+	}
+	t.Cleanup(func() { Runner = old })
+
+	focused, err := FocusSession(uuid)
+	if err != nil {
+		t.Fatalf("FocusSession: %v", err)
+	}
+	if !focused {
+		t.Fatal("expected focused=true")
+	}
+	want := []string{"action", "focus-pane-id", "terminal_16"}
+	if !slices.Equal(focusArgs, want) {
+		t.Errorf("focus argv = %v; want %v", focusArgs, want)
+	}
+}
+
+// TestFocusSessionResumeFlag — covers --resume in pane_command.
+func TestFocusSessionResumeFlag(t *testing.T) {
+	const uuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	const listJSON = `[
+  {"id": 7, "is_plugin": false, "pane_command": "claude --resume aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"}
+]`
+	stubRunnerOutput(t, func(args []string) ([]byte, error) { return []byte(listJSON), nil })
+	var focusArgs []string
+	old := Runner
+	Runner = func(args []string) error { focusArgs = args; return nil }
+	t.Cleanup(func() { Runner = old })
+
+	focused, err := FocusSession(uuid)
+	if err != nil || !focused {
+		t.Fatalf("got (%v, %v); want (true, nil)", focused, err)
+	}
+	want := []string{"action", "focus-pane-id", "terminal_7"}
+	if !slices.Equal(focusArgs, want) {
+		t.Errorf("focus argv = %v; want %v", focusArgs, want)
+	}
+}
+
+// TestFocusSessionUUIDCaseInsensitive — UUID match is case-insensitive.
+func TestFocusSessionUUIDCaseInsensitive(t *testing.T) {
+	const uuid = "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE"
+	const listJSON = `[
+  {"id": 9, "is_plugin": false, "pane_command": "claude --session-id aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"}
+]`
+	stubRunnerOutput(t, func(args []string) ([]byte, error) { return []byte(listJSON), nil })
+	old := Runner
+	Runner = func(args []string) error { return nil }
+	t.Cleanup(func() { Runner = old })
+
+	focused, err := FocusSession(uuid)
+	if err != nil || !focused {
+		t.Errorf("uppercase UUID should match lowercase pane_command; got (%v, %v)", focused, err)
+	}
+}
+
+// TestFocusSessionNoMatch — list-panes contains no claude with this UUID.
+func TestFocusSessionNoMatch(t *testing.T) {
+	const listJSON = `[
+  {"id": 2, "is_plugin": false, "pane_command": "/opt/homebrew/bin/fish"},
+  {"id": 18, "is_plugin": false, "pane_command": "claude"}
+]`
+	stubRunnerOutput(t, func(args []string) ([]byte, error) { return []byte(listJSON), nil })
+	rCalled := false
+	old := Runner
+	Runner = func(args []string) error { rCalled = true; return nil }
+	t.Cleanup(func() { Runner = old })
+
+	focused, err := FocusSession("11111111-2222-4333-8444-555555555555")
+	if focused || err != nil {
+		t.Errorf("got (%v, %v); want (false, nil)", focused, err)
+	}
+	if rCalled {
+		t.Error("Runner should not be called when no pane matches")
+	}
+}
+
+// TestFocusSessionSkipsPluginPanes — plugin panes (tab-bar, status-bar)
+// have null pane_command and must not match.
+func TestFocusSessionSkipsPluginPanes(t *testing.T) {
+	const uuid = "11111111-2222-4333-8444-555555555555"
+	// Plugin pane has the UUID in pane_command — pathological but worth
+	// guarding against. is_plugin must filter it out.
+	const listJSON = `[
+  {"id": 2, "is_plugin": true, "pane_command": "claude --session-id 11111111-2222-4333-8444-555555555555"}
+]`
+	stubRunnerOutput(t, func(args []string) ([]byte, error) { return []byte(listJSON), nil })
+	rCalled := false
+	old := Runner
+	Runner = func(args []string) error { rCalled = true; return nil }
+	t.Cleanup(func() { Runner = old })
+
+	focused, err := FocusSession(uuid)
+	if focused || err != nil {
+		t.Errorf("got (%v, %v); want (false, nil) for plugin pane", focused, err)
+	}
+	if rCalled {
+		t.Error("Runner should not be called when only plugin matched")
+	}
+}
+
+// TestFocusSessionListPanesError surfaces zellij CLI errors.
+func TestFocusSessionListPanesError(t *testing.T) {
+	stubRunnerOutput(t, func(args []string) ([]byte, error) {
+		return nil, errors.New("zellij not in a session")
+	})
+	focused, err := FocusSession("11111111-2222-4333-8444-555555555555")
+	if focused || err == nil {
+		t.Errorf("got (%v, %v); want (false, non-nil)", focused, err)
+	}
+}
+
+// TestFocusSessionFocusError surfaces focus-pane-id errors as a backend
+// failure (distinct from "no match found").
+func TestFocusSessionFocusError(t *testing.T) {
+	const uuid = "11111111-2222-4333-8444-555555555555"
+	const listJSON = `[
+  {"id": 5, "is_plugin": false, "pane_command": "claude --session-id 11111111-2222-4333-8444-555555555555"}
+]`
+	stubRunnerOutput(t, func(args []string) ([]byte, error) { return []byte(listJSON), nil })
+	old := Runner
+	Runner = func(args []string) error { return errors.New("zellij failed") }
+	t.Cleanup(func() { Runner = old })
+
+	focused, err := FocusSession(uuid)
+	if focused || err == nil {
+		t.Errorf("got (%v, %v); want (false, non-nil)", focused, err)
+	}
+}
+
+// TestFocusSessionMalformedJSON — protect against zellij output drift.
+func TestFocusSessionMalformedJSON(t *testing.T) {
+	stubRunnerOutput(t, func(args []string) ([]byte, error) { return []byte("{not json"), nil })
+	focused, err := FocusSession("11111111-2222-4333-8444-555555555555")
+	if focused || err == nil {
+		t.Errorf("got (%v, %v); want (false, non-nil) for malformed JSON", focused, err)
+	}
+}
+
+func stubRunnerOutput(t *testing.T, fn func([]string) ([]byte, error)) {
+	t.Helper()
+	old := RunnerOutput
+	RunnerOutput = fn
+	t.Cleanup(func() { RunnerOutput = old })
+}
+
 // TestShellQuote — same contract as iterm.ShellQuote / terminal.ShellQuote.
 func TestShellQuote(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## What

When `flow do <task>` detects the task's `session_id` is already running, focus that tab instead of erroring. Adds `spawner.FocusSession` with per-backend implementations across iTerm2, Terminal.app, and zellij.

## Why

Closes #27.

Today the live-session guard in `internal/app/do.go` correctly detects the duplicate-spawn case but the action it offers is poor: tell the user to manually find the tab, or pass `--force` to spawn a duplicate (which makes both processes write to the same session jsonl and race, losing transcript history).

The information needed to do better is already on the system — `ps` gives us the claude PID and tty; each terminal backend exposes a way to map that back to a tab and select it. This change wires that up.

On focus success, exits 0 with `Already open: <slug> — switched to existing tab`. On focus miss (different terminal app, different zellij session, claude relaunched without UUID flags) the existing error message is preserved so `--force` semantics are unchanged.

The skill (`internal/app/skill/SKILL.md`) is **not** modified — this is a UX improvement to an existing flow, not a new workflow Claude needs to know about.

## Test plan

- [x] `make test` passes
- [x] `go vet ./...` clean
- [x] Manually exercised on iTerm2: `flow do <task>` from another window switches to the existing tab; `--force` still spawns a duplicate; closing the original tab makes the next `flow do` resume normally
- [x] CI green (`go vet`, `go test ./...`, build on macOS + Ubuntu)
- [x] Manual exercise on zellij and Terminal.app by the reviewer if they have those backends handy
- [x] Skill unchanged — no `flow skill update` needed
- [x] `hookCommand` in `internal/app/skill.go` unchanged — no
      breaking change for existing installs

## Notes

**Backend mapping**

| Backend | Evidence | Focus call |
|---|---|---|
| iTerm2 | `ps -axo pid,tty,command` → match UUID → tty | osascript walks `every session` and selects by `tty` |
| Terminal.app | same ps lookup | osascript walks tabs, sets `selected` and `frontmost` |
| Zellij | `zellij action list-panes --all --json` → match UUID against `pane_command` | `zellij action focus-pane-id terminal_<id>` |

`spawner.FocusSession(sessionID) (focused bool, err error)` is three-valued: `(true, nil)` on focus, `(false, nil)` if no matching tab was found in the active backend (caller falls through), or `(false, err)` only on backend failure.

**Duplicate-process detection (bonus)**

When more than one claude process is detected for the same UUID (prior `--force`, or a manual `claude --resume <uuid>`), `flow do`
warns before focusing because both processes write to the same
transcript and may race. Warning goes to stderr; focus still
succeeds against the first match.

**Limitations called out in #27**

- Zellij focus is current-session only — `list-panes` doesn't see other zellij sessions. Cross-session zellij IPC is a much larger lift.
- Bare `claude` invocations stay invisible — same existing limitation as `liveClaudeSessions`. ps and `pane_command` both rely on the UUID being in argv.

**Out of scope** (called out in #27): persisting tab locators in the DB at spawn time, cross-zellij focus, cycling through duplicates, title-based fallback matching.

**Test coverage added**

- iterm: 9 new tests (happy path, --resume variant, case-insensitive UUID, no-match, no-controlling-tty, script-miss, ps error, osascript error, empty-UUID short-circuit)
- terminal: 6 new tests mirroring the iterm shape
- zellij: 9 new tests including malformed JSON guard and plugin-pane filtering
- spawner: 3 new routing tests — one per backend
- app/do: existing live-session-guard test made deterministic; new test for the focus-success path; new test capturing the duplicate-process warning on stderr
- app/sessions: 4 new tests for `countClaudeProcessesForSession`

## Related PRs

- Notification on focus: split into a separate PR stacked on this branch (`pa:feat/notify-tab-focus`)
- README logo: split into a separate PR (`pa:docs/flow-logo`)