### PR TITLE
fix(flowdb): apply busy_timeout at OpenDB so concurrent opens don't race

### DIFF
--- a/internal/flowdb/db.go
+++ b/internal/flowdb/db.go
@@ -4,6 +4,7 @@ package flowdb
 import (
 	"database/sql"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -182,8 +183,18 @@ func NullIfEmpty(s string) any {
 
 // OpenDB opens (or creates) the SQLite database at path, ensures the
 // schema is present, and runs idempotent migrations.
+//
+// The connection is opened with busy_timeout(30000) applied via the
+// DSN so every pooled connection inherits it. Without this, concurrent
+// `flow do` invocations can race during the schema-DDL / migration
+// setup here and the loser gets SQLITE_BUSY immediately instead of
+// waiting — surfaces as a flaky `migrate: pragma table_info(...):
+// database is locked` on slow runners.
 func OpenDB(path string) (*sql.DB, error) {
-	db, err := sql.Open("sqlite", path)
+	q := url.Values{}
+	q.Set("_pragma", "busy_timeout(30000)")
+	dsn := "file:" + path + "?" + q.Encode()
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite %s: %w", path, err)
 	}

--- a/internal/flowdb/db_test.go
+++ b/internal/flowdb/db_test.go
@@ -3,6 +3,7 @@ package flowdb
 import (
 	"database/sql"
 	"path/filepath"
+	"sync"
 	"testing"
 )
 
@@ -60,6 +61,36 @@ func TestOpenDBIdempotent(t *testing.T) {
 		t.Fatalf("second open: %v", err)
 	}
 	db2.Close()
+}
+
+// TestOpenDBConcurrentDoesNotBusy pins that two parallel OpenDB calls
+// on the same path don't race during schema setup. Without busy_timeout
+// applied at open time, the loser hits SQLITE_BUSY on `pragma
+// table_info(tasks)` during runMigrations on slow runners — observed
+// as a flaky CI failure on the app-level concurrent-do test.
+func TestOpenDBConcurrentDoesNotBusy(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "flow.db")
+	const n = 8
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	wg.Add(n)
+	for i := range n {
+		go func() {
+			defer wg.Done()
+			db, err := OpenDB(path)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			db.Close()
+		}()
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: %v", i, err)
+		}
+	}
 }
 
 func TestProjectCRUD(t *testing.T) {


### PR DESCRIPTION
## What

Adds `busy_timeout(30000)` to `flowdb.OpenDB`'s connection DSN so every pooled connection inherits it from the moment the file is touched, before any schema DDL or migration runs.

## Why

`openConcurrentDB` in `internal/app/do.go` already sets `busy_timeout(30000)` and `_txlock=immediate` on the second connection it opens — but its **first** connection (the one that runs schema DDL and migrations via `flowdb.OpenDB`) never had a busy timeout. SQLite's default is 0, so the loser of a concurrent setup race gets SQLITE_BUSY immediately rather than waiting.

Surfaced on a slow Linux CI runner inside `TestCmdDoConcurrentFreshTasks` (which has lived on `main` since the pre-allocate-session-UUID change) as:

```
error: migrate: pragma table_info(tasks): database is locked (5) (SQLITE_BUSY)
--- FAIL: TestCmdDoConcurrentFreshTasks (0.03s)
    do_test.go:581: goroutine 0 rc=1
    do_test.go:590: iTerm spawn count=1, want 2
```

Reference run: https://github.com/Facets-cloud/flow/actions/runs/25716872650/job/75508687420

Passes locally and on most CI runs — but the race is real and the fix is one line.

## Fix

```go
q := url.Values{}
q.Set("_pragma", "busy_timeout(30000)")
dsn := "file:" + path + "?" + q.Encode()
db, err := sql.Open("sqlite", dsn)
```

DSN-based pragma means every connection in the pool inherits it, not just the one that handles a one-shot `PRAGMA` exec.

## Test plan

- [x] `go test ./...` passes
- [x] New `TestOpenDBConcurrentDoesNotBusy` regression: fans out 8 parallel \`OpenDB\` calls on the same path, asserts none error. Passes 20x in a row locally on the fix.
- [ ] Watch CI on this PR and on `feat/notify-tab-focus` (which exhibited the flake) after rebase.

## Notes

- `openConcurrentDB`'s pre-open/close dance via `OpenDB` is now slightly redundant since `OpenDB` already applies busy_timeout. Could be simplified in a follow-up — kept the structure here so the fix stays minimal.
- Unblocks #34 (notify-tab-focus) once that branch rebases onto `main` post-merge.