### PR TITLE
feat: surface done/archived tasks and projects as referenceable

### DIFF
--- a/internal/app/hook.go
+++ b/internal/app/hook.go
@@ -141,8 +141,11 @@ func emitAmbientSkillHint() int {
 		"flow's data before guessing or asking. The KB at ~/.flow/kb/ holds durable " +
 		"facts; the briefs under ~/.flow/projects/<slug>/ and ~/.flow/tasks/<slug>/ " +
 		"hold project and task context. Names and context that are non-obvious from " +
-		"this conversation alone are very likely already documented there. The skill's " +
-		"§4.10 governs how to lazy-load these without reading them eagerly every turn."
+		"this conversation alone are very likely already documented there — and not " +
+		"only in active work: when the reference points at past work, also consult " +
+		"done and archived tasks/projects (which need explicit `--status done` / " +
+		"`--include-archived` flags on the list commands). The skill's §4.10 governs " +
+		"how to lazy-load these without reading them eagerly every turn."
 	return emitSessionStartContext(hint + appendStaleVersionHint())
 }
 

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -912,6 +912,12 @@ sequence at the moment the fact is heard.
 under an `other:` section. Apply the same lazy-load discipline as KB
 files: load them on demand when relevant to the work, not preemptively.
 
+**Past tasks and projects can be referenced too.** `flow list tasks` and
+`flow list projects` default to non-archived active rows; done and
+archived rows need explicit flags: `--status done` for completed work,
+`--include-archived` to include archived rows. `flow show task <slug>`
+and `flow transcript <slug>` work on done/archived tasks too.
+
 ### 4.11 Scope-creep detection (passive — surface via AskUserQuestion)
 
 This is a **passive** workflow like §5.10 — you watch the session as it


### PR DESCRIPTION
## Summary
- Extends both the ambient SessionStart hint and the skill's §4.10 to make Claude aware that done and archived tasks/projects are still referenceable, just behind explicit flags (`--status done` / `--include-archived`)
- Closes a real recall gap: when a user mentions prior work, Claude was defaulting to "no context exists" because the default list commands hide done/archived rows

## What changed
- `internal/app/hook.go` — ambient hint now names done/archived as referenceable and points at the flags needed to surface them
- `internal/app/skill/SKILL.md` (§4.10) — explicit paragraph: list commands default to active rows; `--status done` and `--include-archived` open the rest; `flow show` and `flow transcript` work on done/archived too

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` passes
- [ ] Manually verify a fresh session greets the user with the updated hint copy after `flow skill update`
- [ ] Reference a known-done task in conversation and confirm Claude reaches for `--status done` / `--include-archived` rather than declaring it absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)