### PR TITLE
feat(list): tabwriter-aligned columns, --format json|tsv, ANSI color on TTY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 # running the CLI with a relative FLOW_ROOT.
 /projects/
 /tasks/
+
+# git worktrees for isolated feature work
+/.worktrees/

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,14 @@ module flow
 
 go 1.25.0
 
-require modernc.org/sqlite v1.48.2
+require (
+	github.com/mattn/go-isatty v0.0.20
+	modernc.org/sqlite v1.48.2
+)
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/internal/app/list.go
+++ b/internal/app/list.go
@@ -2,9 +2,11 @@ package app
 
 import (
 	"database/sql"
+	"flag"
 	"flow/internal/flowdb"
 	"flow/internal/listfmt"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,12 +15,46 @@ import (
 
 // waitingMaxRunes caps the [waiting: ...] field width in table output so a
 // long blocking note doesn't blow the row past terminal width. JSON/TSV
-// emit the full value.
+// emit the full value. The --no-truncate flag suppresses this cap.
 const waitingMaxRunes = 60
 
 // identMaxRunes caps the slug column in table output. JSON/TSV emit the full
-// slug regardless.
+// slug regardless. The --no-truncate flag suppresses this cap (handy when
+// you want to copy-paste a long slug into `flow do`).
 const identMaxRunes = 40
+
+// listOpts are the format/color/truncation flags every list subcommand shares.
+type listOpts struct {
+	format     *string
+	noColor    *bool
+	noTruncate *bool
+}
+
+// addListFlags registers the common --format / --no-color / --no-truncate
+// flags on fs.
+func addListFlags(fs *flag.FlagSet) listOpts {
+	return listOpts{
+		format:     fs.String("format", "table", "output format: table|json|tsv"),
+		noColor:    fs.Bool("no-color", false, "disable ANSI color even when stdout is a TTY"),
+		noTruncate: fs.Bool("no-truncate", false, "do not truncate slug or waiting field in table output"),
+	}
+}
+
+// slugMax returns identMaxRunes when truncation is enabled, 0 (disabled) otherwise.
+func (o listOpts) slugMax() int {
+	if *o.noTruncate {
+		return 0
+	}
+	return identMaxRunes
+}
+
+// waitMax returns waitingMaxRunes when truncation is enabled, 0 otherwise.
+func (o listOpts) waitMax() int {
+	if *o.noTruncate {
+		return 0
+	}
+	return waitingMaxRunes
+}
 
 // cmdList dispatches `flow list tasks|projects|playbooks|runs|tags`.
 func cmdList(args []string) int {
@@ -42,19 +78,11 @@ func cmdList(args []string) int {
 	return 2
 }
 
-// addFormatFlags registers --format and --no-color on fs. The returned
-// closure resolves them at parse time into a Format value and a Painter
-// configured for the appropriate output stream.
-func addFormatFlags(fs interface {
-	String(name, value, usage string) *string
-	Bool(name string, value bool, usage string) *bool
-}) (format *string, noColor *bool) {
-	format = fs.String("format", "table", "output format: table|json|tsv")
-	noColor = fs.Bool("no-color", false, "disable ANSI color even when stdout is a TTY")
-	return
-}
+// Color palette. Red is reserved for anomaly signals (overdue / stale).
+// "high" priority is the dominant active state for daily users, so coloring
+// it red turns every row into a wall of red and defeats the signal —
+// keep it bold-uncolored instead.
 
-// statusColor returns the ANSI color code to wrap a status badge in.
 func statusColor(status string) string {
 	switch status {
 	case "in-progress":
@@ -67,11 +95,10 @@ func statusColor(status string) string {
 	return ""
 }
 
-// priorityColor returns the ANSI color code to wrap a priority cell in.
 func priorityColor(pri string) string {
 	switch pri {
 	case "high":
-		return listfmt.Red
+		return listfmt.Bold
 	case "low":
 		return listfmt.Dim
 	}
@@ -84,7 +111,7 @@ func priorityColor(pri string) string {
 func emptyResult(format listfmt.Format, label string, tsvHeaders []string) int {
 	switch format {
 	case listfmt.FormatJSON:
-		fmt.Println("[]")
+		return runJSON(os.Stdout, []any{})
 	case listfmt.FormatTSV:
 		_ = listfmt.RenderTSV(os.Stdout, tsvHeaders, nil)
 	default:
@@ -93,17 +120,13 @@ func emptyResult(format listfmt.Format, label string, tsvHeaders []string) int {
 	return 0
 }
 
-// listTagsCmd prints all distinct tags currently in use across non-archived
-// tasks, with a per-tag task count. Sorted by count descending so the
-// most-used tags appear first. Read this before suggesting new tag
-// names — keeps the user's tag vocabulary consistent.
 func listTagsCmd(args []string) int {
 	fs := flagSet("list tags")
-	format, noColor := addFormatFlags(fs)
+	opts := addListFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	fmtKind, err := listfmt.ParseFormat(*format)
+	fmtKind, err := listfmt.ParseFormat(*opts.format)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 2
@@ -149,11 +172,11 @@ func listTagsCmd(args []string) int {
 		for i, tc := range tags {
 			rows[i] = []string{tc.Tag, fmt.Sprintf("%d", tc.Count)}
 		}
-		_ = listfmt.RenderTSV(os.Stdout, headers, rows)
+		_ = listfmt.RenderTSV(os.Stdout, tsvHeaders, rows)
 		return 0
 	}
 
-	painter := listfmt.Painter{Enabled: listfmt.ColorEnabled(os.Stdout, *noColor)}
+	painter := listfmt.Painter{Enabled: listfmt.ColorEnabled(os.Stdout, *opts.noColor)}
 	tabRows := make([][]string, len(tags))
 	for i, tc := range tags {
 		tabRows[i] = []string{
@@ -179,12 +202,12 @@ func listTasksCmd(args []string) int {
 	includeArchived := fs.Bool("include-archived", false, "include archived tasks")
 	includeDone := fs.Bool("include-done", false, "include done tasks (hidden by default)")
 	kind := fs.String("kind", "regular", "filter by task kind: regular | playbook_run | all")
-	format, noColor := addFormatFlags(fs)
+	opts := addListFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 
-	fmtKind, err := listfmt.ParseFormat(*format)
+	fmtKind, err := listfmt.ParseFormat(*opts.format)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 2
@@ -235,7 +258,12 @@ func listTasksCmd(args []string) int {
 	}
 
 	headers := []string{"STATUS", "PRI", "SLUG", "PROJECT", "AGE", "DUE", "NOTES"}
-	tsvHeaders := []string{"slug", "status", "priority", "project", "age", "due", "notes", "tags"}
+	tsvHeaders := []string{
+		"slug", "status", "priority", "project",
+		"age_days", "due_in_days", "due_label",
+		"stale", "stale_days", "waiting_on", "assignee", "live",
+		"archived", "tags",
+	}
 	if len(tasks) == 0 {
 		return emptyResult(fmtKind, "tasks", tsvHeaders)
 	}
@@ -265,7 +293,6 @@ func listTasksCmd(args []string) int {
 	for _, t := range tasks {
 		r := taskListRow{
 			Slug:     t.Slug,
-			Name:     t.Name,
 			Status:   t.Status,
 			Priority: t.Priority,
 			Archived: t.ArchivedAt.Valid,
@@ -324,30 +351,34 @@ func listTasksCmd(args []string) int {
 				r.Status,
 				r.Priority,
 				r.Project,
-				ageString(r.AgeDays),
+				intOrEmpty(r.AgeDays),
+				intPtrOrEmpty(r.DueInDays),
 				r.DueLabel,
-				notesString(r),
+				boolStr(r.Stale),
+				intOrEmpty(r.StaleDays),
+				r.WaitingOn,
+				r.Assignee,
+				boolStr(r.Live),
+				boolStr(r.Archived),
 				strings.Join(r.Tags, ","),
 			}
 		}
-		_ = listfmt.RenderTSV(os.Stdout,
-			[]string{"slug", "status", "priority", "project", "age", "due", "notes", "tags"},
-			tsvRows)
+		_ = listfmt.RenderTSV(os.Stdout, tsvHeaders, tsvRows)
 		return 0
 	}
 
 	// Table mode: assemble color-aware cells.
-	painter := listfmt.Painter{Enabled: listfmt.ColorEnabled(os.Stdout, *noColor)}
+	painter := listfmt.Painter{Enabled: listfmt.ColorEnabled(os.Stdout, *opts.noColor)}
 	tableRows := make([][]string, len(rows))
 	for i, r := range rows {
 		tableRows[i] = []string{
 			painter.Wrap("["+statusAbbrev(r.Status)+"]", statusColor(r.Status)),
 			painter.Wrap(priorityShort(r.Priority), priorityColor(r.Priority)),
-			listfmt.Truncate(r.Slug, identMaxRunes),
+			listfmt.Truncate(r.Slug, opts.slugMax()),
 			projectCell(r.Project),
 			ageString(r.AgeDays),
 			painter.Wrap(r.DueLabel, dueColor(r)),
-			notesCell(painter, r),
+			notesCell(painter, r, opts.waitMax()),
 		}
 	}
 	tab := &listfmt.Table{
@@ -372,11 +403,35 @@ func projectCell(slug string) string {
 	return "(" + slug + ")"
 }
 
+// intOrEmpty stringifies n unless it's zero, in which case it returns "" —
+// useful for TSV cells where 0 means "no data" rather than literal zero.
+func intOrEmpty(n int) string {
+	if n == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d", n)
+}
+
+func intPtrOrEmpty(p *int) string {
+	if p == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d", *p)
+}
+
+// boolStr renders booleans as "true"/"" so empty TSV cells stay visually
+// quiet and don't clutter the grep'able stream.
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return ""
+}
+
 // taskListRow is the row shape that feeds table, JSON, and TSV rendering
 // for `flow list tasks`. Field order matters for JSON output stability.
 type taskListRow struct {
 	Slug      string   `json:"slug"`
-	Name      string   `json:"name"`
 	Status    string   `json:"status"`
 	Priority  string   `json:"priority"`
 	Project   string   `json:"project,omitempty"`
@@ -405,40 +460,17 @@ func dueColor(r taskListRow) string {
 	return ""
 }
 
-// notesString builds the trailing "notes" column for TSV output. Plain
-// text only; the table renderer uses notesCell to apply per-fragment color.
-func notesString(r taskListRow) string {
-	var parts []string
-	if r.Stale {
-		parts = append(parts, fmt.Sprintf("⚠ stale (%dd)", r.StaleDays))
-	}
-	if r.WaitingOn != "" {
-		parts = append(parts, "[waiting: "+listfmt.Truncate(r.WaitingOn, waitingMaxRunes)+"]")
-	}
-	if r.Assignee != "" {
-		parts = append(parts, "[@"+r.Assignee+"]")
-	}
-	if r.Live {
-		parts = append(parts, "[live]")
-	}
-	for _, t := range r.Tags {
-		parts = append(parts, "#"+t)
-	}
-	if r.Archived {
-		parts = append(parts, "(archived)")
-	}
-	return strings.Join(parts, " ")
-}
-
-// notesCell is the color-aware variant of notesString for table output.
-// Each fragment is independently colored so the row reads well at a glance.
-func notesCell(p listfmt.Painter, r taskListRow) string {
+// notesCell builds the trailing NOTES column in table output. Each fragment
+// is colored independently so the row reads well at a glance. waitMax > 0
+// truncates the waiting field; 0 disables truncation (the --no-truncate
+// path).
+func notesCell(p listfmt.Painter, r taskListRow, waitMax int) string {
 	var parts []string
 	if r.Stale {
 		parts = append(parts, p.Wrap(fmt.Sprintf("⚠ stale (%dd)", r.StaleDays), listfmt.Red))
 	}
 	if r.WaitingOn != "" {
-		parts = append(parts, p.Wrap("[waiting: "+listfmt.Truncate(r.WaitingOn, waitingMaxRunes)+"]", listfmt.Yellow))
+		parts = append(parts, p.Wrap("[waiting: "+listfmt.Truncate(r.WaitingOn, waitMax)+"]", listfmt.Yellow))
 	}
 	if r.Assignee != "" {
 		parts = append(parts, p.Wrap("[@"+r.Assignee+"]", listfmt.Blue))
@@ -459,11 +491,11 @@ func listProjectsCmd(args []string) int {
 	fs := flagSet("list projects")
 	status := fs.String("status", "", "active|done")
 	includeArchived := fs.Bool("include-archived", false, "include archived projects")
-	format, noColor := addFormatFlags(fs)
+	opts := addListFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	fmtKind, err := listfmt.ParseFormat(*format)
+	fmtKind, err := listfmt.ParseFormat(*opts.format)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 2
@@ -523,15 +555,14 @@ func listProjectsCmd(args []string) int {
 	}
 
 	type projectRow struct {
-		Slug      string `json:"slug"`
-		Name      string `json:"name"`
-		Priority  string `json:"priority"`
-		Status    string `json:"status"`
-		Total     int    `json:"total"`
-		InProgress int   `json:"in_progress"`
-		Backlog   int    `json:"backlog"`
-		Done      int    `json:"done"`
-		Archived  bool   `json:"archived,omitempty"`
+		Slug       string `json:"slug"`
+		Priority   string `json:"priority"`
+		Status     string `json:"status"`
+		Total      int    `json:"total"`
+		InProgress int    `json:"in_progress"`
+		Backlog    int    `json:"backlog"`
+		Done       int    `json:"done"`
+		Archived   bool   `json:"archived,omitempty"`
 	}
 
 	rows := make([]projectRow, 0, len(sortedProjects))
@@ -547,7 +578,6 @@ func listProjectsCmd(args []string) int {
 		}
 		rows = append(rows, projectRow{
 			Slug:       p.Slug,
-			Name:       p.Name,
 			Priority:   p.Priority,
 			Status:     statusW,
 			Total:      counts.total,
@@ -570,16 +600,14 @@ func listProjectsCmd(args []string) int {
 				fmt.Sprintf("%d", r.InProgress),
 				fmt.Sprintf("%d", r.Backlog),
 				fmt.Sprintf("%d", r.Done),
-				archivedString(r.Archived),
+				boolStr(r.Archived),
 			}
 		}
-		_ = listfmt.RenderTSV(os.Stdout,
-			[]string{"slug", "priority", "status", "total", "in_progress", "backlog", "done", "archived"},
-			tsvRows)
+		_ = listfmt.RenderTSV(os.Stdout, tsvHeaders, tsvRows)
 		return 0
 	}
 
-	painter := listfmt.Painter{Enabled: listfmt.ColorEnabled(os.Stdout, *noColor)}
+	painter := listfmt.Painter{Enabled: listfmt.ColorEnabled(os.Stdout, *opts.noColor)}
 	tableRows := make([][]string, len(rows))
 	for i, r := range rows {
 		taskLabel := fmt.Sprintf("%d tasks", r.Total)
@@ -613,7 +641,7 @@ func listProjectsCmd(args []string) int {
 		}
 		tableRows[i] = []string{
 			painter.Wrap(priorityShort(r.Priority), priorityColor(r.Priority)),
-			listfmt.Truncate(r.Slug, identMaxRunes),
+			listfmt.Truncate(r.Slug, opts.slugMax()),
 			statusCol,
 			taskLabel,
 			breakdown,
@@ -628,22 +656,15 @@ func listProjectsCmd(args []string) int {
 	return 0
 }
 
-func archivedString(b bool) string {
-	if b {
-		return "archived"
-	}
-	return ""
-}
-
 func listPlaybooksCmd(args []string) int {
 	fs := flagSet("list playbooks")
 	project := fs.String("project", "", "filter by project slug")
 	includeArchived := fs.Bool("include-archived", false, "include archived")
-	format, noColor := addFormatFlags(fs)
+	opts := addListFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	fmtKind, err := listfmt.ParseFormat(*format)
+	fmtKind, err := listfmt.ParseFormat(*opts.format)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 2
@@ -678,13 +699,12 @@ func listPlaybooksCmd(args []string) int {
 
 	type playbookRow struct {
 		Slug     string `json:"slug"`
-		Name     string `json:"name"`
 		Project  string `json:"project,omitempty"`
 		Archived bool   `json:"archived,omitempty"`
 	}
 	rows := make([]playbookRow, len(pbs))
 	for i, pb := range pbs {
-		r := playbookRow{Slug: pb.Slug, Name: pb.Name, Archived: pb.ArchivedAt.Valid}
+		r := playbookRow{Slug: pb.Slug, Archived: pb.ArchivedAt.Valid}
 		if pb.ProjectSlug.Valid {
 			r.Project = pb.ProjectSlug.String
 		}
@@ -697,13 +717,13 @@ func listPlaybooksCmd(args []string) int {
 	case listfmt.FormatTSV:
 		tsvRows := make([][]string, len(rows))
 		for i, r := range rows {
-			tsvRows[i] = []string{r.Slug, r.Project, archivedString(r.Archived)}
+			tsvRows[i] = []string{r.Slug, r.Project, boolStr(r.Archived)}
 		}
-		_ = listfmt.RenderTSV(os.Stdout, []string{"slug", "project", "archived"}, tsvRows)
+		_ = listfmt.RenderTSV(os.Stdout, tsvHeaders, tsvRows)
 		return 0
 	}
 
-	painter := listfmt.Painter{Enabled: listfmt.ColorEnabled(os.Stdout, *noColor)}
+	painter := listfmt.Painter{Enabled: listfmt.ColorEnabled(os.Stdout, *opts.noColor)}
 	tableRows := make([][]string, len(rows))
 	for i, r := range rows {
 		notes := ""
@@ -711,7 +731,7 @@ func listPlaybooksCmd(args []string) int {
 			notes = painter.Wrap("(archived)", listfmt.Dim)
 		}
 		tableRows[i] = []string{
-			listfmt.Truncate(r.Slug, identMaxRunes),
+			listfmt.Truncate(r.Slug, opts.slugMax()),
 			projectCell(r.Project),
 			notes,
 		}
@@ -728,11 +748,11 @@ func listRunsCmd(args []string) int {
 	fs := flagSet("list runs")
 	status := fs.String("status", "", "backlog|in-progress|done")
 	includeArchived := fs.Bool("include-archived", false, "include archived")
-	format, noColor := addFormatFlags(fs)
+	opts := addListFlags(fs)
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	fmtKind, err := listfmt.ParseFormat(*format)
+	fmtKind, err := listfmt.ParseFormat(*opts.format)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 2
@@ -792,13 +812,13 @@ func listRunsCmd(args []string) int {
 	case listfmt.FormatTSV:
 		tsvRows := make([][]string, len(rows))
 		for i, r := range rows {
-			tsvRows[i] = []string{r.Slug, r.Status, r.Playbook, archivedString(r.Archived)}
+			tsvRows[i] = []string{r.Slug, r.Status, r.Playbook, boolStr(r.Archived)}
 		}
-		_ = listfmt.RenderTSV(os.Stdout, []string{"slug", "status", "playbook", "archived"}, tsvRows)
+		_ = listfmt.RenderTSV(os.Stdout, tsvHeaders, tsvRows)
 		return 0
 	}
 
-	painter := listfmt.Painter{Enabled: listfmt.ColorEnabled(os.Stdout, *noColor)}
+	painter := listfmt.Painter{Enabled: listfmt.ColorEnabled(os.Stdout, *opts.noColor)}
 	tableRows := make([][]string, len(rows))
 	for i, r := range rows {
 		notes := ""
@@ -807,7 +827,7 @@ func listRunsCmd(args []string) int {
 		}
 		tableRows[i] = []string{
 			painter.Wrap("["+statusAbbrev(r.Status)+"]", statusColor(r.Status)),
-			listfmt.Truncate(r.Slug, identMaxRunes),
+			listfmt.Truncate(r.Slug, opts.slugMax()),
 			projectCell(r.Playbook),
 			notes,
 		}
@@ -821,7 +841,7 @@ func listRunsCmd(args []string) int {
 }
 
 // runJSON is a thin wrapper that reports errors as exit code 1.
-func runJSON(w *os.File, v any) int {
+func runJSON(w io.Writer, v any) int {
 	if err := listfmt.RenderJSON(w, v); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1

--- a/internal/app/list.go
+++ b/internal/app/list.go
@@ -14,14 +14,9 @@ import (
 )
 
 // waitingMaxRunes caps the [waiting: ...] field width in table output so a
-// long blocking note doesn't blow the row past terminal width. JSON/TSV
-// emit the full value. The --no-truncate flag suppresses this cap.
+// long freeform blocking note doesn't blow the row past terminal width.
+// JSON/TSV emit the full value. The --no-truncate flag suppresses this cap.
 const waitingMaxRunes = 60
-
-// identMaxRunes caps the slug column in table output. JSON/TSV emit the full
-// slug regardless. The --no-truncate flag suppresses this cap (handy when
-// you want to copy-paste a long slug into `flow do`).
-const identMaxRunes = 40
 
 // listOpts are the format/color/truncation flags every list subcommand shares.
 type listOpts struct {
@@ -31,21 +26,14 @@ type listOpts struct {
 }
 
 // addListFlags registers the common --format / --no-color / --no-truncate
-// flags on fs.
+// flags on fs. Slugs are never truncated — only the freeform waiting field
+// has a default cap, which --no-truncate disables.
 func addListFlags(fs *flag.FlagSet) listOpts {
 	return listOpts{
 		format:     fs.String("format", "table", "output format: table|json|tsv"),
 		noColor:    fs.Bool("no-color", false, "disable ANSI color even when stdout is a TTY"),
-		noTruncate: fs.Bool("no-truncate", false, "do not truncate slug or waiting field in table output"),
+		noTruncate: fs.Bool("no-truncate", false, "do not truncate the [waiting: ...] field in table output"),
 	}
-}
-
-// slugMax returns identMaxRunes when truncation is enabled, 0 (disabled) otherwise.
-func (o listOpts) slugMax() int {
-	if *o.noTruncate {
-		return 0
-	}
-	return identMaxRunes
 }
 
 // waitMax returns waitingMaxRunes when truncation is enabled, 0 otherwise.
@@ -257,7 +245,7 @@ func listTasksCmd(args []string) int {
 		return 1
 	}
 
-	headers := []string{"STATUS", "PRI", "SLUG", "PROJECT", "AGE", "DUE", "NOTES"}
+	headers := []string{"STATUS", "PRIORITY", "SLUG", "PROJECT", "AGE", "DUE", "NOTES"}
 	tsvHeaders := []string{
 		"slug", "status", "priority", "project",
 		"age_days", "due_in_days", "due_label",
@@ -374,7 +362,7 @@ func listTasksCmd(args []string) int {
 		tableRows[i] = []string{
 			painter.Wrap("["+statusAbbrev(r.Status)+"]", statusColor(r.Status)),
 			painter.Wrap(priorityShort(r.Priority), priorityColor(r.Priority)),
-			listfmt.Truncate(r.Slug, opts.slugMax()),
+			r.Slug,
 			projectCell(r.Project),
 			ageString(r.AgeDays),
 			painter.Wrap(r.DueLabel, dueColor(r)),
@@ -522,7 +510,7 @@ func listProjectsCmd(args []string) int {
 		return 1
 	}
 
-	headers := []string{"PRI", "SLUG", "STATUS", "TASKS", "BREAKDOWN", "NOTES"}
+	headers := []string{"PRIORITY", "SLUG", "STATUS", "TASKS", "BREAKDOWN", "NOTES"}
 	tsvHeaders := []string{"slug", "priority", "status", "total", "in_progress", "backlog", "done", "archived"}
 	if len(projects) == 0 {
 		return emptyResult(fmtKind, "projects", tsvHeaders)
@@ -641,7 +629,7 @@ func listProjectsCmd(args []string) int {
 		}
 		tableRows[i] = []string{
 			painter.Wrap(priorityShort(r.Priority), priorityColor(r.Priority)),
-			listfmt.Truncate(r.Slug, opts.slugMax()),
+			r.Slug,
 			statusCol,
 			taskLabel,
 			breakdown,
@@ -731,7 +719,7 @@ func listPlaybooksCmd(args []string) int {
 			notes = painter.Wrap("(archived)", listfmt.Dim)
 		}
 		tableRows[i] = []string{
-			listfmt.Truncate(r.Slug, opts.slugMax()),
+			r.Slug,
 			projectCell(r.Project),
 			notes,
 		}
@@ -827,7 +815,7 @@ func listRunsCmd(args []string) int {
 		}
 		tableRows[i] = []string{
 			painter.Wrap("["+statusAbbrev(r.Status)+"]", statusColor(r.Status)),
-			listfmt.Truncate(r.Slug, opts.slugMax()),
+			r.Slug,
 			projectCell(r.Playbook),
 			notes,
 		}

--- a/internal/app/list.go
+++ b/internal/app/list.go
@@ -3,12 +3,22 @@ package app
 import (
 	"database/sql"
 	"flow/internal/flowdb"
+	"flow/internal/listfmt"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 )
+
+// waitingMaxRunes caps the [waiting: ...] field width in table output so a
+// long blocking note doesn't blow the row past terminal width. JSON/TSV
+// emit the full value.
+const waitingMaxRunes = 60
+
+// identMaxRunes caps the slug column in table output. JSON/TSV emit the full
+// slug regardless.
+const identMaxRunes = 40
 
 // cmdList dispatches `flow list tasks|projects|playbooks|runs|tags`.
 func cmdList(args []string) int {
@@ -32,13 +42,70 @@ func cmdList(args []string) int {
 	return 2
 }
 
+// addFormatFlags registers --format and --no-color on fs. The returned
+// closure resolves them at parse time into a Format value and a Painter
+// configured for the appropriate output stream.
+func addFormatFlags(fs interface {
+	String(name, value, usage string) *string
+	Bool(name string, value bool, usage string) *bool
+}) (format *string, noColor *bool) {
+	format = fs.String("format", "table", "output format: table|json|tsv")
+	noColor = fs.Bool("no-color", false, "disable ANSI color even when stdout is a TTY")
+	return
+}
+
+// statusColor returns the ANSI color code to wrap a status badge in.
+func statusColor(status string) string {
+	switch status {
+	case "in-progress":
+		return listfmt.Green
+	case "backlog":
+		return listfmt.Yellow
+	case "done":
+		return listfmt.Dim
+	}
+	return ""
+}
+
+// priorityColor returns the ANSI color code to wrap a priority cell in.
+func priorityColor(pri string) string {
+	switch pri {
+	case "high":
+		return listfmt.Red
+	case "low":
+		return listfmt.Dim
+	}
+	return ""
+}
+
+// emptyResult prints the conventional "(no X)" line and returns 0. Honors
+// the requested format: JSON emits "[]", TSV emits a header-only stream,
+// table emits the human-friendly placeholder.
+func emptyResult(format listfmt.Format, label string, tsvHeaders []string) int {
+	switch format {
+	case listfmt.FormatJSON:
+		fmt.Println("[]")
+	case listfmt.FormatTSV:
+		_ = listfmt.RenderTSV(os.Stdout, tsvHeaders, nil)
+	default:
+		fmt.Printf("(no %s)\n", label)
+	}
+	return 0
+}
+
 // listTagsCmd prints all distinct tags currently in use across non-archived
 // tasks, with a per-tag task count. Sorted by count descending so the
 // most-used tags appear first. Read this before suggesting new tag
 // names — keeps the user's tag vocabulary consistent.
 func listTagsCmd(args []string) int {
 	fs := flagSet("list tags")
+	format, noColor := addFormatFlags(fs)
 	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	fmtKind, err := listfmt.ParseFormat(*format)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 2
 	}
 
@@ -59,13 +126,46 @@ func listTagsCmd(args []string) int {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
 	}
+
+	headers := []string{"TAG", "COUNT"}
+	tsvHeaders := []string{"tag", "count"}
 	if len(tags) == 0 {
-		fmt.Println("(no tags in use)")
+		return emptyResult(fmtKind, "tags in use", tsvHeaders)
+	}
+
+	switch fmtKind {
+	case listfmt.FormatJSON:
+		type tagRow struct {
+			Tag   string `json:"tag"`
+			Count int    `json:"count"`
+		}
+		rows := make([]tagRow, len(tags))
+		for i, tc := range tags {
+			rows[i] = tagRow{Tag: tc.Tag, Count: tc.Count}
+		}
+		return runJSON(os.Stdout, rows)
+	case listfmt.FormatTSV:
+		rows := make([][]string, len(tags))
+		for i, tc := range tags {
+			rows[i] = []string{tc.Tag, fmt.Sprintf("%d", tc.Count)}
+		}
+		_ = listfmt.RenderTSV(os.Stdout, headers, rows)
 		return 0
 	}
-	for _, tc := range tags {
-		fmt.Printf("  #%-30s %d tasks\n", tc.Tag, tc.Count)
+
+	painter := listfmt.Painter{Enabled: listfmt.ColorEnabled(os.Stdout, *noColor)}
+	tabRows := make([][]string, len(tags))
+	for i, tc := range tags {
+		tabRows[i] = []string{
+			painter.Wrap("#"+tc.Tag, listfmt.Cyan),
+			fmt.Sprintf("%d tasks", tc.Count),
+		}
 	}
+	tab := &listfmt.Table{
+		Headers: dimHeaders(painter, headers),
+		Rows:    tabRows,
+	}
+	_ = tab.Render(os.Stdout)
 	return 0
 }
 
@@ -79,7 +179,14 @@ func listTasksCmd(args []string) int {
 	includeArchived := fs.Bool("include-archived", false, "include archived tasks")
 	includeDone := fs.Bool("include-done", false, "include done tasks (hidden by default)")
 	kind := fs.String("kind", "regular", "filter by task kind: regular | playbook_run | all")
+	format, noColor := addFormatFlags(fs)
 	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	fmtKind, err := listfmt.ParseFormat(*format)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 2
 	}
 
@@ -126,9 +233,11 @@ func listTasksCmd(args []string) int {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
 	}
+
+	headers := []string{"STATUS", "PRI", "SLUG", "PROJECT", "AGE", "DUE", "NOTES"}
+	tsvHeaders := []string{"slug", "status", "priority", "project", "age", "due", "notes", "tags"}
 	if len(tasks) == 0 {
-		fmt.Println("(no tasks)")
-		return 0
+		return emptyResult(fmtKind, "tasks", tsvHeaders)
 	}
 
 	root, err := flowRoot()
@@ -140,170 +249,223 @@ func listTasksCmd(args []string) int {
 	now := time.Now()
 
 	// Best-effort scan of running claude processes. ps failures are
-	// silently ignored — the list still renders, just without [live]
+	// silently ignored — the rows still render, just without [live]
 	// markers. See sessions.go for the limitations.
 	live, _ := liveClaudeSessions()
 
 	// Batch-load tags for every task in the result set. Failures are
-	// non-fatal; the list still renders without #tag tokens.
+	// non-fatal; the rows still render without #tag tokens.
 	slugs := make([]string, 0, len(tasks))
 	for _, t := range tasks {
 		slugs = append(slugs, t.Slug)
 	}
 	tagsByTask, _ := flowdb.GetTaskTagsBatch(db, slugs)
 
-	// Compute max slug+name width for alignment. We render
-	// "<slug>  <name>" as the identity column; truncate later.
-	type row struct {
-		ident    string
-		statusAb string
-		pri      string
-		project  string
-		age      string
-		due      string
-		stale    string
-		waiting  string
-		assignee string
-		liveTag  string
-		tags     string
-		archived bool
-		done     bool
-	}
-	var rows []row
-	maxIdent := 0
+	rows := make([]taskListRow, 0, len(tasks))
 	for _, t := range tasks {
-		ident := t.Slug
-		if t.Name != "" && t.Name != t.Slug {
-			ident = t.Slug
+		r := taskListRow{
+			Slug:     t.Slug,
+			Name:     t.Name,
+			Status:   t.Status,
+			Priority: t.Priority,
+			Archived: t.ArchivedAt.Valid,
 		}
-		if n := len(ident); n > maxIdent {
-			maxIdent = n
+		if t.ProjectSlug.Valid {
+			r.Project = t.ProjectSlug.String
 		}
-		r := row{
-			ident:    ident,
-			statusAb: statusAbbrev(t.Status),
-			pri:      priorityShort(t.Priority),
-			archived: t.ArchivedAt.Valid,
-			done:     t.Status == "done",
-		}
-		if t.ProjectSlug.Valid && t.ProjectSlug.String != "" {
-			r.project = "(" + t.ProjectSlug.String + ")"
-		}
-
-		// Age: days in current status.
 		if !t.ArchivedAt.Valid {
 			if age := daysInStatus(t, now); age > 0 {
-				r.age = fmt.Sprintf("%dd", age)
+				r.AgeDays = age
 			}
 		}
-
-		// Due date indicator.
 		if diff, ok := daysUntilDue(t, now); ok {
+			d := diff
+			r.DueInDays = &d
 			switch {
 			case diff < 0:
-				r.due = fmt.Sprintf("⚠ overdue %dd", -diff)
+				r.DueLabel = fmt.Sprintf("⚠ overdue %dd", -diff)
 			case diff == 0:
-				r.due = "⚡ due today"
+				r.DueLabel = "⚡ due today"
 			case diff == 1:
-				r.due = "due tomorrow"
+				r.DueLabel = "due tomorrow"
 			default:
-				r.due = fmt.Sprintf("due %dd", diff)
+				r.DueLabel = fmt.Sprintf("due %dd", diff)
 			}
 		}
-
 		if t.Status == "in-progress" && !t.ArchivedAt.Valid {
 			if days, ok := taskStaleness(t, root); ok {
-				r.stale = fmt.Sprintf("⚠ stale (%dd)", days)
+				r.Stale = true
+				r.StaleDays = days
 			}
 		}
-		if t.WaitingOn.Valid && t.WaitingOn.String != "" {
-			r.waiting = "[waiting: " + t.WaitingOn.String + "]"
+		if t.WaitingOn.Valid {
+			r.WaitingOn = t.WaitingOn.String
 		}
-		if t.Assignee.Valid && t.Assignee.String != "" {
-			r.assignee = "[@" + t.Assignee.String + "]"
+		if t.Assignee.Valid {
+			r.Assignee = t.Assignee.String
 		}
-		if t.SessionID.Valid && t.SessionID.String != "" {
-			if live[strings.ToLower(t.SessionID.String)] {
-				r.liveTag = "[live]"
-			}
+		if t.SessionID.Valid && live[strings.ToLower(t.SessionID.String)] {
+			r.Live = true
 		}
-		if tags, ok := tagsByTask[t.Slug]; ok && len(tags) > 0 {
-			parts := make([]string, len(tags))
-			for i, tg := range tags {
-				parts[i] = "#" + tg
-			}
-			r.tags = strings.Join(parts, " ")
+		if tags, ok := tagsByTask[t.Slug]; ok {
+			r.Tags = tags
 		}
 		rows = append(rows, r)
 	}
 
-	// Render each row. We align the ident column across all rows.
-	identW := maxIdent
-	if identW > 40 {
-		identW = 40
+	switch fmtKind {
+	case listfmt.FormatJSON:
+		return runJSON(os.Stdout, rows)
+	case listfmt.FormatTSV:
+		tsvRows := make([][]string, len(rows))
+		for i, r := range rows {
+			tsvRows[i] = []string{
+				r.Slug,
+				r.Status,
+				r.Priority,
+				r.Project,
+				ageString(r.AgeDays),
+				r.DueLabel,
+				notesString(r),
+				strings.Join(r.Tags, ","),
+			}
+		}
+		_ = listfmt.RenderTSV(os.Stdout,
+			[]string{"slug", "status", "priority", "project", "age", "due", "notes", "tags"},
+			tsvRows)
+		return 0
 	}
-	if identW < 10 {
-		identW = 10
+
+	// Table mode: assemble color-aware cells.
+	painter := listfmt.Painter{Enabled: listfmt.ColorEnabled(os.Stdout, *noColor)}
+	tableRows := make([][]string, len(rows))
+	for i, r := range rows {
+		tableRows[i] = []string{
+			painter.Wrap("["+statusAbbrev(r.Status)+"]", statusColor(r.Status)),
+			painter.Wrap(priorityShort(r.Priority), priorityColor(r.Priority)),
+			listfmt.Truncate(r.Slug, identMaxRunes),
+			projectCell(r.Project),
+			ageString(r.AgeDays),
+			painter.Wrap(r.DueLabel, dueColor(r)),
+			notesCell(painter, r),
+		}
 	}
-	for _, r := range rows {
-		var sb strings.Builder
-		sb.WriteString("  ")
-		sb.WriteString("[")
-		sb.WriteString(r.statusAb)
-		sb.WriteString("] ")
-		sb.WriteString(fmt.Sprintf("%-6s ", r.pri))
-		ident := r.ident
-		if len(ident) > identW {
-			ident = ident[:identW]
-		}
-		sb.WriteString(fmt.Sprintf("%-*s ", identW, ident))
-		if r.project != "" {
-			sb.WriteString(fmt.Sprintf(" %-18s", r.project))
-		} else {
-			sb.WriteString(fmt.Sprintf(" %-18s", ""))
-		}
-		if r.age != "" {
-			sb.WriteString(fmt.Sprintf("  %4s", r.age))
-		} else {
-			sb.WriteString("      ")
-		}
-		if r.due != "" {
-			sb.WriteString("  ")
-			sb.WriteString(r.due)
-		}
-		if r.stale != "" {
-			sb.WriteString("  ")
-			sb.WriteString(r.stale)
-		}
-		if r.waiting != "" {
-			sb.WriteString("  ")
-			sb.WriteString(r.waiting)
-		}
-		if r.assignee != "" {
-			sb.WriteString("  ")
-			sb.WriteString(r.assignee)
-		}
-		if r.liveTag != "" {
-			sb.WriteString("  ")
-			sb.WriteString(r.liveTag)
-		}
-		if r.tags != "" {
-			sb.WriteString("  ")
-			sb.WriteString(r.tags)
-		}
-		if r.archived {
-			sb.WriteString("  (archived)")
-		}
-		fmt.Println(strings.TrimRight(sb.String(), " "))
+	tab := &listfmt.Table{
+		Headers: dimHeaders(painter, headers),
+		Rows:    tableRows,
 	}
+	_ = tab.Render(os.Stdout)
 	return 0
+}
+
+func ageString(days int) string {
+	if days <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("%dd", days)
+}
+
+func projectCell(slug string) string {
+	if slug == "" {
+		return ""
+	}
+	return "(" + slug + ")"
+}
+
+// taskListRow is the row shape that feeds table, JSON, and TSV rendering
+// for `flow list tasks`. Field order matters for JSON output stability.
+type taskListRow struct {
+	Slug      string   `json:"slug"`
+	Name      string   `json:"name"`
+	Status    string   `json:"status"`
+	Priority  string   `json:"priority"`
+	Project   string   `json:"project,omitempty"`
+	AgeDays   int      `json:"age_days,omitempty"`
+	DueInDays *int     `json:"due_in_days,omitempty"`
+	DueLabel  string   `json:"due_label,omitempty"`
+	Stale     bool     `json:"stale,omitempty"`
+	StaleDays int      `json:"stale_days,omitempty"`
+	WaitingOn string   `json:"waiting_on,omitempty"`
+	Assignee  string   `json:"assignee,omitempty"`
+	Live      bool     `json:"live,omitempty"`
+	Archived  bool     `json:"archived,omitempty"`
+	Tags      []string `json:"tags,omitempty"`
+}
+
+func dueColor(r taskListRow) string {
+	if r.DueInDays == nil {
+		return ""
+	}
+	if *r.DueInDays < 0 {
+		return listfmt.Red
+	}
+	if *r.DueInDays == 0 {
+		return listfmt.Yellow
+	}
+	return ""
+}
+
+// notesString builds the trailing "notes" column for TSV output. Plain
+// text only; the table renderer uses notesCell to apply per-fragment color.
+func notesString(r taskListRow) string {
+	var parts []string
+	if r.Stale {
+		parts = append(parts, fmt.Sprintf("⚠ stale (%dd)", r.StaleDays))
+	}
+	if r.WaitingOn != "" {
+		parts = append(parts, "[waiting: "+listfmt.Truncate(r.WaitingOn, waitingMaxRunes)+"]")
+	}
+	if r.Assignee != "" {
+		parts = append(parts, "[@"+r.Assignee+"]")
+	}
+	if r.Live {
+		parts = append(parts, "[live]")
+	}
+	for _, t := range r.Tags {
+		parts = append(parts, "#"+t)
+	}
+	if r.Archived {
+		parts = append(parts, "(archived)")
+	}
+	return strings.Join(parts, " ")
+}
+
+// notesCell is the color-aware variant of notesString for table output.
+// Each fragment is independently colored so the row reads well at a glance.
+func notesCell(p listfmt.Painter, r taskListRow) string {
+	var parts []string
+	if r.Stale {
+		parts = append(parts, p.Wrap(fmt.Sprintf("⚠ stale (%dd)", r.StaleDays), listfmt.Red))
+	}
+	if r.WaitingOn != "" {
+		parts = append(parts, p.Wrap("[waiting: "+listfmt.Truncate(r.WaitingOn, waitingMaxRunes)+"]", listfmt.Yellow))
+	}
+	if r.Assignee != "" {
+		parts = append(parts, p.Wrap("[@"+r.Assignee+"]", listfmt.Blue))
+	}
+	if r.Live {
+		parts = append(parts, p.Wrap("[live]", listfmt.Cyan))
+	}
+	for _, t := range r.Tags {
+		parts = append(parts, p.Wrap("#"+t, listfmt.Gray))
+	}
+	if r.Archived {
+		parts = append(parts, p.Wrap("(archived)", listfmt.Dim))
+	}
+	return strings.Join(parts, " ")
 }
 
 func listProjectsCmd(args []string) int {
 	fs := flagSet("list projects")
 	status := fs.String("status", "", "active|done")
 	includeArchived := fs.Bool("include-archived", false, "include archived projects")
+	format, noColor := addFormatFlags(fs)
 	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	fmtKind, err := listfmt.ParseFormat(*format)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 2
 	}
 	filter := flowdb.ProjectFilter{
@@ -327,14 +489,15 @@ func listProjectsCmd(args []string) int {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
 	}
+
+	headers := []string{"PRI", "SLUG", "STATUS", "TASKS", "BREAKDOWN", "NOTES"}
+	tsvHeaders := []string{"slug", "priority", "status", "total", "in_progress", "backlog", "done", "archived"}
 	if len(projects) == 0 {
-		fmt.Println("(no projects)")
-		return 0
+		return emptyResult(fmtKind, "projects", tsvHeaders)
 	}
 
 	// Sort projects by priority (high, med, low) then slug. ListProjects
 	// currently sorts by slug only, so reorder here.
-	// A stable insertion sort is fine at the volumes we expect.
 	sortedProjects := make([]*flowdb.Project, len(projects))
 	copy(sortedProjects, projects)
 	priorityOrder := func(p string) int {
@@ -348,7 +511,6 @@ func listProjectsCmd(args []string) int {
 		}
 		return 3
 	}
-	// Simple insertion sort for stability and small N.
 	for i := 1; i < len(sortedProjects); i++ {
 		for j := i; j > 0; j-- {
 			a, b := sortedProjects[j-1], sortedProjects[j]
@@ -360,19 +522,19 @@ func listProjectsCmd(args []string) int {
 		}
 	}
 
-	maxSlug := 0
-	for _, p := range sortedProjects {
-		if n := len(p.Slug); n > maxSlug {
-			maxSlug = n
-		}
-	}
-	if maxSlug > 40 {
-		maxSlug = 40
-	}
-	if maxSlug < 10 {
-		maxSlug = 10
+	type projectRow struct {
+		Slug      string `json:"slug"`
+		Name      string `json:"name"`
+		Priority  string `json:"priority"`
+		Status    string `json:"status"`
+		Total     int    `json:"total"`
+		InProgress int   `json:"in_progress"`
+		Backlog   int    `json:"backlog"`
+		Done      int    `json:"done"`
+		Archived  bool   `json:"archived,omitempty"`
 	}
 
+	rows := make([]projectRow, 0, len(sortedProjects))
 	for _, p := range sortedProjects {
 		counts, err := projectTaskCounts(db, p.Slug)
 		if err != nil {
@@ -383,44 +545,107 @@ func listProjectsCmd(args []string) int {
 		if p.Status != "" {
 			statusW = p.Status
 		}
-		slug := p.Slug
-		if len(slug) > maxSlug {
-			slug = slug[:maxSlug]
-		}
+		rows = append(rows, projectRow{
+			Slug:       p.Slug,
+			Name:       p.Name,
+			Priority:   p.Priority,
+			Status:     statusW,
+			Total:      counts.total,
+			InProgress: counts.inProg,
+			Backlog:    counts.backlog,
+			Done:       counts.done,
+			Archived:   p.ArchivedAt.Valid,
+		})
+	}
 
-		label := fmt.Sprintf("%d tasks", counts.total)
-		if counts.total == 1 {
-			label = "1 task "
+	switch fmtKind {
+	case listfmt.FormatJSON:
+		return runJSON(os.Stdout, rows)
+	case listfmt.FormatTSV:
+		tsvRows := make([][]string, len(rows))
+		for i, r := range rows {
+			tsvRows[i] = []string{
+				r.Slug, r.Priority, r.Status,
+				fmt.Sprintf("%d", r.Total),
+				fmt.Sprintf("%d", r.InProgress),
+				fmt.Sprintf("%d", r.Backlog),
+				fmt.Sprintf("%d", r.Done),
+				archivedString(r.Archived),
+			}
+		}
+		_ = listfmt.RenderTSV(os.Stdout,
+			[]string{"slug", "priority", "status", "total", "in_progress", "backlog", "done", "archived"},
+			tsvRows)
+		return 0
+	}
+
+	painter := listfmt.Painter{Enabled: listfmt.ColorEnabled(os.Stdout, *noColor)}
+	tableRows := make([][]string, len(rows))
+	for i, r := range rows {
+		taskLabel := fmt.Sprintf("%d tasks", r.Total)
+		if r.Total == 1 {
+			taskLabel = "1 task"
 		}
 		var segs []string
-		if counts.inProg > 0 {
-			segs = append(segs, fmt.Sprintf("%d IP", counts.inProg))
+		if r.InProgress > 0 {
+			segs = append(segs, fmt.Sprintf("%d IP", r.InProgress))
 		}
-		if counts.backlog > 0 {
-			segs = append(segs, fmt.Sprintf("%d BL", counts.backlog))
+		if r.Backlog > 0 {
+			segs = append(segs, fmt.Sprintf("%d BL", r.Backlog))
 		}
-		if counts.done > 0 {
-			segs = append(segs, fmt.Sprintf("%d DN", counts.done))
+		if r.Done > 0 {
+			segs = append(segs, fmt.Sprintf("%d DN", r.Done))
 		}
 		breakdown := ""
 		if len(segs) > 0 {
 			breakdown = "(" + strings.Join(segs, ", ") + ")"
 		}
-		arch := ""
-		if p.ArchivedAt.Valid {
-			arch = "  (archived)"
+		notes := ""
+		if r.Archived {
+			notes = painter.Wrap("(archived)", listfmt.Dim)
 		}
-		fmt.Printf("  %-6s %-*s   %-7s %s %s%s\n",
-			priorityShort(p.Priority), maxSlug, slug, statusW, label, breakdown, arch)
+		statusCol := r.Status
+		switch r.Status {
+		case "active":
+			statusCol = painter.Wrap(r.Status, listfmt.Green)
+		case "done":
+			statusCol = painter.Wrap(r.Status, listfmt.Dim)
+		}
+		tableRows[i] = []string{
+			painter.Wrap(priorityShort(r.Priority), priorityColor(r.Priority)),
+			listfmt.Truncate(r.Slug, identMaxRunes),
+			statusCol,
+			taskLabel,
+			breakdown,
+			notes,
+		}
 	}
+	tab := &listfmt.Table{
+		Headers: dimHeaders(painter, headers),
+		Rows:    tableRows,
+	}
+	_ = tab.Render(os.Stdout)
 	return 0
+}
+
+func archivedString(b bool) string {
+	if b {
+		return "archived"
+	}
+	return ""
 }
 
 func listPlaybooksCmd(args []string) int {
 	fs := flagSet("list playbooks")
 	project := fs.String("project", "", "filter by project slug")
 	includeArchived := fs.Bool("include-archived", false, "include archived")
+	format, noColor := addFormatFlags(fs)
 	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	fmtKind, err := listfmt.ParseFormat(*format)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 2
 	}
 
@@ -444,21 +669,58 @@ func listPlaybooksCmd(args []string) int {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
 	}
+
+	headers := []string{"SLUG", "PROJECT", "NOTES"}
+	tsvHeaders := []string{"slug", "project", "archived"}
 	if len(pbs) == 0 {
-		fmt.Println("(no playbooks)")
+		return emptyResult(fmtKind, "playbooks", tsvHeaders)
+	}
+
+	type playbookRow struct {
+		Slug     string `json:"slug"`
+		Name     string `json:"name"`
+		Project  string `json:"project,omitempty"`
+		Archived bool   `json:"archived,omitempty"`
+	}
+	rows := make([]playbookRow, len(pbs))
+	for i, pb := range pbs {
+		r := playbookRow{Slug: pb.Slug, Name: pb.Name, Archived: pb.ArchivedAt.Valid}
+		if pb.ProjectSlug.Valid {
+			r.Project = pb.ProjectSlug.String
+		}
+		rows[i] = r
+	}
+
+	switch fmtKind {
+	case listfmt.FormatJSON:
+		return runJSON(os.Stdout, rows)
+	case listfmt.FormatTSV:
+		tsvRows := make([][]string, len(rows))
+		for i, r := range rows {
+			tsvRows[i] = []string{r.Slug, r.Project, archivedString(r.Archived)}
+		}
+		_ = listfmt.RenderTSV(os.Stdout, []string{"slug", "project", "archived"}, tsvRows)
 		return 0
 	}
-	for _, pb := range pbs {
-		proj := ""
-		if pb.ProjectSlug.Valid {
-			proj = "(" + pb.ProjectSlug.String + ")"
+
+	painter := listfmt.Painter{Enabled: listfmt.ColorEnabled(os.Stdout, *noColor)}
+	tableRows := make([][]string, len(rows))
+	for i, r := range rows {
+		notes := ""
+		if r.Archived {
+			notes = painter.Wrap("(archived)", listfmt.Dim)
 		}
-		archived := ""
-		if pb.ArchivedAt.Valid {
-			archived = "  (archived)"
+		tableRows[i] = []string{
+			listfmt.Truncate(r.Slug, identMaxRunes),
+			projectCell(r.Project),
+			notes,
 		}
-		fmt.Printf("  %-40s %s%s\n", pb.Slug, proj, archived)
 	}
+	tab := &listfmt.Table{
+		Headers: dimHeaders(painter, headers),
+		Rows:    tableRows,
+	}
+	_ = tab.Render(os.Stdout)
 	return 0
 }
 
@@ -466,7 +728,13 @@ func listRunsCmd(args []string) int {
 	fs := flagSet("list runs")
 	status := fs.String("status", "", "backlog|in-progress|done")
 	includeArchived := fs.Bool("include-archived", false, "include archived")
+	format, noColor := addFormatFlags(fs)
 	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	fmtKind, err := listfmt.ParseFormat(*format)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 2
 	}
 	var playbookSlug string
@@ -496,22 +764,82 @@ func listRunsCmd(args []string) int {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
 	}
+
+	headers := []string{"STATUS", "SLUG", "PLAYBOOK", "NOTES"}
+	tsvHeaders := []string{"slug", "status", "playbook", "archived"}
 	if len(tasks) == 0 {
-		fmt.Println("(no runs)")
+		return emptyResult(fmtKind, "runs", tsvHeaders)
+	}
+
+	type runRow struct {
+		Slug     string `json:"slug"`
+		Status   string `json:"status"`
+		Playbook string `json:"playbook,omitempty"`
+		Archived bool   `json:"archived,omitempty"`
+	}
+	rows := make([]runRow, len(tasks))
+	for i, tk := range tasks {
+		r := runRow{Slug: tk.Slug, Status: tk.Status, Archived: tk.ArchivedAt.Valid}
+		if tk.PlaybookSlug.Valid {
+			r.Playbook = tk.PlaybookSlug.String
+		}
+		rows[i] = r
+	}
+
+	switch fmtKind {
+	case listfmt.FormatJSON:
+		return runJSON(os.Stdout, rows)
+	case listfmt.FormatTSV:
+		tsvRows := make([][]string, len(rows))
+		for i, r := range rows {
+			tsvRows[i] = []string{r.Slug, r.Status, r.Playbook, archivedString(r.Archived)}
+		}
+		_ = listfmt.RenderTSV(os.Stdout, []string{"slug", "status", "playbook", "archived"}, tsvRows)
 		return 0
 	}
-	for _, tk := range tasks {
-		archived := ""
-		if tk.ArchivedAt.Valid {
-			archived = "  (archived)"
+
+	painter := listfmt.Painter{Enabled: listfmt.ColorEnabled(os.Stdout, *noColor)}
+	tableRows := make([][]string, len(rows))
+	for i, r := range rows {
+		notes := ""
+		if r.Archived {
+			notes = painter.Wrap("(archived)", listfmt.Dim)
 		}
-		pbCol := ""
-		if tk.PlaybookSlug.Valid {
-			pbCol = "(" + tk.PlaybookSlug.String + ")"
+		tableRows[i] = []string{
+			painter.Wrap("["+statusAbbrev(r.Status)+"]", statusColor(r.Status)),
+			listfmt.Truncate(r.Slug, identMaxRunes),
+			projectCell(r.Playbook),
+			notes,
 		}
-		fmt.Printf("  [%s] %-50s %s%s\n", statusAbbrev(tk.Status), tk.Slug, pbCol, archived)
+	}
+	tab := &listfmt.Table{
+		Headers: dimHeaders(painter, headers),
+		Rows:    tableRows,
+	}
+	_ = tab.Render(os.Stdout)
+	return 0
+}
+
+// runJSON is a thin wrapper that reports errors as exit code 1.
+func runJSON(w *os.File, v any) int {
+	if err := listfmt.RenderJSON(w, v); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
 	}
 	return 0
+}
+
+// dimHeaders wraps each header label in dim ANSI when color is enabled so
+// the header line reads as supporting text rather than a row of data.
+func dimHeaders(p listfmt.Painter, hs []string) []string {
+	if !p.Enabled {
+		return hs
+	}
+	out := make([]string, len(hs))
+	for i, h := range hs {
+		out[i] = p.Wrap(h, listfmt.Dim)
+	}
+	return out
 }
 
 // ---------- helpers ----------

--- a/internal/app/list_test.go
+++ b/internal/app/list_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"database/sql"
+	"encoding/json"
 	"flow/internal/flowdb"
 	"os"
 	"path/filepath"
@@ -745,5 +746,182 @@ func TestListTagsAggregatesValues(t *testing.T) {
 	}
 	if got[1].Tag != "beta" || got[1].Count != 1 {
 		t.Errorf("second should be beta×1, got %+v", got[1])
+	}
+}
+
+// ---------- --format / --no-color / --no-truncate ----------
+
+func TestCmdListTasksFormatJSON(t *testing.T) {
+	root, db := showListEditDB(t)
+	insertProject(t, db, "demo", "Demo", filepath.Join(root, "repo"), "high")
+	insertTask(t, db, "a-ip", "Alpha IP", "in-progress", "high", filepath.Join(root, "repo"), "demo")
+	insertTask(t, db, "b-bl", "Beta BL", "backlog", "medium", filepath.Join(root, "repo"), nil)
+
+	out := captureStdout(t, func() {
+		if rc := cmdList([]string{"tasks", "--format", "json"}); rc != 0 {
+			t.Fatalf("rc=%d", rc)
+		}
+	})
+	var rows []taskListRow
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("output is not valid JSON: %v\nout=%q", err, out)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2: %+v", len(rows), rows)
+	}
+	// Expect priority sort: high before medium.
+	if rows[0].Slug != "a-ip" || rows[0].Priority != "high" || rows[0].Status != "in-progress" {
+		t.Errorf("row 0 unexpected: %+v", rows[0])
+	}
+	if rows[1].Slug != "b-bl" || rows[1].Priority != "medium" || rows[1].Status != "backlog" {
+		t.Errorf("row 1 unexpected: %+v", rows[1])
+	}
+	if rows[0].Project != "demo" {
+		t.Errorf("row 0 should carry project=demo, got %q", rows[0].Project)
+	}
+	// Floating task must not carry a project value.
+	if rows[1].Project != "" {
+		t.Errorf("row 1 should be floating, got project=%q", rows[1].Project)
+	}
+}
+
+func TestCmdListTasksFormatTSV(t *testing.T) {
+	root, db := showListEditDB(t)
+	insertTask(t, db, "only-one", "Only", "in-progress", "high", filepath.Join(root, "x"), nil)
+	if _, err := db.Exec(`UPDATE tasks SET waiting_on = ? WHERE slug = ?`, "Alice", "only-one"); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(t, func() {
+		if rc := cmdList([]string{"tasks", "--format", "tsv"}); rc != 0 {
+			t.Fatalf("rc=%d", rc)
+		}
+	})
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want 2 lines (header + 1 row), got %d:\n%s", len(lines), out)
+	}
+	header := strings.Split(lines[0], "\t")
+	row := strings.Split(lines[1], "\t")
+	if len(header) != len(row) {
+		t.Errorf("column count mismatch: header=%d, row=%d", len(header), len(row))
+	}
+	// `waiting_on` must be a first-class column (raw value, no [waiting: ...]
+	// prefix and no ellipsis truncation) so scripts can pipe it cleanly.
+	waitIdx := -1
+	for i, h := range header {
+		if h == "waiting_on" {
+			waitIdx = i
+			break
+		}
+	}
+	if waitIdx < 0 {
+		t.Fatalf("waiting_on header missing: %v", header)
+	}
+	if row[waitIdx] != "Alice" {
+		t.Errorf("waiting_on cell = %q, want %q", row[waitIdx], "Alice")
+	}
+}
+
+func TestCmdListTasksFormatBad(t *testing.T) {
+	_, _ = showListEditDB(t)
+	if rc := cmdList([]string{"tasks", "--format", "yaml"}); rc != 2 {
+		t.Errorf("rc=%d, want 2 (usage error)", rc)
+	}
+}
+
+func TestCmdListTasksEmptyJSON(t *testing.T) {
+	_, _ = showListEditDB(t)
+	out := captureStdout(t, func() {
+		if rc := cmdList([]string{"tasks", "--format", "json"}); rc != 0 {
+			t.Fatalf("rc=%d", rc)
+		}
+	})
+	var rows []taskListRow
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("empty-result JSON should parse, got %v\nout=%q", err, out)
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected empty array, got %d rows", len(rows))
+	}
+}
+
+func TestCmdListTasksTruncation(t *testing.T) {
+	root, db := showListEditDB(t)
+	longSlug := "very-very-very-very-very-very-long-slug-overrun-cap"
+	insertTask(t, db, longSlug, "L", "in-progress", "high", filepath.Join(root, "x"), nil)
+
+	// Default table mode truncates to identMaxRunes.
+	out := captureStdout(t, func() {
+		if rc := cmdList([]string{"tasks"}); rc != 0 {
+			t.Fatalf("rc=%d", rc)
+		}
+	})
+	if !strings.Contains(out, "…") {
+		t.Errorf("expected ellipsis truncation marker; out=%q", out)
+	}
+	if strings.Contains(out, longSlug) {
+		t.Errorf("full slug should not appear in default table; out=%q", out)
+	}
+
+	// --no-truncate emits the full slug, no ellipsis.
+	out2 := captureStdout(t, func() {
+		if rc := cmdList([]string{"tasks", "--no-truncate"}); rc != 0 {
+			t.Fatalf("rc=%d", rc)
+		}
+	})
+	if !strings.Contains(out2, longSlug) {
+		t.Errorf("full slug missing under --no-truncate; out=%q", out2)
+	}
+	if strings.Contains(out2, "…") {
+		t.Errorf("--no-truncate should not emit ellipsis; out=%q", out2)
+	}
+}
+
+func TestCmdListTasksNoColorPipe(t *testing.T) {
+	// captureStdout uses os.Pipe, which is never a TTY, so color is
+	// already disabled. This test guards the contract: no ANSI escape
+	// byte (0x1b) should ever appear in non-TTY output, even when the
+	// painter is wired in everywhere.
+	root, db := showListEditDB(t)
+	insertTask(t, db, "ip-row", "I", "in-progress", "high", filepath.Join(root, "x"), nil)
+	out := captureStdout(t, func() {
+		if rc := cmdList([]string{"tasks"}); rc != 0 {
+			t.Fatalf("rc=%d", rc)
+		}
+	})
+	if strings.ContainsRune(out, 0x1b) {
+		t.Errorf("non-TTY output contains ANSI escape; out=%q", out)
+	}
+}
+
+func TestCmdListProjectsFormatJSON(t *testing.T) {
+	root, db := showListEditDB(t)
+	insertProject(t, db, "p1", "P1", filepath.Join(root, "x"), "high")
+	insertTask(t, db, "p1-ip", "I", "in-progress", "high", filepath.Join(root, "x"), "p1")
+	insertTask(t, db, "p1-bl", "B", "backlog", "medium", filepath.Join(root, "x"), "p1")
+
+	out := captureStdout(t, func() {
+		if rc := cmdList([]string{"projects", "--format", "json"}); rc != 0 {
+			t.Fatalf("rc=%d", rc)
+		}
+	})
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("invalid JSON: %v\nout=%q", err, out)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("want 1 project, got %d", len(rows))
+	}
+	r := rows[0]
+	if r["slug"] != "p1" {
+		t.Errorf("slug = %v, want p1", r["slug"])
+	}
+	if r["in_progress"].(float64) != 1 || r["backlog"].(float64) != 1 {
+		t.Errorf("breakdown wrong: %+v", r)
+	}
+	// `name` field was removed from JSON — confirm absence.
+	if _, ok := r["name"]; ok {
+		t.Errorf("name field should be absent from project JSON: %+v", r)
 	}
 }

--- a/internal/app/list_test.go
+++ b/internal/app/list_test.go
@@ -846,32 +846,53 @@ func TestCmdListTasksEmptyJSON(t *testing.T) {
 	}
 }
 
-func TestCmdListTasksTruncation(t *testing.T) {
+func TestCmdListTasksSlugAlwaysFull(t *testing.T) {
+	// Slugs are emitted in full by default — there's no length cap. The
+	// only field with a default truncation cap is the freeform waiting
+	// note (covered by TestCmdListTasksWaitingTruncation).
 	root, db := showListEditDB(t)
-	longSlug := "very-very-very-very-very-very-long-slug-overrun-cap"
+	longSlug := "very-very-very-very-very-very-long-slug-no-truncation-here"
 	insertTask(t, db, longSlug, "L", "in-progress", "high", filepath.Join(root, "x"), nil)
 
-	// Default table mode truncates to identMaxRunes.
+	out := captureStdout(t, func() {
+		if rc := cmdList([]string{"tasks"}); rc != 0 {
+			t.Fatalf("rc=%d", rc)
+		}
+	})
+	if !strings.Contains(out, longSlug) {
+		t.Errorf("full slug missing in default output; out=%q", out)
+	}
+	if strings.Contains(out, "…") {
+		t.Errorf("ellipsis should not appear when slug is the only long field; out=%q", out)
+	}
+}
+
+func TestCmdListTasksWaitingTruncation(t *testing.T) {
+	root, db := showListEditDB(t)
+	insertTask(t, db, "blocked", "B", "in-progress", "high", filepath.Join(root, "x"), nil)
+	longWait := "alice is reviewing the migration plan and also waiting on bob for the schema change approval"
+	if _, err := db.Exec(`UPDATE tasks SET waiting_on = ? WHERE slug = ?`, longWait, "blocked"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Default truncates the waiting field.
 	out := captureStdout(t, func() {
 		if rc := cmdList([]string{"tasks"}); rc != 0 {
 			t.Fatalf("rc=%d", rc)
 		}
 	})
 	if !strings.Contains(out, "…") {
-		t.Errorf("expected ellipsis truncation marker; out=%q", out)
-	}
-	if strings.Contains(out, longSlug) {
-		t.Errorf("full slug should not appear in default table; out=%q", out)
+		t.Errorf("waiting field should be truncated with …; out=%q", out)
 	}
 
-	// --no-truncate emits the full slug, no ellipsis.
+	// --no-truncate emits the full waiting note, no ellipsis.
 	out2 := captureStdout(t, func() {
 		if rc := cmdList([]string{"tasks", "--no-truncate"}); rc != 0 {
 			t.Fatalf("rc=%d", rc)
 		}
 	})
-	if !strings.Contains(out2, longSlug) {
-		t.Errorf("full slug missing under --no-truncate; out=%q", out2)
+	if !strings.Contains(out2, longWait) {
+		t.Errorf("full waiting note missing under --no-truncate; out=%q", out2)
 	}
 	if strings.Contains(out2, "…") {
 		t.Errorf("--no-truncate should not emit ellipsis; out=%q", out2)

--- a/internal/listfmt/listfmt.go
+++ b/internal/listfmt/listfmt.go
@@ -1,0 +1,149 @@
+// Package listfmt is the shared output renderer used by every `flow list`
+// subcommand. It wraps text/tabwriter for table output, adds JSON and TSV
+// emitters, and provides ANSI color helpers that disable themselves when
+// stdout is not a TTY.
+package listfmt
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/mattn/go-isatty"
+)
+
+// Format selects how a list result is serialized to the output stream.
+type Format int
+
+const (
+	FormatTable Format = iota
+	FormatJSON
+	FormatTSV
+)
+
+// ParseFormat converts a user-supplied string into a Format. Empty string and
+// "table" both yield FormatTable; "json" and "tsv" are the other accepted
+// values. Comparison is case-insensitive and ignores surrounding whitespace.
+func ParseFormat(s string) (Format, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "table":
+		return FormatTable, nil
+	case "json":
+		return FormatJSON, nil
+	case "tsv":
+		return FormatTSV, nil
+	}
+	return 0, fmt.Errorf("invalid format %q (want table|json|tsv)", s)
+}
+
+// ANSI color codes used by the color-aware renderers below.
+const (
+	Reset  = "\x1b[0m"
+	Bold   = "\x1b[1m"
+	Dim    = "\x1b[2m"
+	Red    = "\x1b[31m"
+	Green  = "\x1b[32m"
+	Yellow = "\x1b[33m"
+	Blue   = "\x1b[34m"
+	Cyan   = "\x1b[36m"
+	Gray   = "\x1b[90m"
+)
+
+// ColorEnabled reports whether ANSI color codes should be emitted to w.
+// Color is disabled when forceOff is true, when the NO_COLOR env var is set
+// (per https://no-color.org), or when w is not a TTY.
+func ColorEnabled(w io.Writer, forceOff bool) bool {
+	if forceOff {
+		return false
+	}
+	if _, ok := os.LookupEnv("NO_COLOR"); ok {
+		return false
+	}
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	return isatty.IsTerminal(f.Fd())
+}
+
+// Painter applies ANSI color when Enabled, otherwise returns text unchanged.
+type Painter struct {
+	Enabled bool
+}
+
+// Wrap returns text decorated with the given ANSI code. The decoration is
+// bracketed by tabwriter.Escape (0xff) markers so the color bytes are excluded
+// from column-width calculations. The Table renderer strips the markers
+// before emitting output.
+func (p Painter) Wrap(text, code string) string {
+	if !p.Enabled || code == "" {
+		return text
+	}
+	return "\xff" + code + "\xff" + text + "\xff" + Reset + "\xff"
+}
+
+// Table is a simple column-aligned renderer backed by text/tabwriter.
+type Table struct {
+	Headers []string
+	Rows    [][]string
+}
+
+// Render writes the table to w. Columns are tab-separated on input and
+// auto-padded to align on output. tabwriter.StripEscape is set so 0xff
+// markers (used by Painter.Wrap to hide ANSI codes from width math) are
+// removed from the output stream.
+func (t *Table) Render(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', tabwriter.StripEscape)
+	if len(t.Headers) > 0 {
+		if _, err := fmt.Fprintln(tw, strings.Join(t.Headers, "\t")); err != nil {
+			return err
+		}
+	}
+	for _, row := range t.Rows {
+		if _, err := fmt.Fprintln(tw, strings.Join(row, "\t")); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+// RenderJSON encodes v as indented JSON. Callers should pass a slice of
+// concrete structs (or maps) — json.Marshal handles key ordering for structs
+// based on field declaration order, giving a stable output.
+func RenderJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+// RenderTSV emits a tab-separated values stream with a header row.
+func RenderTSV(w io.Writer, headers []string, rows [][]string) error {
+	if _, err := fmt.Fprintln(w, strings.Join(headers, "\t")); err != nil {
+		return err
+	}
+	for _, r := range rows {
+		if _, err := fmt.Fprintln(w, strings.Join(r, "\t")); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Truncate shortens s to maxRunes runes, appending an ellipsis when the
+// string was actually shortened. maxRunes <= 0 disables truncation.
+func Truncate(s string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= maxRunes {
+		return s
+	}
+	if maxRunes == 1 {
+		return "…"
+	}
+	return string(runes[:maxRunes-1]) + "…"
+}

--- a/internal/listfmt/listfmt.go
+++ b/internal/listfmt/listfmt.go
@@ -9,11 +9,26 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
-	"text/tabwriter"
+	"unicode/utf8"
 
 	"github.com/mattn/go-isatty"
 )
+
+// ansiSGR matches ANSI SGR (Select Graphic Rendition) escape sequences —
+// the family of codes used for color/bold/dim/etc. We strip these to
+// compute the *visible* width of a cell, which is what tabular alignment
+// must care about. Go's text/tabwriter has no built-in way to exempt
+// inline ANSI from its width math (despite what the Escape-character
+// docs suggest for tab-bearing cells), so we render manually.
+var ansiSGR = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// visibleWidth returns the rune count of s after stripping ANSI SGR
+// escape sequences. This is the width tabular renderers should pad to.
+func visibleWidth(s string) int {
+	return utf8.RuneCountInString(ansiSGR.ReplaceAllString(s, ""))
+}
 
 // Format selects how a list result is serialized to the output stream.
 type Format int
@@ -74,40 +89,78 @@ type Painter struct {
 	Enabled bool
 }
 
-// Wrap returns text decorated with the given ANSI code. The decoration is
-// bracketed by tabwriter.Escape (0xff) markers so the color bytes are excluded
-// from column-width calculations. The Table renderer strips the markers
-// before emitting output.
+// Wrap returns text decorated with the given ANSI code. When color is
+// disabled or code is empty, the input is returned unchanged.
 func (p Painter) Wrap(text, code string) string {
 	if !p.Enabled || code == "" {
 		return text
 	}
-	return "\xff" + code + "\xff" + text + "\xff" + Reset + "\xff"
+	return code + text + Reset
 }
 
-// Table is a simple column-aligned renderer backed by text/tabwriter.
+// Table is a column-aligned renderer. Columns auto-size to the widest
+// *visible* cell — ANSI escape codes are ignored for width purposes, so a
+// row with colored cells aligns identically to a row of plain text.
 type Table struct {
 	Headers []string
 	Rows    [][]string
+	// ColumnGap is the number of spaces inserted between adjacent columns
+	// after the widest cell. Zero falls back to 2.
+	ColumnGap int
 }
 
-// Render writes the table to w. Columns are tab-separated on input and
-// auto-padded to align on output. tabwriter.StripEscape is set so 0xff
-// markers (used by Painter.Wrap to hide ANSI codes from width math) are
-// removed from the output stream.
+// Render writes the table to w. Trailing whitespace is trimmed from every
+// emitted line so an empty last cell doesn't litter output with spaces.
 func (t *Table) Render(w io.Writer) error {
-	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', tabwriter.StripEscape)
+	gap := t.ColumnGap
+	if gap <= 0 {
+		gap = 2
+	}
+
+	allRows := t.Rows
 	if len(t.Headers) > 0 {
-		if _, err := fmt.Fprintln(tw, strings.Join(t.Headers, "\t")); err != nil {
+		allRows = append([][]string{t.Headers}, t.Rows...)
+	}
+	if len(allRows) == 0 {
+		return nil
+	}
+
+	ncols := 0
+	for _, r := range allRows {
+		if len(r) > ncols {
+			ncols = len(r)
+		}
+	}
+	widths := make([]int, ncols)
+	for _, r := range allRows {
+		for i, cell := range r {
+			if vw := visibleWidth(cell); vw > widths[i] {
+				widths[i] = vw
+			}
+		}
+	}
+
+	for _, r := range allRows {
+		var sb strings.Builder
+		for i := 0; i < ncols; i++ {
+			cell := ""
+			if i < len(r) {
+				cell = r[i]
+			}
+			sb.WriteString(cell)
+			if i < ncols-1 {
+				pad := widths[i] - visibleWidth(cell) + gap
+				if pad > 0 {
+					sb.WriteString(strings.Repeat(" ", pad))
+				}
+			}
+		}
+		line := strings.TrimRight(sb.String(), " ")
+		if _, err := fmt.Fprintln(w, line); err != nil {
 			return err
 		}
 	}
-	for _, row := range t.Rows {
-		if _, err := fmt.Fprintln(tw, strings.Join(row, "\t")); err != nil {
-			return err
-		}
-	}
-	return tw.Flush()
+	return nil
 }
 
 // RenderJSON encodes v as indented JSON. Callers should pass a slice of

--- a/internal/listfmt/listfmt.go
+++ b/internal/listfmt/listfmt.go
@@ -1,7 +1,8 @@
 // Package listfmt is the shared output renderer used by every `flow list`
-// subcommand. It wraps text/tabwriter for table output, adds JSON and TSV
-// emitters, and provides ANSI color helpers that disable themselves when
-// stdout is not a TTY.
+// subcommand. It provides a manually-padded Table renderer that's aware of
+// ANSI escape sequences (so colored cells align against uncolored ones),
+// JSON and TSV emitters, and ANSI color helpers that disable themselves
+// when stdout is not a TTY.
 package listfmt
 
 import (
@@ -11,7 +12,6 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/mattn/go-isatty"
 )
@@ -19,15 +19,33 @@ import (
 // ansiSGR matches ANSI SGR (Select Graphic Rendition) escape sequences —
 // the family of codes used for color/bold/dim/etc. We strip these to
 // compute the *visible* width of a cell, which is what tabular alignment
-// must care about. Go's text/tabwriter has no built-in way to exempt
-// inline ANSI from its width math (despite what the Escape-character
-// docs suggest for tab-bearing cells), so we render manually.
+// must care about. Cursor/OSC/hyperlink sequences aren't matched — flow
+// doesn't emit them, but if that changes the regex needs to grow.
 var ansiSGR = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
-// visibleWidth returns the rune count of s after stripping ANSI SGR
-// escape sequences. This is the width tabular renderers should pad to.
+// wideRunes lists the East Asian Wide / emoji glyphs that flow's list
+// output emits inline. Every common terminal renders these as two cells,
+// but utf8.RuneCountInString counts them as one — so without this lookup
+// every overdue/stale row would push the following column one cell left
+// of the header. Add new wide runes here if list.go starts emitting them.
+var wideRunes = map[rune]bool{
+	'⚠': true, // U+26A0 WARNING SIGN
+	'⚡': true, // U+26A1 HIGH VOLTAGE SIGN
+}
+
+// visibleWidth returns the number of terminal cells s occupies, after
+// stripping ANSI SGR escape sequences. Known wide runes count as 2 cells.
 func visibleWidth(s string) int {
-	return utf8.RuneCountInString(ansiSGR.ReplaceAllString(s, ""))
+	stripped := ansiSGR.ReplaceAllString(s, "")
+	n := 0
+	for _, r := range stripped {
+		if wideRunes[r] {
+			n += 2
+		} else {
+			n++
+		}
+	}
+	return n
 }
 
 // Format selects how a list result is serialized to the output stream.

--- a/internal/listfmt/listfmt_test.go
+++ b/internal/listfmt/listfmt_test.go
@@ -102,6 +102,10 @@ func TestVisibleWidth(t *testing.T) {
 		{Red + "hé" + Reset, 2},
 		{"", 0},
 		{"\x1b[31m" + "abc" + "\x1b[0m" + "def", 6},
+		// Wide runes from flow's list output — each counts as 2 cells.
+		{"⚠", 2},
+		{"⚡ due today", 12},
+		{Red + "⚠ stale" + Reset, 8},
 	}
 	for _, c := range cases {
 		if got := visibleWidth(c.s); got != c.want {
@@ -110,9 +114,8 @@ func TestVisibleWidth(t *testing.T) {
 	}
 }
 
-// TestTable_AlignedColumns verifies that tabwriter aligns columns to the
-// widest cell, regardless of input width — the primary value-add over the
-// hand-rolled Sprintf padding we're replacing.
+// TestTable_AlignedColumns verifies that the Table renderer pads columns
+// to the widest visible cell across all rows.
 func TestTable_AlignedColumns(t *testing.T) {
 	tab := &Table{
 		Headers: []string{"A", "B"},
@@ -131,7 +134,7 @@ func TestTable_AlignedColumns(t *testing.T) {
 		t.Fatalf("expected 4 lines, got %d: %q", len(lines), buf.String())
 	}
 	// The "B" column should start at the same column index in every row,
-	// because tabwriter pads the first column to its widest cell.
+	// because the first column is padded to its widest cell.
 	bIdx := -1
 	for i, line := range lines {
 		idx := strings.LastIndexAny(line, "xyzB")

--- a/internal/listfmt/listfmt_test.go
+++ b/internal/listfmt/listfmt_test.go
@@ -86,13 +86,27 @@ func TestPainter_Disabled(t *testing.T) {
 func TestPainter_Enabled(t *testing.T) {
 	p := Painter{Enabled: true}
 	got := p.Wrap("hello", Red)
-	// Wrapped output contains the ANSI code, the text, and the reset, all
-	// bracketed by 0xff markers.
-	if !strings.Contains(got, Red) || !strings.Contains(got, "hello") || !strings.Contains(got, Reset) {
-		t.Errorf("enabled Painter.Wrap missing parts: %q", got)
+	want := Red + "hello" + Reset
+	if got != want {
+		t.Errorf("enabled Painter.Wrap = %q, want %q", got, want)
 	}
-	if !strings.HasPrefix(got, "\xff") || !strings.HasSuffix(got, "\xff") {
-		t.Errorf("enabled Painter.Wrap missing 0xff markers: %q", got)
+}
+
+func TestVisibleWidth(t *testing.T) {
+	cases := []struct {
+		s    string
+		want int
+	}{
+		{"hello", 5},
+		{Red + "hello" + Reset, 5},
+		{Red + "hé" + Reset, 2},
+		{"", 0},
+		{"\x1b[31m" + "abc" + "\x1b[0m" + "def", 6},
+	}
+	for _, c := range cases {
+		if got := visibleWidth(c.s); got != c.want {
+			t.Errorf("visibleWidth(%q) = %d, want %d", c.s, got, c.want)
+		}
 	}
 }
 
@@ -131,25 +145,42 @@ func TestTable_AlignedColumns(t *testing.T) {
 	}
 }
 
-// TestTable_StripsEscape verifies the StripEscape flag is honored — 0xff
-// bytes from Painter.Wrap must not appear in the output stream.
-func TestTable_StripsEscape(t *testing.T) {
+// TestTable_AlignedWithANSI verifies that colored cells align against
+// uncolored cells of the same visible width — the bug that motivated
+// dropping text/tabwriter.
+func TestTable_AlignedWithANSI(t *testing.T) {
 	p := Painter{Enabled: true}
 	tab := &Table{
-		Headers: []string{"name"},
 		Rows: [][]string{
-			{p.Wrap("hello", Red)},
+			{p.Wrap("high", Red), "alpha"},
+			{"med", "beta"},
+			{p.Wrap("low", Dim), "gamma"},
 		},
 	}
 	var buf bytes.Buffer
 	if err := tab.Render(&buf); err != nil {
 		t.Fatalf("Render: %v", err)
 	}
-	if strings.Contains(buf.String(), "\xff") {
-		t.Errorf("output contains 0xff bytes: %q", buf.String())
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d: %q", len(lines), buf.String())
 	}
-	if !strings.Contains(buf.String(), Red) {
-		t.Errorf("output missing ANSI code: %q", buf.String())
+	// The second column should start at the same *visible* offset in
+	// every row. Compute the visible offset of "alpha"/"beta"/"gamma" by
+	// stripping ANSI before locating the marker.
+	offsets := make([]int, 3)
+	markers := []string{"alpha", "beta", "gamma"}
+	for i, ln := range lines {
+		plain := ansiSGR.ReplaceAllString(ln, "")
+		offsets[i] = strings.Index(plain, markers[i])
+		if offsets[i] < 0 {
+			t.Fatalf("line %d: missing marker %q in %q", i, markers[i], ln)
+		}
+	}
+	for i := 1; i < 3; i++ {
+		if offsets[i] != offsets[0] {
+			t.Errorf("line %d column 2 offset = %d, line 0 = %d", i, offsets[i], offsets[0])
+		}
 	}
 }
 

--- a/internal/listfmt/listfmt_test.go
+++ b/internal/listfmt/listfmt_test.go
@@ -1,0 +1,185 @@
+package listfmt
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestParseFormat(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Format
+		err  bool
+	}{
+		{"", FormatTable, false},
+		{"table", FormatTable, false},
+		{"TABLE", FormatTable, false},
+		{" json ", FormatJSON, false},
+		{"tsv", FormatTSV, false},
+		{"yaml", 0, true},
+	}
+	for _, c := range cases {
+		got, err := ParseFormat(c.in)
+		if c.err {
+			if err == nil {
+				t.Errorf("ParseFormat(%q): want error, got nil", c.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseFormat(%q): unexpected error %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("ParseFormat(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	cases := []struct {
+		s    string
+		max  int
+		want string
+	}{
+		{"hello", 10, "hello"},
+		{"hello", 5, "hello"},
+		{"hello", 4, "hel…"},
+		{"hello", 1, "…"},
+		{"hello", 0, "hello"},
+		{"héllo", 4, "hél…"},
+	}
+	for _, c := range cases {
+		got := Truncate(c.s, c.max)
+		if got != c.want {
+			t.Errorf("Truncate(%q, %d) = %q, want %q", c.s, c.max, got, c.want)
+		}
+	}
+}
+
+// TestColorEnabled_NonTTY verifies that a bytes.Buffer (non-TTY writer)
+// always returns false, regardless of NO_COLOR. This is the only branch
+// we can hermetically test without a pty.
+func TestColorEnabled_NonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	if ColorEnabled(&buf, false) {
+		t.Error("ColorEnabled on bytes.Buffer: want false, got true")
+	}
+}
+
+func TestColorEnabled_ForceOff(t *testing.T) {
+	var buf bytes.Buffer
+	if ColorEnabled(&buf, true) {
+		t.Error("ColorEnabled(forceOff=true): want false")
+	}
+}
+
+func TestPainter_Disabled(t *testing.T) {
+	p := Painter{Enabled: false}
+	got := p.Wrap("hello", Red)
+	if got != "hello" {
+		t.Errorf("disabled Painter.Wrap = %q, want %q", got, "hello")
+	}
+}
+
+func TestPainter_Enabled(t *testing.T) {
+	p := Painter{Enabled: true}
+	got := p.Wrap("hello", Red)
+	// Wrapped output contains the ANSI code, the text, and the reset, all
+	// bracketed by 0xff markers.
+	if !strings.Contains(got, Red) || !strings.Contains(got, "hello") || !strings.Contains(got, Reset) {
+		t.Errorf("enabled Painter.Wrap missing parts: %q", got)
+	}
+	if !strings.HasPrefix(got, "\xff") || !strings.HasSuffix(got, "\xff") {
+		t.Errorf("enabled Painter.Wrap missing 0xff markers: %q", got)
+	}
+}
+
+// TestTable_AlignedColumns verifies that tabwriter aligns columns to the
+// widest cell, regardless of input width — the primary value-add over the
+// hand-rolled Sprintf padding we're replacing.
+func TestTable_AlignedColumns(t *testing.T) {
+	tab := &Table{
+		Headers: []string{"A", "B"},
+		Rows: [][]string{
+			{"short", "x"},
+			{"a-much-longer-cell", "y"},
+			{"mid", "z"},
+		},
+	}
+	var buf bytes.Buffer
+	if err := tab.Render(&buf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("expected 4 lines, got %d: %q", len(lines), buf.String())
+	}
+	// The "B" column should start at the same column index in every row,
+	// because tabwriter pads the first column to its widest cell.
+	bIdx := -1
+	for i, line := range lines {
+		idx := strings.LastIndexAny(line, "xyzB")
+		if i == 0 {
+			bIdx = idx
+			continue
+		}
+		if idx != bIdx {
+			t.Errorf("line %d: B-column at %d, want %d (line=%q)", i, idx, bIdx, line)
+		}
+	}
+}
+
+// TestTable_StripsEscape verifies the StripEscape flag is honored — 0xff
+// bytes from Painter.Wrap must not appear in the output stream.
+func TestTable_StripsEscape(t *testing.T) {
+	p := Painter{Enabled: true}
+	tab := &Table{
+		Headers: []string{"name"},
+		Rows: [][]string{
+			{p.Wrap("hello", Red)},
+		},
+	}
+	var buf bytes.Buffer
+	if err := tab.Render(&buf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if strings.Contains(buf.String(), "\xff") {
+		t.Errorf("output contains 0xff bytes: %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), Red) {
+		t.Errorf("output missing ANSI code: %q", buf.String())
+	}
+}
+
+func TestRenderJSON(t *testing.T) {
+	type row struct {
+		Slug   string `json:"slug"`
+		Status string `json:"status"`
+	}
+	rows := []row{{"a", "in-progress"}, {"b", "backlog"}}
+	var buf bytes.Buffer
+	if err := RenderJSON(&buf, rows); err != nil {
+		t.Fatalf("RenderJSON: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `"slug": "a"`) || !strings.Contains(out, `"status": "backlog"`) {
+		t.Errorf("RenderJSON output unexpected: %s", out)
+	}
+}
+
+func TestRenderTSV(t *testing.T) {
+	var buf bytes.Buffer
+	err := RenderTSV(&buf, []string{"slug", "status"}, [][]string{
+		{"a", "in-progress"},
+		{"b", "backlog"},
+	})
+	if err != nil {
+		t.Fatalf("RenderTSV: %v", err)
+	}
+	want := "slug\tstatus\na\tin-progress\nb\tbacklog\n"
+	if buf.String() != want {
+		t.Errorf("RenderTSV =\n%q\nwant\n%q", buf.String(), want)
+	}
+}


### PR DESCRIPTION
## Summary

Revamp every `flow list <subcommand>` (tasks, projects, playbooks, runs, tags) with:

- Auto-sized columns — kills the long-standing `%-18s` overflow on project slugs like `implementation-arch` / `tekion-project-overview` that pushed AGE column right.
- Header row by default (table mode), with `PRIORITY` spelled out (not `PRI`).
- `--format table|json|tsv` flag — table default; JSON/TSV deterministic and `jq`-pipeable.
- ANSI color on TTY only — auto-disabled on pipes, via `NO_COLOR` env, or `--no-color` flag.
- Slugs emitted in full (never truncated) so they remain copy-pasteable into `flow do`.
- `--no-truncate` flag — disables the default 60-rune cap on the freeform `[waiting: ...]` field.

## Screenshots

**`flow list tasks`** —

<img width="1430" height="322" alt="image" src="https://github.com/user-attachments/assets/7c6c3ae3-4140-468f-968d-74879a9fd75f" />

**`flow list projects`** —

<img width="751" height="164" alt="image" src="https://github.com/user-attachments/assets/3b7365d6-4174-4808-a2d4-2cec174a4e5a" />

> Screenshots predate the `PRI → PRIORITY` and "never truncate slugs" pass — see commit `03a823d` and the updated sample below for the final header / slug behavior.

## What changed

### New package `internal/listfmt/`

Shared renderer used by every list subcommand:

- `Table` — manual column-padded renderer, ANSI-aware (computes width from SGR-stripped runes, treats `⚠`/`⚡` as 2 cells).
- `RenderJSON` / `RenderTSV` — deterministic emitters.
- `Painter` — gated ANSI color wrapper.
- `ColorEnabled` — `isatty` + `NO_COLOR` + forceOff.
- `Truncate` — runes-aware with `…` ellipsis, `0` disables.

### `internal/app/list.go` migration

- Every subcommand now goes through `listfmt`.
- New `listOpts` carries `--format` / `--no-color` / `--no-truncate`.
- Tasks TSV emits raw first-class columns (`waiting_on`, `assignee`, `live`, `stale`, `stale_days`, `archived`, `tags`) instead of a stew string. Matches the JSON shape so scripts get parseable data.
- Color palette: `high` priority is bold (not red — daily users have many high-priority rows, so red turned every row into a wall of noise). Red is reserved for `⚠ overdue` and `⚠ stale`.
- Status: `[IP]` green, `[BL]` yellow, `[DN]` dim. `[live]` cyan. `[waiting:]` yellow. `[@assignee]` blue. `(archived)` dim. Headers dim.
- Slug column emitted in full in every table mode (tasks/projects/playbooks/runs). Truncation cost more than it saved — terminal width budget is rarely the constraint, and `…` made long slugs uncopyable.
- `--no-truncate` flag now controls only the `[waiting: ...]` field. JSON and TSV continue to emit the full value regardless.
- Empty results — `(no X)` in table, `[]` in JSON, header-only stream in TSV.
- Bad `--format` value exits with code `2` (usage error).

### Bug fixes along the way

- Initially attempted `text/tabwriter` with its `Escape` (`\xff`) mechanism for ANSI-aware width math. Turns out the docs are misleading — escape pairs only prevent special-char interpretation; they do **not** exempt content from width counting. Switched to manual `visibleWidth`-driven padding. `TestTable_AlignedWithANSI` guards the regression.
- Wide runes (`⚠`, `⚡`) were counted as 1 cell by `utf8.RuneCountInString` but render as 2 in most terminals — caused 1-char drift after overdue/stale markers. Hardcoded wide-rune map fixes it.

## Sample outputs

**Table** (color stripped for markdown — final header layout):

```
STATUS  PRIORITY  SLUG                                        PROJECT         AGE  DUE  NOTES
[IP]    high      fix-integrations-resources-configs-in-json  (integrations)
[BL]    high      integrations-eks                            (integrations)  7d
[BL]    high      integrations-stage-architecture             (integrations)  16d       [live]
[IP]    med       ref-cluster-outputs                         (integrations)  1d        [live]
```

**JSON** (`flow list tasks --format json`):

```json
[
  {
    "slug": "integrations-pod-infra-split",
    "status": "in-progress",
    "priority": "high",
    "project": "integrations",
    "live": true
  }
]
```

**TSV** (`flow list tasks --format tsv | head -2`):

```
slug	status	priority	project	age_days	due_in_days	due_label	stale	stale_days	waiting_on	assignee	live	archived	tags
integrations-pod-infra-split	in-progress	high	integrations								true
```

## Backwards compatibility

- Existing list tests (substring-based) pass unchanged — the visible tokens callers asserted on (`[IP]`, `[waiting: ...]`, `2 IP`, `7d`, `⚠ stale`, `(archived)`, etc.) are preserved.
- No DB schema changes. No flag removals. New flags are additive.

## Test plan

- [x] `go test ./...` — 327 passing (308 baseline + 7 listfmt + new list-format/color/truncation tests).
- [x] `./flow list tasks` — default table view aligns correctly when multiple priority groups exist.
- [x] `./flow list tasks --format json | jq '.[] | select(.priority=="high") | .slug'` — JSON is jq-pipeable.
- [x] `./flow list tasks --format tsv | cut -f10` — `waiting_on` column is raw value.
- [x] `./flow list tasks --no-truncate` — `[waiting: ...]` emitted full, no ellipsis. Slug is full in both modes.
- [x] `./flow list tasks --no-color` — no ANSI bytes in output even on TTY.
- [x] `NO_COLOR=1 ./flow list tasks` — same.
- [x] `./flow list tasks --format yaml` — exits with code 2 and clear error.
- [x] `./flow list tasks --project nonexistent --format json` — emits `[]`.
- [x] `./flow list tasks --project nonexistent --format tsv` — emits header-only stream.
- [x] `[BL]` yellow, `[IP]` green, `high` bold (not red), `[live]` cyan verified on real TTY.

## Out of scope (pre-existing, not changed)

- `flow show task` / `flow show project` / `flow transcript` / `flow workdir list` still use ad-hoc `Sprintf` formatting — future migration target for `listfmt`.
- `listProjectsCmd` hand-rolls insertion sort for priority ordering (pre-existing).
- Existing list tests use substring assertions only — preserved as-is for this PR; future PR could tighten.