### PR TITLE
feat: kitty terminal backend for flow do

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ handles the rest.
 ## What you get
 
 - **One task, one Claude session, one tab.** `flow do <task>`
-  spawns a dedicated tab in iTerm2, stock macOS Terminal, or your
+  spawns a dedicated tab in iTerm2, stock macOS Terminal, kitty
+  (requires `allow_remote_control yes` in `kitty.conf`), or your
   current zellij session (requires zellij ≥ 0.40) — flow picks
   whichever you launched it from. Tomorrow's `flow do <task>`
   resumes the same conversation.
@@ -208,8 +209,9 @@ handles the rest.
 ## How it works under the hood
 
 `flow do <task>` pre-allocates a session UUID, writes it to the
-task row, and spawns a tab in zellij (when `$ZELLIJ` is set), iTerm2,
-or stock Terminal.app — chosen in that priority order, with iTerm as
+task row, and spawns a tab in zellij (when `$ZELLIJ` is set), kitty
+(when `$KITTY_WINDOW_ID` is set or `$TERM=xterm-kitty`), iTerm2, or
+stock Terminal.app — chosen in that priority order, with iTerm as
 the historical fallback — running `claude --session-id <uuid>` with
 `FLOW_TASK` / `FLOW_PROJECT` inlined. The jsonl file lands at the deterministic path
 `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`, so future
@@ -293,11 +295,14 @@ and reinstall the skill + hook.
 
 ## Where flow runs (and where we'd love help)
 
-Today flow runs on **macOS (iTerm2, stock Terminal.app, or zellij)
-+ Claude Code only**. That's the stack we use, and that's what the
-session-spawn layer was built and tested against. zellij works on
-Linux too as a side effect — it's cross-platform and flow's zellij
-backend doesn't depend on any macOS APIs.
+Today flow runs on **macOS (iTerm2, stock Terminal.app, kitty, or
+zellij) + Claude Code only**. That's the stack we use, and that's
+what the session-spawn layer was built and tested against. zellij
+and kitty work on Linux too as a side effect — both are
+cross-platform and flow's zellij / kitty backends don't depend on
+any macOS APIs. Kitty needs `allow_remote_control yes` (or
+`socket-only`) in `kitty.conf` so flow can drive `kitty @ launch`
+from inside the running kitty instance.
 
 The architecture is portable — session spawning is one small
 package — but other harnesses (Codex, Cursor, plain shell) and other

--- a/internal/kitty/kitty.go
+++ b/internal/kitty/kitty.go
@@ -1,0 +1,103 @@
+// Package kitty provides kitty-terminal tab spawning via the `kitty @`
+// remote-control CLI. Activated by spawner.Detect() when $KITTY_WINDOW_ID
+// is set or $TERM=xterm-kitty (kitty sets these in every shell it
+// spawns).
+//
+// Mechanism:
+//
+//  1. kitty @ launch --type=tab --tab-title=<title> --cwd=<cwd>
+//     (prints the new window id to stdout)
+//  2. kitty @ send-text --match=id:<id> " <env-prefix><flat-command>\n"
+//
+// Step 1 opens a new tab in the current OS window, running the default
+// shell, and returns the kitty window id. Step 2 types the command
+// into that window's PTY so the shell executes it. The leading space
+// triggers histignorespace on shells that have it on, matching the
+// iterm/terminal/zellij backends. The trailing newline submits the
+// line.
+//
+// Newline handling: send-text writes raw bytes to the target window's
+// PTY, so any embedded `\n` in the command is interpreted by the shell
+// as Enter. Same flattening rule as the zellij backend.
+//
+// Prereq: `allow_remote_control yes` (or `socket-only`) in kitty.conf.
+// Without it, `kitty @ launch` exits non-zero with an explicit error;
+// SpawnTab surfaces that as a wrapped error so the user knows to enable
+// remote control.
+//
+// This file mirrors the contract of internal/iterm, internal/terminal,
+// and internal/zellij — same SpawnTab signature, same Runner mock var
+// for tests, same ShellQuote helper.
+package kitty
+
+import (
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// Runner is the function used to execute kitty for side-effect calls
+// (send-text). Tests override this to capture argv without invoking
+// the real CLI.
+var Runner = func(args []string) error {
+	cmd := exec.Command("kitty", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("kitty failed: %v: %s", err, string(out))
+	}
+	return nil
+}
+
+// RunnerOutput executes kitty and returns stdout. Used by SpawnTab to
+// read the new window id from `kitty @ launch`. Separate var from
+// Runner so existing SpawnTab argv tests stay readable.
+var RunnerOutput = func(args []string) ([]byte, error) {
+	return exec.Command("kitty", args...).Output()
+}
+
+// SpawnTab opens a new kitty tab in the current OS window, sets its
+// title and cwd, and types `command` into the new window's PTY.
+//
+// envVars are attached as an inline shell prefix to `command` only —
+// they are present in the command's environment but do NOT persist in
+// the tab's shell after the command exits.
+func SpawnTab(title, cwd, command string, envVars map[string]string) error {
+	out, err := RunnerOutput([]string{
+		"@", "launch",
+		"--type=tab",
+		"--tab-title=" + title,
+		"--cwd=" + cwd,
+	})
+	if err != nil {
+		return fmt.Errorf("kitty @ launch: %w (is `allow_remote_control yes` set in kitty.conf?)", err)
+	}
+	windowID := strings.TrimSpace(string(out))
+	if windowID == "" {
+		return fmt.Errorf("kitty @ launch returned empty window id")
+	}
+
+	envPrefix := ""
+	if len(envVars) > 0 {
+		keys := make([]string, 0, len(envVars))
+		for k := range envVars {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		parts := make([]string, 0, len(envVars))
+		for _, k := range keys {
+			parts = append(parts, fmt.Sprintf("%s=%s", k, ShellQuote(envVars[k])))
+		}
+		envPrefix = strings.Join(parts, " ") + " "
+	}
+	flat := strings.ReplaceAll(command, "\n", " ")
+	line := " " + envPrefix + flat + "\n"
+	return Runner([]string{"@", "send-text", "--match=id:" + windowID, line})
+}
+
+// ShellQuote wraps s in single quotes with proper escaping. Same
+// implementation as iterm.ShellQuote / terminal.ShellQuote /
+// zellij.ShellQuote.
+func ShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/kitty/kitty_test.go
+++ b/internal/kitty/kitty_test.go
@@ -1,0 +1,176 @@
+package kitty
+
+import (
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// TestSpawnTabBasicNoEnv verifies the two-call argv sequence with no
+// env vars:
+//  1. RunnerOutput: kitty @ launch --type=tab --tab-title=<t> --cwd=<cwd>  (returns window id)
+//  2. Runner:       kitty @ send-text --match=id:<id> " <command>\n"      (leading space for histignorespace)
+func TestSpawnTabBasicNoEnv(t *testing.T) {
+	var launchArgs []string
+	stubRunnerOutput(t, func(args []string) ([]byte, error) {
+		launchArgs = append([]string(nil), args...)
+		return []byte("42\n"), nil
+	})
+
+	var sendArgs []string
+	old := Runner
+	Runner = func(args []string) error {
+		sendArgs = append([]string(nil), args...)
+		return nil
+	}
+	t.Cleanup(func() { Runner = old })
+
+	if err := SpawnTab("my-task", "/tmp", "echo hi", nil); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+
+	wantLaunch := []string{"@", "launch", "--type=tab", "--tab-title=my-task", "--cwd=/tmp"}
+	if !slices.Equal(launchArgs, wantLaunch) {
+		t.Errorf("launch argv = %v; want %v", launchArgs, wantLaunch)
+	}
+	wantSend := []string{"@", "send-text", "--match=id:42", " echo hi\n"}
+	if !slices.Equal(sendArgs, wantSend) {
+		t.Errorf("send argv = %v; want %v", sendArgs, wantSend)
+	}
+}
+
+// TestSpawnTabEnvVarsSorted verifies env vars are emitted alphabetically,
+// each value shell-quoted, all space-separated, before the command. This
+// matches the iterm/terminal/zellij env-prefix contract exactly.
+func TestSpawnTabEnvVarsSorted(t *testing.T) {
+	stubRunnerOutput(t, func(args []string) ([]byte, error) {
+		return []byte("17\n"), nil
+	})
+
+	var captured string
+	old := Runner
+	Runner = func(args []string) error {
+		if len(args) >= 4 && args[1] == "send-text" {
+			captured = args[3]
+		}
+		return nil
+	}
+	t.Cleanup(func() { Runner = old })
+
+	envVars := map[string]string{
+		"FLOW_TASK":    "my-task",
+		"FLOW_PROJECT": "flow",
+	}
+	if err := SpawnTab("flow/my-task", "/Users/me/repo", "claude --resume abc", envVars); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+	want := " FLOW_PROJECT='flow' FLOW_TASK='my-task' claude --resume abc\n"
+	if captured != want {
+		t.Errorf("send-text payload = %q; want %q", captured, want)
+	}
+}
+
+// TestSpawnTabLaunchErrorShortCircuits — an error from `kitty @ launch`
+// must be wrapped (with the remote-control hint) and send-text must NOT
+// be attempted.
+func TestSpawnTabLaunchErrorShortCircuits(t *testing.T) {
+	stubRunnerOutput(t, func(args []string) ([]byte, error) {
+		return nil, errors.New("exit status 1: remote control is not enabled")
+	})
+	runnerCalled := false
+	old := Runner
+	Runner = func(args []string) error {
+		runnerCalled = true
+		return nil
+	}
+	t.Cleanup(func() { Runner = old })
+
+	err := SpawnTab("t", "/tmp", "echo hi", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if runnerCalled {
+		t.Error("Runner (send-text) should not be called when launch fails")
+	}
+	if !strings.Contains(err.Error(), "allow_remote_control") {
+		t.Errorf("expected error to mention remote_control hint, got: %v", err)
+	}
+}
+
+// TestSpawnTabLaunchEmptyOutput — if kitty @ launch returns empty
+// stdout, SpawnTab must fail rather than send-text to id:"" (which
+// kitty would interpret as match-all).
+func TestSpawnTabLaunchEmptyOutput(t *testing.T) {
+	stubRunnerOutput(t, func(args []string) ([]byte, error) {
+		return []byte("\n"), nil
+	})
+	runnerCalled := false
+	old := Runner
+	Runner = func(args []string) error {
+		runnerCalled = true
+		return nil
+	}
+	t.Cleanup(func() { Runner = old })
+
+	err := SpawnTab("t", "/tmp", "echo hi", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if runnerCalled {
+		t.Error("Runner (send-text) should not be called when launch returns empty id")
+	}
+}
+
+// TestSpawnTabFlattensEmbeddedNewlines — embedded `\n` in command must
+// be replaced with a space before send-text, same reasoning as zellij
+// (PTY would interpret each \n as Enter and run partial lines).
+func TestSpawnTabFlattensEmbeddedNewlines(t *testing.T) {
+	stubRunnerOutput(t, func(args []string) ([]byte, error) {
+		return []byte("5\n"), nil
+	})
+	var captured string
+	old := Runner
+	Runner = func(args []string) error {
+		if len(args) >= 4 && args[1] == "send-text" {
+			captured = args[3]
+		}
+		return nil
+	}
+	t.Cleanup(func() { Runner = old })
+
+	cmd := "claude --session-id abc 'line1\nline2\nline3'"
+	if err := SpawnTab("t", "/tmp", cmd, nil); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+	want := " claude --session-id abc 'line1 line2 line3'\n"
+	if captured != want {
+		t.Errorf("send-text payload = %q; want %q", captured, want)
+	}
+	if got := strings.Count(captured, "\n"); got != 1 {
+		t.Errorf("send-text payload contains %d newlines; want exactly 1", got)
+	}
+}
+
+func stubRunnerOutput(t *testing.T, fn func([]string) ([]byte, error)) {
+	t.Helper()
+	old := RunnerOutput
+	RunnerOutput = fn
+	t.Cleanup(func() { RunnerOutput = old })
+}
+
+// TestShellQuote — same contract as iterm/terminal/zellij.
+func TestShellQuote(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"plain", "'plain'"},
+		{"with space", "'with space'"},
+		{"with'quote", `'with'\''quote'`},
+	}
+	for _, tc := range cases {
+		if got := ShellQuote(tc.in); got != tc.want {
+			t.Errorf("ShellQuote(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/spawner/spawner.go
+++ b/internal/spawner/spawner.go
@@ -1,23 +1,27 @@
-// Package spawner picks a terminal backend (zellij, iTerm2, or macOS
-// Terminal.app) at runtime and forwards SpawnTab to it.
+// Package spawner picks a terminal backend (zellij, kitty, iTerm2, or
+// macOS Terminal.app) at runtime and forwards SpawnTab to it.
 //
 // Selection priority:
 //
-//	$ZELLIJ set                       → internal/zellij
-//	TERM_PROGRAM=Apple_Terminal       → internal/terminal
-//	TERM_PROGRAM=iTerm.app            → internal/iterm
-//	anything else (or unset)          → internal/iterm  (historical default)
+//	$ZELLIJ set                                    → internal/zellij
+//	$KITTY_WINDOW_ID set or $TERM=xterm-kitty      → internal/kitty
+//	TERM_PROGRAM=Apple_Terminal                    → internal/terminal
+//	TERM_PROGRAM=iTerm.app                         → internal/iterm
+//	anything else (or unset)                       → internal/iterm  (historical default)
 //
-// $ZELLIJ wins over TERM_PROGRAM because if the user is inside a zellij
+// $ZELLIJ wins over everything because if the user is inside a zellij
 // session, that's where their workflow lives — the host terminal is a
-// substrate detail.
+// substrate detail. Kitty sits same tier as zellij (explicit
+// per-window session marker set by the terminal itself) and beats the
+// TERM_PROGRAM fallback because kitty does not set TERM_PROGRAM.
 //
 // The Override var lets tests pin the backend deterministically without
-// having to set TERM_PROGRAM via t.Setenv.
+// having to set env vars via t.Setenv.
 package spawner
 
 import (
 	"flow/internal/iterm"
+	"flow/internal/kitty"
 	"flow/internal/terminal"
 	"flow/internal/zellij"
 	"os"
@@ -30,9 +34,10 @@ const (
 	BackendITerm    Backend = "iterm"
 	BackendTerminal Backend = "terminal"
 	BackendZellij   Backend = "zellij"
+	BackendKitty    Backend = "kitty"
 )
 
-// Override, if non-empty, forces a backend regardless of TERM_PROGRAM.
+// Override, if non-empty, forces a backend regardless of env vars.
 // Used by tests; production code should leave it as "".
 var Override Backend
 
@@ -46,6 +51,9 @@ func Detect() Backend {
 	if os.Getenv("ZELLIJ") != "" {
 		return BackendZellij
 	}
+	if os.Getenv("KITTY_WINDOW_ID") != "" || os.Getenv("TERM") == "xterm-kitty" {
+		return BackendKitty
+	}
 	switch os.Getenv("TERM_PROGRAM") {
 	case "Apple_Terminal":
 		return BackendTerminal
@@ -57,11 +65,14 @@ func Detect() Backend {
 }
 
 // SpawnTab opens a tab in the auto-detected backend. The contract
-// matches both iterm.SpawnTab and terminal.SpawnTab.
+// matches iterm.SpawnTab, terminal.SpawnTab, zellij.SpawnTab, and
+// kitty.SpawnTab.
 func SpawnTab(title, cwd, command string, envVars map[string]string) error {
 	switch Detect() {
 	case BackendZellij:
 		return zellij.SpawnTab(title, cwd, command, envVars)
+	case BackendKitty:
+		return kitty.SpawnTab(title, cwd, command, envVars)
 	case BackendTerminal:
 		return terminal.SpawnTab(title, cwd, command, envVars)
 	default:
@@ -70,7 +81,7 @@ func SpawnTab(title, cwd, command string, envVars map[string]string) error {
 }
 
 // ShellQuote is re-exported so callers don't need to import the chosen
-// backend just to quote a value before handing it to SpawnTab. Both
+// backend just to quote a value before handing it to SpawnTab. All
 // backends quote identically (POSIX single-quote with embedded-quote
 // escape), so we delegate to iterm's implementation.
 func ShellQuote(s string) string {

--- a/internal/spawner/spawner_test.go
+++ b/internal/spawner/spawner_test.go
@@ -2,6 +2,7 @@ package spawner
 
 import (
 	"flow/internal/iterm"
+	"flow/internal/kitty"
 	"flow/internal/terminal"
 	"flow/internal/zellij"
 	"strings"
@@ -9,7 +10,8 @@ import (
 )
 
 // TestDetectFromEnv verifies the TERM_PROGRAM → backend mapping. The
-// Override knob has higher precedence and is checked separately below.
+// Override knob and the kitty / ZELLIJ checks have higher precedence
+// and are checked separately below.
 func TestDetectFromEnv(t *testing.T) {
 	cases := []struct {
 		termProgram string
@@ -24,6 +26,8 @@ func TestDetectFromEnv(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.termProgram, func(t *testing.T) {
 			t.Setenv("ZELLIJ", "")
+			t.Setenv("KITTY_WINDOW_ID", "")
+			t.Setenv("TERM", "")
 			t.Setenv("TERM_PROGRAM", tc.termProgram)
 			Override = ""
 			if got := Detect(); got != tc.want {
@@ -35,10 +39,12 @@ func TestDetectFromEnv(t *testing.T) {
 }
 
 // TestOverrideBeatsEnv confirms the test escape hatch: setting Override
-// pins the backend regardless of TERM_PROGRAM, so individual tests can
-// pin the dispatcher without relying on env-var mutation order.
+// pins the backend regardless of env vars, so individual tests can pin
+// the dispatcher without relying on env-var mutation order.
 func TestOverrideBeatsEnv(t *testing.T) {
 	t.Setenv("ZELLIJ", "")
+	t.Setenv("KITTY_WINDOW_ID", "")
+	t.Setenv("TERM", "")
 	t.Setenv("TERM_PROGRAM", "iTerm.app")
 	t.Cleanup(func() { Override = "" })
 
@@ -50,18 +56,55 @@ func TestOverrideBeatsEnv(t *testing.T) {
 	if got := Detect(); got != BackendITerm {
 		t.Errorf("Override=ITerm: got %q, want %q", got, BackendITerm)
 	}
+	Override = BackendKitty
+	if got := Detect(); got != BackendKitty {
+		t.Errorf("Override=Kitty: got %q, want %q", got, BackendKitty)
+	}
 }
 
-// TestDetectZellij verifies the ZELLIJ env var beats TERM_PROGRAM.
-// zellij sets ZELLIJ in every shell it spawns, so its presence means
-// the user is inside a zellij session regardless of which terminal
-// hosts it.
+// TestDetectZellij verifies the ZELLIJ env var beats TERM_PROGRAM, kitty,
+// and everything else. zellij sets ZELLIJ in every shell it spawns, so
+// its presence means the user is inside a zellij session regardless of
+// which terminal hosts it.
 func TestDetectZellij(t *testing.T) {
 	t.Setenv("ZELLIJ", "0")
-	t.Setenv("TERM_PROGRAM", "iTerm.app") // proves ZELLIJ wins
+	t.Setenv("KITTY_WINDOW_ID", "1") // proves ZELLIJ wins over kitty
+	t.Setenv("TERM", "xterm-kitty")  // ditto
+	t.Setenv("TERM_PROGRAM", "iTerm.app")
 	Override = ""
 	if got := Detect(); got != BackendZellij {
 		t.Errorf("Detect() with ZELLIJ=0: got %q, want %q", got, BackendZellij)
+	}
+}
+
+// TestDetectKitty verifies $KITTY_WINDOW_ID and $TERM=xterm-kitty both
+// route to BackendKitty, and that kitty beats TERM_PROGRAM (kitty does
+// not set TERM_PROGRAM, so without this check kitty users fall back to
+// the iTerm path).
+func TestDetectKitty(t *testing.T) {
+	cases := []struct {
+		name          string
+		kittyWindowID string
+		term          string
+		termProgram   string
+	}{
+		{"KITTY_WINDOW_ID set", "42", "", ""},
+		{"TERM=xterm-kitty", "", "xterm-kitty", ""},
+		{"both set", "42", "xterm-kitty", ""},
+		{"KITTY_WINDOW_ID set even with TERM_PROGRAM=iTerm.app", "42", "", "iTerm.app"},
+		{"TERM=xterm-kitty even with TERM_PROGRAM=iTerm.app", "", "xterm-kitty", "iTerm.app"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("ZELLIJ", "")
+			t.Setenv("KITTY_WINDOW_ID", tc.kittyWindowID)
+			t.Setenv("TERM", tc.term)
+			t.Setenv("TERM_PROGRAM", tc.termProgram)
+			Override = ""
+			if got := Detect(); got != BackendKitty {
+				t.Errorf("got %q, want %q", got, BackendKitty)
+			}
+		})
 	}
 }
 
@@ -71,18 +114,15 @@ func TestSpawnTabRoutesToITerm(t *testing.T) {
 	Override = BackendITerm
 	t.Cleanup(func() { Override = "" })
 
-	itermCalled, terminalCalled, zellijCalled := stubAllRunners(t)
+	itermCalled, terminalCalled, zellijCalled, kittyCalled := stubAllRunners(t)
 	if err := SpawnTab("title", "/tmp", "echo hi", nil); err != nil {
 		t.Fatalf("SpawnTab: %v", err)
 	}
 	if !*itermCalled {
 		t.Error("expected iterm.Runner to be called")
 	}
-	if *terminalCalled {
-		t.Error("did not expect terminal.Runner to be called")
-	}
-	if *zellijCalled {
-		t.Error("did not expect zellij.Runner to be called")
+	if *terminalCalled || *zellijCalled || *kittyCalled {
+		t.Error("only iterm.Runner should be called")
 	}
 }
 
@@ -92,18 +132,15 @@ func TestSpawnTabRoutesToTerminal(t *testing.T) {
 	Override = BackendTerminal
 	t.Cleanup(func() { Override = "" })
 
-	itermCalled, terminalCalled, zellijCalled := stubAllRunners(t)
+	itermCalled, terminalCalled, zellijCalled, kittyCalled := stubAllRunners(t)
 	if err := SpawnTab("title", "/tmp", "echo hi", nil); err != nil {
 		t.Fatalf("SpawnTab: %v", err)
-	}
-	if *itermCalled {
-		t.Error("did not expect iterm.Runner to be called")
 	}
 	if !*terminalCalled {
 		t.Error("expected terminal.Runner to be called")
 	}
-	if *zellijCalled {
-		t.Error("did not expect zellij.Runner to be called")
+	if *itermCalled || *zellijCalled || *kittyCalled {
+		t.Error("only terminal.Runner should be called")
 	}
 }
 
@@ -113,23 +150,38 @@ func TestSpawnTabRoutesToZellij(t *testing.T) {
 	Override = BackendZellij
 	t.Cleanup(func() { Override = "" })
 
-	itermCalled, terminalCalled, zellijCalled := stubAllRunners(t)
+	itermCalled, terminalCalled, zellijCalled, kittyCalled := stubAllRunners(t)
 	if err := SpawnTab("title", "/tmp", "echo hi", nil); err != nil {
 		t.Fatalf("SpawnTab: %v", err)
-	}
-	if *itermCalled {
-		t.Error("did not expect iterm.Runner to be called")
-	}
-	if *terminalCalled {
-		t.Error("did not expect terminal.Runner to be called")
 	}
 	if !*zellijCalled {
 		t.Error("expected zellij.Runner to be called")
 	}
+	if *itermCalled || *terminalCalled || *kittyCalled {
+		t.Error("only zellij.Runner should be called")
+	}
+}
+
+// TestSpawnTabRoutesToKitty asserts the kitty Runner+RunnerOutput pair
+// is invoked when Detect() resolves to BackendKitty.
+func TestSpawnTabRoutesToKitty(t *testing.T) {
+	Override = BackendKitty
+	t.Cleanup(func() { Override = "" })
+
+	itermCalled, terminalCalled, zellijCalled, kittyCalled := stubAllRunners(t)
+	if err := SpawnTab("title", "/tmp", "echo hi", nil); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+	if !*kittyCalled {
+		t.Error("expected kitty backend to be called")
+	}
+	if *itermCalled || *terminalCalled || *zellijCalled {
+		t.Error("only kitty backend should be called")
+	}
 }
 
 // TestShellQuoteParity makes sure the re-exported helper matches
-// iterm's implementation. Both backends quote identically.
+// iterm's implementation. All backends quote identically.
 func TestShellQuoteParity(t *testing.T) {
 	cases := []string{"plain", "with space", "with'quote", `back\slash`}
 	for _, in := range cases {
@@ -139,13 +191,12 @@ func TestShellQuoteParity(t *testing.T) {
 	}
 }
 
-// stubAllRunners replaces all three backend Runner vars with no-op
-// stubs that flip a per-runner boolean when called. Restores
-// originals on test cleanup. Returns pointers so callers can read
-// post-call.
-func stubAllRunners(t *testing.T) (*bool, *bool, *bool) {
+// stubAllRunners replaces all backend Runner vars with no-op stubs that
+// flip a per-runner boolean when called. Restores originals on test
+// cleanup. Returns pointers so callers can read post-call.
+func stubAllRunners(t *testing.T) (*bool, *bool, *bool, *bool) {
 	t.Helper()
-	var itermCalled, terminalCalled, zellijCalled bool
+	var itermCalled, terminalCalled, zellijCalled, kittyCalled bool
 
 	oldITerm := iterm.Runner
 	iterm.Runner = func(args []string) error {
@@ -177,5 +228,25 @@ func stubAllRunners(t *testing.T) (*bool, *bool, *bool) {
 	}
 	t.Cleanup(func() { zellij.Runner = oldZellij })
 
-	return &itermCalled, &terminalCalled, &zellijCalled
+	oldKitty := kitty.Runner
+	kitty.Runner = func(args []string) error {
+		kittyCalled = true
+		if len(args) >= 1 && args[0] != "@" {
+			t.Errorf("kitty argv does not start with '@': %v", args)
+		}
+		return nil
+	}
+	t.Cleanup(func() { kitty.Runner = oldKitty })
+
+	// SpawnTab calls RunnerOutput first (kitty @ launch) then Runner
+	// (kitty @ send-text). Stub RunnerOutput to return a fake window
+	// id so SpawnTab progresses to the Runner call we're asserting on.
+	oldKittyRO := kitty.RunnerOutput
+	kitty.RunnerOutput = func(args []string) ([]byte, error) {
+		kittyCalled = true
+		return []byte("1\n"), nil
+	}
+	t.Cleanup(func() { kitty.RunnerOutput = oldKittyRO })
+
+	return &itermCalled, &terminalCalled, &zellijCalled, &kittyCalled
 }


### PR DESCRIPTION
## Summary
- Adds `internal/kitty` package alongside iterm/terminal/zellij with the same `SpawnTab(title, cwd, command, envVars)` contract.
- Wires `BackendKitty` into `spawner.Detect()` after `$ZELLIJ`. Kitty is picked when `$KITTY_WINDOW_ID` is set or `$TERM=xterm-kitty`.
- Kitty doesn't set `TERM_PROGRAM`, so without this change kitty users fell through to the iTerm backend and hit `osascript` errors.

## Mechanism (mirrors zellij two-call pattern)
1. `kitty @ launch --type=tab --tab-title=<t> --cwd=<cwd>` opens new tab, returns window id on stdout.
2. `kitty @ send-text --match=id:<id> " <env-prefix><flat-command>\n"` types the command into the new window's PTY.
   - Leading space → triggers `histignorespace`.
   - Embedded `\n` in the command flattened to spaces (PTY would otherwise interpret each as Enter).

## Prereq
`allow_remote_control yes` (or `socket-only`) in `~/.config/kitty/kitty.conf`. SpawnTab surfaces the hint in its error message when `kitty @ launch` fails so users know what to enable.

## Detect priority
```
Override → $ZELLIJ → $KITTY_WINDOW_ID|$TERM=xterm-kitty → TERM_PROGRAM → iTerm fallback
```
Zellij still wins over kitty (workflow > substrate per the existing rationale).

## Out of scope / follow-up
`kitty.FocusSession` (focus existing tab on duplicate `flow do`) — will follow #28 once `spawner.FocusSession` lands on main. Tracked as a separate issue.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` — 308 tests pass, 8 packages
- [x] Manual smoke from kitty: `flow do <task>` opens new kitty tab, `claude --session-id <uuid> '...'` typed in, claude bootstraps.
- [ ] Verify on a kitty.conf without `allow_remote_control` — error surfaces the hint.
- [ ] Verify in zellij-hosted-by-kitty: zellij wins as expected.