### PR TITLE
fix: migration aborts when DB has duplicate session_ids

### DIFF
--- a/internal/flowdb/db.go
+++ b/internal/flowdb/db.go
@@ -92,8 +92,13 @@ const indexesPostMigrate = `
 CREATE INDEX IF NOT EXISTS idx_tasks_kind          ON tasks(kind);
 CREATE INDEX IF NOT EXISTS idx_tasks_playbook_slug ON tasks(playbook_slug);
 CREATE INDEX IF NOT EXISTS idx_playbooks_project   ON playbooks(project_slug);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id) WHERE session_id IS NOT NULL;
 `
+
+// (idx_tasks_session_id is a partial UNIQUE index that requires a
+// dedupe pass against existing data — a flat CREATE UNIQUE INDEX
+// would fail on any DB that has two tasks sharing a session_id.
+// migrateTasksSessionIDUnique handles both the dedupe and the index
+// creation as one idempotent step.)
 
 // ---------- models ----------
 
@@ -264,8 +269,6 @@ func runMigrations(db *sql.DB) error {
 
 	// Session-id invariant: any non-backlog task must have a session_id.
 	// Adds a CHECK to the tasks table; old DBs need a table rebuild.
-	// Runs before indexesPostMigrate so the partial unique index lands
-	// on the rebuilt table.
 	if err := migrateTasksSessionInvariant(db); err != nil {
 		return fmt.Errorf("migrate session invariant: %w", err)
 	}
@@ -275,6 +278,127 @@ func runMigrations(db *sql.DB) error {
 	// this point all referenced columns exist.
 	if _, err := db.Exec(indexesPostMigrate); err != nil {
 		return fmt.Errorf("create post-migrate indexes: %w", err)
+	}
+
+	// Session-id uniqueness: dedupe any tasks sharing a session_id, then
+	// create the partial unique index. Runs after the basic indexes
+	// because it has its own dedupe-first contract; a naive
+	// CREATE UNIQUE INDEX in indexesPostMigrate would fail on a DB with
+	// pre-existing duplicates.
+	if err := migrateTasksSessionIDUnique(db); err != nil {
+		return fmt.Errorf("migrate session-id uniqueness: %w", err)
+	}
+	return nil
+}
+
+// migrateTasksSessionIDUnique creates the partial unique index on
+// tasks(session_id) WHERE session_id IS NOT NULL. Older DBs may have
+// two tasks sharing a session_id (the old `flow update task
+// --session-id` flag could silently overwrite a binding without
+// clearing the prior owner; or a user manually edited the row). A
+// flat CREATE UNIQUE INDEX would fail on those DBs, so this function
+// first deduplicates by:
+//
+//  1. Listing every session_id that appears on 2+ tasks.
+//  2. For each such session_id, ordering the carrier tasks by
+//     updated_at DESC, slug ASC. The first row keeps the binding.
+//  3. The remaining rows get session_id=NULL, session_started=NULL,
+//     and status='backlog' (the only state legal for a NULL
+//     session_id under the invariant). A stderr summary explains
+//     which task kept the session and which were demoted.
+//
+// Idempotent: probes sqlite_master for the index first; subsequent
+// calls are no-ops once the index exists.
+func migrateTasksSessionIDUnique(db *sql.DB) error {
+	var existing sql.NullString
+	err := db.QueryRow(
+		`SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_tasks_session_id'`,
+	).Scan(&existing)
+	if err == nil && existing.Valid {
+		return nil
+	}
+	if err != nil && err != sql.ErrNoRows {
+		return fmt.Errorf("probe unique index: %w", err)
+	}
+
+	rows, err := db.Query(
+		`SELECT session_id FROM tasks
+		 WHERE session_id IS NOT NULL
+		 GROUP BY session_id
+		 HAVING COUNT(*) > 1
+		 ORDER BY session_id`,
+	)
+	if err != nil {
+		return fmt.Errorf("scan duplicates: %w", err)
+	}
+	var dupedSIDs []string
+	for rows.Next() {
+		var sid string
+		if err := rows.Scan(&sid); err != nil {
+			rows.Close()
+			return err
+		}
+		dupedSIDs = append(dupedSIDs, sid)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	rows.Close()
+
+	if len(dupedSIDs) > 0 {
+		fmt.Fprintf(os.Stderr,
+			"flow migration: deduplicating %d session_id(s) shared across multiple tasks (only one task may carry a given session_id):\n",
+			len(dupedSIDs))
+		now := NowISO()
+		for _, sid := range dupedSIDs {
+			tRows, err := db.Query(
+				`SELECT slug, status FROM tasks
+				 WHERE session_id = ?
+				 ORDER BY updated_at DESC, slug ASC`,
+				sid,
+			)
+			if err != nil {
+				return fmt.Errorf("scan duplicate group %s: %w", sid, err)
+			}
+			type tRow struct{ slug, status string }
+			var carriers []tRow
+			for tRows.Next() {
+				var t tRow
+				if err := tRows.Scan(&t.slug, &t.status); err != nil {
+					tRows.Close()
+					return err
+				}
+				carriers = append(carriers, t)
+			}
+			if err := tRows.Err(); err != nil {
+				tRows.Close()
+				return err
+			}
+			tRows.Close()
+			if len(carriers) < 2 {
+				continue
+			}
+			winner := carriers[0]
+			fmt.Fprintf(os.Stderr,
+				"  %s: keeping on %s (was %s); demoting to backlog with NULL session_id:\n",
+				sid, winner.slug, winner.status)
+			for _, l := range carriers[1:] {
+				fmt.Fprintf(os.Stderr, "    - %s (was %s)\n", l.slug, l.status)
+				if _, err := db.Exec(
+					`UPDATE tasks SET session_id=NULL, session_started=NULL, status='backlog', updated_at=? WHERE slug=?`,
+					now, l.slug,
+				); err != nil {
+					return fmt.Errorf("demote duplicate %s: %w", l.slug, err)
+				}
+			}
+		}
+	}
+
+	if _, err := db.Exec(
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id) WHERE session_id IS NOT NULL`,
+	); err != nil {
+		return fmt.Errorf("create unique index: %w", err)
 	}
 	return nil
 }

--- a/internal/flowdb/db_test.go
+++ b/internal/flowdb/db_test.go
@@ -423,3 +423,97 @@ func TestMigrationIdempotent(t *testing.T) {
 	}
 	db.Close()
 }
+
+// TestMigrationDeduplicatesSessionIDs simulates Anshul's bug: a DB
+// where two non-archived tasks share the same session_id (could
+// happen via the now-removed `flow update task --session-id` flag,
+// or a manual edit). The naive partial UNIQUE INDEX would fail to
+// create. The migration should dedupe (winner = most recent
+// updated_at) and then succeed at creating the index.
+func TestMigrationDeduplicatesSessionIDs(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "flow.db")
+
+	// Bootstrap a DB and seed two tasks sharing one session_id.
+	// Bypass OpenDB's migration by directly writing to the table
+	// after first open, then reopening to trigger migration.
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Drop the unique index that the migration just created so we
+	// can simulate a pre-migration state with duplicates.
+	if _, err := db.Exec(`DROP INDEX IF EXISTS idx_tasks_session_id`); err != nil {
+		t.Fatal(err)
+	}
+	const sharedSID = "deadbeef-1111-4222-8333-444455556666"
+	now := NowISO()
+	old := "2026-01-01T00:00:00Z"
+	// Two tasks with same session_id; the one with newer updated_at
+	// should win.
+	if _, err := db.Exec(
+		`INSERT INTO tasks (slug, name, status, priority, work_dir, session_id, session_started, created_at, updated_at)
+		 VALUES ('winner', 'W', 'in-progress', 'medium', '/tmp', ?, ?, ?, ?)`,
+		sharedSID, old, old, now,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO tasks (slug, name, status, priority, work_dir, session_id, session_started, created_at, updated_at)
+		 VALUES ('loser', 'L', 'done', 'medium', '/tmp', ?, ?, ?, ?)`,
+		sharedSID, old, old, old,
+	); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+
+	// Reopen — the migration's dedupe step should fire.
+	db, err = OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("reopen with duplicates failed: %v", err)
+	}
+	defer db.Close()
+
+	// Winner keeps the session_id and stays in-progress.
+	winner, err := GetTask(db, "winner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !winner.SessionID.Valid || winner.SessionID.String != sharedSID {
+		t.Errorf("winner session_id = %+v, want %s", winner.SessionID, sharedSID)
+	}
+	if winner.Status != "in-progress" {
+		t.Errorf("winner status = %q, want in-progress", winner.Status)
+	}
+
+	// Loser gets demoted: NULL session_id, status='backlog'.
+	loser, err := GetTask(db, "loser")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loser.SessionID.Valid {
+		t.Errorf("loser session_id should be NULL, got %q", loser.SessionID.String)
+	}
+	if loser.Status != "backlog" {
+		t.Errorf("loser status = %q, want backlog (demoted)", loser.Status)
+	}
+
+	// The unique index should now exist.
+	var idxSQL sql.NullString
+	if err := db.QueryRow(
+		`SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_tasks_session_id'`,
+	).Scan(&idxSQL); err != nil {
+		t.Fatalf("unique index missing after migration: %v", err)
+	}
+	if !idxSQL.Valid {
+		t.Error("unique index DDL is NULL")
+	}
+
+	// Idempotent: opening again is a no-op.
+	db.Close()
+	db2, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("second reopen failed: %v", err)
+	}
+	db2.Close()
+}


### PR DESCRIPTION
## Summary

Reported by @anshulsao after upgrading to v0.1.0-alpha.11:

```
flow migration: demoting 7 task(s) without session_id back to backlog ...
  zyla-deck (was done)
  ...
error: migrate: create post-migrate indexes: constraint failed:
UNIQUE constraint failed: tasks.session_id (2067)
```

The status-violator demote fired correctly, but then `CREATE UNIQUE INDEX ... ON tasks(session_id) WHERE session_id IS NOT NULL` couldn't land because his DB had at least two tasks sharing the same `session_id`. Stuck — every subsequent `flow` invocation re-runs the failing migration.

Two ways pre-existing duplicate session_ids could happen:
- The now-removed `flow update task --session-id` flag silently overwrote a binding without clearing the prior owner.
- Manual `flow.db` edit.

## Fix

Split the partial UNIQUE index out of `indexesPostMigrate` into a new `migrateTasksSessionIDUnique` step that dedupes first.

**Dedupe rule** (mirrors the existing status-violator demote in `migrateTasksSessionInvariant`):

1. Find every `session_id` that appears on 2+ tasks.
2. For each, order carriers by `updated_at DESC, slug ASC`. The first row keeps the binding.
3. Remaining rows: `session_id=NULL`, `session_started=NULL`, `status='backlog'` (the only state legal for a NULL `session_id` under the invariant).
4. Stderr summary names the winner and the demoted losers per session_id.
5. Then create the partial UNIQUE INDEX.

Idempotent: probes `sqlite_master` for the index first; subsequent runs are no-ops once the index exists.

## Restrictions are NOT loosened

- The `CHECK (status='backlog' OR session_id IS NOT NULL)` constraint stays.
- The partial UNIQUE INDEX still gets created — just after a one-time dedupe pass on old data.
- `flow do --here` still refuses to bind to a target with a different existing session (override with `--force`) and still refuses to bind THIS session if it's already bound elsewhere (no `--force` escape — structural).

The dedupe is a one-time data cleanup for old DBs, analogous to how `migrateTasksSessionInvariant` demotes status-violators before adding the CHECK.

## Test plan

- [x] `go test ./...` green
- [x] New `TestMigrationDeduplicatesSessionIDs` simulates Anshul's exact scenario: two tasks (one in-progress, one done) sharing a session_id → migration picks winner by `updated_at`, demotes loser to backlog with NULL session_id, then creates the unique index. Reopen confirms idempotency.
- [ ] Ship as v0.1.0-alpha.12; @anshulsao re-downloads, re-runs, his DB clears the dedupe summary then succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)