### PR TITLE
fix: pin spawner.Override in e2e test to prevent kitty tab leak

### DIFF
--- a/internal/app/e2e_test.go
+++ b/internal/app/e2e_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"flow/internal/flowdb"
 	"flow/internal/iterm"
+	"flow/internal/spawner"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,6 +29,14 @@ func TestE2EFullRoundtrip(t *testing.T) {
 	if err := os.MkdirAll(repo, 0o755); err != nil {
 		t.Fatal(err)
 	}
+
+	// Pin the spawner backend so a kitty/zellij/Terminal.app host does
+	// not route SpawnTab to a real terminal CLI. Without this, running
+	// the test inside kitty (KITTY_WINDOW_ID set) opens a real tab and
+	// types the fixture command into the user's shell.
+	oldOverride := spawner.Override
+	spawner.Override = spawner.BackendITerm
+	t.Cleanup(func() { spawner.Override = oldOverride })
 
 	// Stub osascript for the whole test.
 	oldOsa := iterm.Runner


### PR DESCRIPTION
## Summary
- Pins `spawner.Override = BackendITerm` in `TestE2EFullRoundtrip` so a kitty/zellij/Terminal.app host can't route `SpawnTab` to a real terminal CLI during tests.
- Matches the same Override-pin pattern already used in `do_test.go`.

Fixes #40.

## Root cause
`e2e_test.go` mocked only `iterm.Runner`, `claudeRunner`, and `newUUID`. On a kitty host (`KITTY_WINDOW_ID` set or `TERM=xterm-kitty`), `spawner.Detect()` returned `BackendKitty` and the test invoked real `kitty @ launch` / `kitty @ send-text`, opening a tab in the user's window that typed the fixture command into the shell.

## Test plan
- [x] `go test ./...` passes (all 7 packages green).
- [x] `go test ./internal/app/ -run TestE2EFullRoundtrip -count=1` passes with simulated `KITTY_WINDOW_ID=42` env — no leak.
- [x] Same test executed inside a real kitty terminal (`KITTY_WINDOW_ID=548 TERM=xterm-kitty`) — verified visually that no new kitty tab opens.

## Follow-up (not in this PR)
Durable hardening discussed on #40: add a `TestMain` in `internal/app` that pins `spawner.Override` and stubs every backend's `Runner`/`RunnerOutput` to no-ops. Catches future backends + future tests in one place. Defer to a separate PR.