### PR TITLE
flow init: install SKILL.md to Codex / Cursor / Gemini skill dirs

### DIFF
--- a/internal/app/init.go
+++ b/internal/app/init.go
@@ -129,6 +129,10 @@ func cmdInit(args []string) int {
 		fmt.Printf("installed SessionStart hook in %s\n", settings)
 	}
 
+	// Clear any opt-out marker — `flow init` is an explicit setup
+	// signal, so subsequent auto-upgrade should run normally.
+	_ = setSkillUninstallOptOut(false)
+
 	fmt.Printf("flow initialized at %s\n", root)
 	fmt.Println(`Next: flow add project "My first project" --work-dir <path>`)
 	return 0

--- a/internal/app/init.go
+++ b/internal/app/init.go
@@ -92,29 +92,33 @@ func cmdInit(args []string) int {
 	}
 	db.Close()
 
-	// Install the skill idempotently. Skip if already present; we never
-	// overwrite on init (use `flow skill update` for that).
-	skillPath, err := skillInstallPath()
+	// Install the skill idempotently for every agent target whose home
+	// dir is present. Skip per-target if SKILL.md already exists — we
+	// never overwrite on init (use `flow skill update` for that).
+	targets, err := skillTargets()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
 	}
-	if _, err := os.Stat(skillPath); os.IsNotExist(err) {
-		if err := os.MkdirAll(filepath.Dir(skillPath), 0o755); err != nil {
-			fmt.Fprintf(os.Stderr, "error: create %s: %v\n", filepath.Dir(skillPath), err)
+	for _, t := range targets {
+		if _, err := os.Stat(t.skillPath); err == nil {
+			continue
+		} else if !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "error: stat %s: %v\n", t.skillPath, err)
 			return 1
 		}
-		if err := os.WriteFile(skillPath, embeddedSkill, 0o644); err != nil {
-			fmt.Fprintf(os.Stderr, "error: write %s: %v\n", skillPath, err)
+		if err := os.MkdirAll(filepath.Dir(t.skillPath), 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "error: create %s: %v\n", filepath.Dir(t.skillPath), err)
 			return 1
 		}
-		if err := writeSkillVersion(Version); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: could not record skill version: %v\n", err)
+		if err := os.WriteFile(t.skillPath, embeddedSkill, 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "error: write %s: %v\n", t.skillPath, err)
+			return 1
 		}
-		fmt.Printf("installed flow skill to %s\n", skillPath)
-	} else if err != nil {
-		fmt.Fprintf(os.Stderr, "error: stat %s: %v\n", skillPath, err)
-		return 1
+		if err := writeVersionAt(versionPathFor(t.skillPath), Version); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not record skill version for %s: %v\n", t.agent, err)
+		}
+		fmt.Printf("installed flow skill to %s\n", t.skillPath)
 	}
 
 	// Install the SessionStart hook idempotently.

--- a/internal/app/skill.go
+++ b/internal/app/skill.go
@@ -148,17 +148,89 @@ func userSettingsPath() (string, error) {
 	return filepath.Join(home, ".claude", "settings.json"), nil
 }
 
-// maybeAutoUpgradeSkill checks the recorded skill version against the
-// running binary's version and, if they differ, refreshes the skill +
-// SessionStart hook. Designed to run on every flow invocation so the
-// user gets a self-healing upgrade flow after replacing the binary.
+// skillUninstallOptOutPath returns the marker file under flowRoot
+// that records "user explicitly ran `flow skill uninstall`, do not
+// auto-reinstall on subsequent `flow` invocations". Living under
+// flowRoot (not under any one agent's home) keeps the signal
+// independent of which agents the user has installed today.
+func skillUninstallOptOutPath() (string, error) {
+	root, err := flowRoot()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, ".skill-uninstalled"), nil
+}
+
+// skillUninstallOptOutSet reports whether the opt-out marker exists.
+// Best-effort: any error (including no flowRoot) is treated as
+// "not opted out" so auto-upgrade still runs on a fresh machine
+// where ~/.flow doesn't exist yet.
+func skillUninstallOptOutSet() bool {
+	p, err := skillUninstallOptOutPath()
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(p)
+	return err == nil
+}
+
+// flowEngagementDetected reports whether the user has taken any
+// prior install action: a flow.db exists (from `flow init`) or some
+// target already has SKILL.md on disk. Used to gate auto-install on
+// the very first invocation of a freshly-downloaded binary.
+func flowEngagementDetected(targets []resolvedSkillTarget) bool {
+	if root, err := flowRoot(); err == nil {
+		if _, err := os.Stat(filepath.Join(root, "flow.db")); err == nil {
+			return true
+		}
+	}
+	for _, t := range targets {
+		if _, err := os.Stat(t.skillPath); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// setSkillUninstallOptOut writes (set=true) or removes (set=false)
+// the opt-out marker. Errors are returned but call sites should
+// generally swallow them — the marker is a hint, never a contract.
+func setSkillUninstallOptOut(set bool) error {
+	p, err := skillUninstallOptOutPath()
+	if err != nil {
+		return err
+	}
+	if !set {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(p, []byte("flow skill uninstall opt-out marker\n"), 0o644)
+}
+
+// maybeAutoUpgradeSkill checks every detected agent target and
+// refreshes its SKILL.md when needed. Designed to run on every flow
+// invocation so the user gets a self-healing install/upgrade flow.
+//
+// "Needed" means either:
+//   - SKILL.md is missing but the agent is present (e.g. user installed
+//     Codex after `flow init` — we want the skill to land without
+//     requiring them to manually re-run `flow skill install --force`).
+//   - SKILL.md exists but VERSION sidecar lags the running binary.
 //
 // The check is intentionally conservative — it does nothing when:
 //   - The binary is a "dev" build (Version == "dev"). Local devs use
 //     `make install` and shouldn't fight an auto-installer.
-//   - The skill isn't installed at all (sentinel: SKILL.md missing).
-//     Treat this as an explicit user opt-out; never re-install.
-//   - The recorded version already matches Version. The common path.
+//   - The user explicitly ran `flow skill uninstall` (marker file at
+//     ~/.flow/.skill-uninstalled). The marker is cleared by
+//     `flow skill install` / `flow init`, so opting back in is a
+//     normal command, not a hidden incantation.
+//   - The recorded version already matches and SKILL.md is present
+//     for every target. The common path.
 //
 // All errors are silent — auto-upgrade is best-effort plumbing, not a
 // command. A user-visible failure here would be far more annoying than
@@ -167,18 +239,33 @@ func maybeAutoUpgradeSkill() {
 	if Version == "" || Version == "dev" {
 		return
 	}
+	if skillUninstallOptOutSet() {
+		return
+	}
 	targets, err := skillTargets()
 	if err != nil {
 		return
 	}
+	// Don't conjure SKILL.md out of thin air on a fresh binary the user
+	// has never touched. Auto-install requires at least one prior
+	// engagement — either `flow init` (flow.db present) or a previous
+	// `flow skill install` (some target's SKILL.md present). Without
+	// this gate, `flow list` on a virgin binary would silently create
+	// ~/.claude/skills/flow/SKILL.md alongside the "not initialized"
+	// error, which is more surprising than helpful.
+	if !flowEngagementDetected(targets) {
+		return
+	}
 	upgraded := false
 	for _, t := range targets {
-		if _, err := os.Stat(t.skillPath); err != nil {
-			// Not installed for this agent → user opted out; don't
-			// reinstall behind their back.
-			continue
+		if _, err := os.Stat(t.skillPath); err == nil {
+			if readVersionAt(versionPathFor(t.skillPath)) == Version {
+				continue
+			}
 		}
-		if readVersionAt(versionPathFor(t.skillPath)) == Version {
+		// Either missing (newly-installed agent) or stale (version
+		// drift). Both want the same action: write the embedded skill.
+		if err := os.MkdirAll(filepath.Dir(t.skillPath), 0o755); err != nil {
 			continue
 		}
 		if err := os.WriteFile(t.skillPath, embeddedSkill, 0o644); err != nil {
@@ -259,6 +346,11 @@ func skillInstall(args []string, forceDefault bool) int {
 		fmt.Printf("installed flow skill to %s\n", t.skillPath)
 	}
 
+	// Explicit install/update is a clear "opt back in" signal — clear
+	// any uninstall marker so maybeAutoUpgradeSkill resumes normal
+	// operation on subsequent runs.
+	_ = setSkillUninstallOptOut(false)
+
 	if *skipHook {
 		fmt.Println("--skip-hook: leaving ~/.claude/settings.json alone")
 		return 0
@@ -322,6 +414,15 @@ func skillUninstall(args []string) int {
 	}
 	if !anyRemoved {
 		fmt.Println("flow skill not installed anywhere — nothing to do")
+	} else {
+		// Drop the opt-out marker so the next `flow` invocation's
+		// auto-upgrade pass doesn't silently reinstall what the user
+		// just removed. Gated on anyRemoved so a no-op uninstall on an
+		// empty home stays a true no-op (no ~/.flow/ created as a side
+		// effect).
+		if err := setSkillUninstallOptOut(true); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not write uninstall marker: %v\n", err)
+		}
 	}
 
 	if *keepHook {

--- a/internal/app/skill.go
+++ b/internal/app/skill.go
@@ -28,50 +28,74 @@ const hookMatcher = "startup|resume"
 const userPromptSubmitHookCommand = "flow hook user-prompt-submit"
 
 // skillTarget describes one agent installation destination for the
-// flow skill: an agent name, the agent's home dir under $HOME, and
-// the absolute SKILL.md path inside that dir.
+// flow skill.
+//
+// presenceSubdir and installSubdir intentionally diverge: most agents
+// install into their own `~/.<agent>/skills/`, but some (Gemini)
+// scan the shared `~/.agents/skills/` root in addition to their own
+// dir, so installing to both would double-load the skill.
 type skillTarget struct {
-	agent     string // "claude", "codex", "cursor", "gemini"
-	homeDir   string // absolute path to ~/.<agent>
-	skillPath string // absolute path to ~/.<agent>/skills/flow/SKILL.md
+	agent          string // "claude", "codex", "cursor", "gemini"
+	presenceSubdir string // dir under $HOME that signals "agent is installed"
+	installSubdir  string // dir under $HOME where SKILL.md goes (parent of skills/flow)
 }
 
-// skillTargetCandidates enumerates the agents flow knows how to install
-// to. Order is significant: Claude first (it's the canonical legacy
-// target and always installed); the rest are auto-discovered.
-var skillTargetCandidates = []struct {
-	agent  string
-	subdir string
-}{
-	{"claude", ".claude"},
-	{"codex", ".codex"},
-	{"cursor", ".cursor"},
-	{"gemini", ".gemini"},
+// skillTargetCandidates enumerates the agents flow knows how to
+// install to. Claude is always installed (canonical legacy target —
+// `flow init` has always created `~/.claude/skills/flow/` even if the
+// user hadn't started Claude yet). Other agents are auto-discovered
+// by checking presenceSubdir on disk.
+//
+// Why presence and install dirs differ for Gemini: Gemini CLI scans
+// `~/.agents/skills/` as a shared multi-agent skills root in addition
+// to its per-agent `~/.gemini/skills/`. Writing to both produces a
+// duplicate-load. The shared root is the better target because other
+// tools (plugins, marketplaces) also discover skills there.
+var skillTargetCandidates = []skillTarget{
+	{agent: "claude", presenceSubdir: ".claude", installSubdir: ".claude"},
+	{agent: "codex", presenceSubdir: ".codex", installSubdir: ".codex"},
+	{agent: "cursor", presenceSubdir: ".cursor", installSubdir: ".cursor"},
+	{agent: "gemini", presenceSubdir: ".gemini", installSubdir: ".agents"},
+}
+
+// skillPathFor returns the absolute SKILL.md path for a candidate
+// under the given home dir.
+func (t skillTarget) skillPathUnder(home string) string {
+	return filepath.Join(home, t.installSubdir, "skills", "flow", "SKILL.md")
+}
+
+// presenceDirUnder returns the absolute path checked to decide
+// whether the agent is installed.
+func (t skillTarget) presenceDirUnder(home string) string {
+	return filepath.Join(home, t.presenceSubdir)
+}
+
+// resolvedSkillTarget is a skillTarget after $HOME has been resolved
+// — it carries absolute paths so callers don't need to recompute.
+type resolvedSkillTarget struct {
+	agent     string
+	skillPath string // absolute path to SKILL.md
 }
 
 // skillTargets returns every install target that should receive
-// SKILL.md right now. Claude is always present (preserves legacy
-// behavior — `flow init` has always created `~/.claude/skills/flow/`
-// even if the user hasn't started Claude yet). Other agents are
-// included only when their parent home dir already exists, so we
-// never pollute `$HOME` for agents the user doesn't have.
-func skillTargets() ([]skillTarget, error) {
+// SKILL.md right now. Claude is always present. Other agents are
+// included only when their presence dir exists, so we never pollute
+// `$HOME` for agents the user doesn't have.
+func skillTargets() ([]resolvedSkillTarget, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("no home dir: %w", err)
 	}
-	var out []skillTarget
+	var out []resolvedSkillTarget
 	for _, c := range skillTargetCandidates {
-		homeDir := filepath.Join(home, c.subdir)
 		if c.agent != "claude" {
-			if _, err := os.Stat(homeDir); err != nil {
+			if _, err := os.Stat(c.presenceDirUnder(home)); err != nil {
 				continue
 			}
 		}
-		out = append(out, skillTarget{
+		out = append(out, resolvedSkillTarget{
 			agent:     c.agent,
-			homeDir:   homeDir,
-			skillPath: filepath.Join(homeDir, "skills", "flow", "SKILL.md"),
+			skillPath: c.skillPathUnder(home),
 		})
 	}
 	return out, nil
@@ -282,7 +306,7 @@ func skillUninstall(args []string) int {
 	}
 	anyRemoved := false
 	for _, c := range skillTargetCandidates {
-		skillDir := filepath.Join(home, c.subdir, "skills", "flow")
+		skillDir := filepath.Dir(c.skillPathUnder(home))
 		if _, err := os.Stat(skillDir); os.IsNotExist(err) {
 			continue
 		} else if err != nil {

--- a/internal/app/skill.go
+++ b/internal/app/skill.go
@@ -27,9 +27,60 @@ const hookMatcher = "startup|resume"
 // hookCommand: changing this string would orphan existing installs.
 const userPromptSubmitHookCommand = "flow hook user-prompt-submit"
 
-// skillInstallPath returns the absolute path where the skill should be
-// installed on disk: ~/.claude/skills/flow/SKILL.md.
-func skillInstallPath() (string, error) {
+// skillTarget describes one agent installation destination for the
+// flow skill: an agent name, the agent's home dir under $HOME, and
+// the absolute SKILL.md path inside that dir.
+type skillTarget struct {
+	agent     string // "claude", "codex", "cursor", "gemini"
+	homeDir   string // absolute path to ~/.<agent>
+	skillPath string // absolute path to ~/.<agent>/skills/flow/SKILL.md
+}
+
+// skillTargetCandidates enumerates the agents flow knows how to install
+// to. Order is significant: Claude first (it's the canonical legacy
+// target and always installed); the rest are auto-discovered.
+var skillTargetCandidates = []struct {
+	agent  string
+	subdir string
+}{
+	{"claude", ".claude"},
+	{"codex", ".codex"},
+	{"cursor", ".cursor"},
+	{"gemini", ".gemini"},
+}
+
+// skillTargets returns every install target that should receive
+// SKILL.md right now. Claude is always present (preserves legacy
+// behavior — `flow init` has always created `~/.claude/skills/flow/`
+// even if the user hasn't started Claude yet). Other agents are
+// included only when their parent home dir already exists, so we
+// never pollute `$HOME` for agents the user doesn't have.
+func skillTargets() ([]skillTarget, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("no home dir: %w", err)
+	}
+	var out []skillTarget
+	for _, c := range skillTargetCandidates {
+		homeDir := filepath.Join(home, c.subdir)
+		if c.agent != "claude" {
+			if _, err := os.Stat(homeDir); err != nil {
+				continue
+			}
+		}
+		out = append(out, skillTarget{
+			agent:     c.agent,
+			homeDir:   homeDir,
+			skillPath: filepath.Join(homeDir, "skills", "flow", "SKILL.md"),
+		})
+	}
+	return out, nil
+}
+
+// claudeSkillInstallPath returns the canonical Claude skill path.
+// Kept as a thin helper because the SessionStart hook is Claude-only
+// and a few callers care specifically about the Claude path.
+func claudeSkillInstallPath() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("no home dir: %w", err)
@@ -37,43 +88,31 @@ func skillInstallPath() (string, error) {
 	return filepath.Join(home, ".claude", "skills", "flow", "SKILL.md"), nil
 }
 
-// skillVersionPath returns the sidecar file that records which binary
-// version installed the current SKILL.md — used by the auto-upgrade
-// check to decide whether to refresh the skill.
-func skillVersionPath() (string, error) {
-	skill, err := skillInstallPath()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(filepath.Dir(skill), "VERSION"), nil
+// versionPathFor returns the VERSION sidecar path adjacent to the
+// given SKILL.md path: `<dir-of-skill>/VERSION`.
+func versionPathFor(skillPath string) string {
+	return filepath.Join(filepath.Dir(skillPath), "VERSION")
 }
 
-// readSkillVersion returns the recorded version string, or "" if the
-// sidecar file is missing or unreadable.
-func readSkillVersion() string {
-	p, err := skillVersionPath()
-	if err != nil {
-		return ""
-	}
-	b, err := os.ReadFile(p)
+// readVersionAt returns the recorded version string at the given
+// VERSION sidecar path, or "" if the file is missing or unreadable.
+func readVersionAt(versionPath string) string {
+	b, err := os.ReadFile(versionPath)
 	if err != nil {
 		return ""
 	}
 	return strings.TrimSpace(string(b))
 }
 
-// writeSkillVersion records v as the version of the binary that
-// installed the current SKILL.md. Errors are non-fatal — failing to
-// write the sidecar should never block a successful skill install.
-func writeSkillVersion(v string) error {
-	p, err := skillVersionPath()
-	if err != nil {
+// writeVersionAt records v as the installed version at the given
+// VERSION sidecar path. Errors are non-fatal at the call sites —
+// failing to write the sidecar should never block a successful skill
+// install.
+func writeVersionAt(versionPath, v string) error {
+	if err := os.MkdirAll(filepath.Dir(versionPath), 0o755); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
-		return err
-	}
-	return os.WriteFile(p, []byte(v+"\n"), 0o644)
+	return os.WriteFile(versionPath, []byte(v+"\n"), 0o644)
 }
 
 // userSettingsPath returns ~/.claude/settings.json.
@@ -104,28 +143,32 @@ func maybeAutoUpgradeSkill() {
 	if Version == "" || Version == "dev" {
 		return
 	}
-	skillPath, err := skillInstallPath()
+	targets, err := skillTargets()
 	if err != nil {
 		return
 	}
-	if _, err := os.Stat(skillPath); err != nil {
-		// Not installed → user opted out; don't reinstall behind their back.
-		return
+	upgraded := false
+	for _, t := range targets {
+		if _, err := os.Stat(t.skillPath); err != nil {
+			// Not installed for this agent → user opted out; don't
+			// reinstall behind their back.
+			continue
+		}
+		if readVersionAt(versionPathFor(t.skillPath)) == Version {
+			continue
+		}
+		if err := os.WriteFile(t.skillPath, embeddedSkill, 0o644); err != nil {
+			continue
+		}
+		_ = writeVersionAt(versionPathFor(t.skillPath), Version)
+		upgraded = true
 	}
-	if readSkillVersion() == Version {
-		return
+	// SessionStart hook + stale UserPromptSubmit cleanup are Claude-only.
+	if upgraded {
+		_, _ = installSessionStartHook()
+		_, _ = uninstallUserPromptSubmitHook()
+		fmt.Fprintf(os.Stderr, "flow: upgraded skill to %s\n", Version)
 	}
-	// Version mismatch — refresh skill bytes and the SessionStart hook.
-	if err := os.WriteFile(skillPath, embeddedSkill, 0o644); err != nil {
-		return
-	}
-	_ = writeSkillVersion(Version)
-	_, _ = installSessionStartHook()
-	// UserPromptSubmit hook was removed in v0.1.0-alpha.7 — the
-	// per-prompt token cost wasn't worth the marginal value. Actively
-	// uninstall any stale entry left behind by older binaries.
-	_, _ = uninstallUserPromptSubmitHook()
-	fmt.Fprintf(os.Stderr, "flow: upgraded skill to %s\n", Version)
 }
 
 // cmdSkill dispatches `flow skill install|uninstall|update`.
@@ -156,30 +199,41 @@ func skillInstall(args []string, forceDefault bool) int {
 		return 2
 	}
 
-	dest, err := skillInstallPath()
+	targets, err := skillTargets()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
 	}
-	if _, err := os.Stat(dest); err == nil && !*force {
-		fmt.Fprintf(os.Stderr, "error: %s already exists; use --force to overwrite\n", dest)
-		return 1
-	} else if err != nil && !os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "error: stat %s: %v\n", dest, err)
-		return 1
+
+	// Pre-check: if any target already has SKILL.md and the user did
+	// not pass --force, refuse the whole batch. Partial overwrites are
+	// confusing; one of two states is much easier to reason about.
+	if !*force {
+		for _, t := range targets {
+			if _, err := os.Stat(t.skillPath); err == nil {
+				fmt.Fprintf(os.Stderr, "error: %s already exists; use --force to overwrite\n", t.skillPath)
+				return 1
+			} else if !os.IsNotExist(err) {
+				fmt.Fprintf(os.Stderr, "error: stat %s: %v\n", t.skillPath, err)
+				return 1
+			}
+		}
 	}
-	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
-		fmt.Fprintf(os.Stderr, "error: create %s: %v\n", filepath.Dir(dest), err)
-		return 1
+
+	for _, t := range targets {
+		if err := os.MkdirAll(filepath.Dir(t.skillPath), 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "error: create %s: %v\n", filepath.Dir(t.skillPath), err)
+			return 1
+		}
+		if err := os.WriteFile(t.skillPath, embeddedSkill, 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "error: write %s: %v\n", t.skillPath, err)
+			return 1
+		}
+		if err := writeVersionAt(versionPathFor(t.skillPath), Version); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not record skill version for %s: %v\n", t.agent, err)
+		}
+		fmt.Printf("installed flow skill to %s\n", t.skillPath)
 	}
-	if err := os.WriteFile(dest, embeddedSkill, 0o644); err != nil {
-		fmt.Fprintf(os.Stderr, "error: write %s: %v\n", dest, err)
-		return 1
-	}
-	if err := writeSkillVersion(Version); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: could not record skill version: %v\n", err)
-	}
-	fmt.Printf("installed flow skill to %s\n", dest)
 
 	if *skipHook {
 		fmt.Println("--skip-hook: leaving ~/.claude/settings.json alone")
@@ -217,20 +271,33 @@ func skillUninstall(args []string) int {
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	dest, err := skillInstallPath()
+	// Uninstall iterates the full candidate set, NOT just live targets,
+	// so we still clean up agents whose home dir disappeared between
+	// install and uninstall. We discover by checking the actual skill
+	// dir path on disk for every known agent.
+	home, err := os.UserHomeDir()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		fmt.Fprintf(os.Stderr, "error: no home dir: %v\n", err)
 		return 1
 	}
-	skillDir := filepath.Dir(dest)
-	if _, err := os.Stat(skillDir); os.IsNotExist(err) {
-		fmt.Printf("flow skill not installed at %s — nothing to do\n", skillDir)
-	} else {
+	anyRemoved := false
+	for _, c := range skillTargetCandidates {
+		skillDir := filepath.Join(home, c.subdir, "skills", "flow")
+		if _, err := os.Stat(skillDir); os.IsNotExist(err) {
+			continue
+		} else if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: stat %s: %v\n", skillDir, err)
+			continue
+		}
 		if err := os.RemoveAll(skillDir); err != nil {
 			fmt.Fprintf(os.Stderr, "error: remove %s: %v\n", skillDir, err)
 			return 1
 		}
 		fmt.Printf("uninstalled flow skill from %s\n", skillDir)
+		anyRemoved = true
+	}
+	if !anyRemoved {
+		fmt.Println("flow skill not installed anywhere — nothing to do")
 	}
 
 	if *keepHook {

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -1,24 +1,19 @@
 ---
 name: flow
 description: |
-  Personal task and Claude session manager. CLI binary is `flow` (assumed
-  on PATH) and stores metadata in ~/.flow/flow.db (SQLite). Use this skill when the
-  user asks about their work, tasks, or projects in any natural phrasing —
-  including but not limited to: "what's left", "what's remaining",
-  "what's pending", "what do I need to do", "what's on my plate",
-  "what should I work on", "status", "give me a status", "anything
-  urgent", "what's overdue", "what's stale", "show me my work",
-  "how's my week looking", "what did I ship", "what's in progress",
-  "what's next", "what am I working on", "where did I leave off",
-  "start my day", "what should I do", "what should I do today".
-  Also use for task/project management actions: "flow", "add a task",
-  "add a project", "resume work", "pick up where I left off", "save a
-  note", "log progress", "write an update", "note that", "I'm waiting
-  on", "blocked on", "stuck until", "mark done", "archive", "weekly
-  review", "clean up my tasks", or when the user invokes any
-  `flow <subcommand>` directly. Also use whenever the user asks you to
-  bootstrap a new Claude session on a task or tell them about their
-  in-flight work.
+  Personal task, project, playbook, and agent-session manager. Use when
+  the user asks about flow or their work in natural language: what's
+  left/pending/remaining, what's on my plate, what should I work on,
+  start my day, status, urgent, overdue, stale, where did I leave off,
+  what shipped, what's next, what's in progress, or show me my work.
+  Also use for task/project/playbook management: add/update/archive work,
+  add task/project/playbook, resume or pick up work, open or close a task
+  session, bind this session, save or log a note, write an update, mark
+  waiting/blocked/stuck, clear waiting, mark done, weekly review, clean up
+  tasks, inspect transcripts, list runs, or when the user invokes any
+  `flow <subcommand>` directly. Use it to bootstrap agent sessions,
+  summarize in-flight work, and keep flow's briefs, updates, and KB
+  current.
 ---
 
 # flow — task and session manager skill

--- a/internal/app/skill_test.go
+++ b/internal/app/skill_test.go
@@ -315,6 +315,233 @@ func TestSkillInstallSkipHook(t *testing.T) {
 	}
 }
 
+// TestSkillTargetsClaudeAlwaysPresent verifies Claude is in the
+// returned target list even when ~/.claude doesn't exist on disk —
+// preserves the legacy behavior where `flow init` always provisions
+// the Claude skill dir.
+func TestSkillTargetsClaudeAlwaysPresent(t *testing.T) {
+	withTempHome(t)
+	targets, err := skillTargets()
+	if err != nil {
+		t.Fatalf("skillTargets: %v", err)
+	}
+	if len(targets) != 1 || targets[0].agent != "claude" {
+		t.Errorf("with empty home, want only claude target; got %+v", targets)
+	}
+}
+
+// TestSkillTargetsDiscoversInstalledAgents seeds ~/.codex, ~/.cursor,
+// ~/.gemini in the tempdir and verifies they all show up alongside
+// Claude.
+func TestSkillTargetsDiscoversInstalledAgents(t *testing.T) {
+	home := withTempHome(t)
+	for _, sub := range []string{".codex", ".cursor", ".gemini"} {
+		if err := os.MkdirAll(filepath.Join(home, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	targets, err := skillTargets()
+	if err != nil {
+		t.Fatalf("skillTargets: %v", err)
+	}
+	gotAgents := make(map[string]string)
+	for _, t := range targets {
+		gotAgents[t.agent] = t.skillPath
+	}
+	for _, want := range []string{"claude", "codex", "cursor", "gemini"} {
+		if _, ok := gotAgents[want]; !ok {
+			t.Errorf("missing %s target; got %+v", want, gotAgents)
+		}
+	}
+	// Spot-check one path shape so future renames stay honest.
+	want := filepath.Join(home, ".codex", "skills", "flow", "SKILL.md")
+	if got := gotAgents["codex"]; got != want {
+		t.Errorf("codex skillPath=%q, want %q", got, want)
+	}
+}
+
+// TestSkillInstallWritesAllAgentTargets verifies `flow skill install`
+// drops SKILL.md into every discovered agent's skills/flow/ dir.
+func TestSkillInstallWritesAllAgentTargets(t *testing.T) {
+	home := withTempHome(t)
+	for _, sub := range []string{".codex", ".cursor", ".gemini"} {
+		if err := os.MkdirAll(filepath.Join(home, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if rc := cmdSkill([]string{"install"}); rc != 0 {
+		t.Fatalf("install rc=%d", rc)
+	}
+
+	for _, agent := range []string{".claude", ".codex", ".cursor", ".gemini"} {
+		p := filepath.Join(home, agent, "skills", "flow", "SKILL.md")
+		data, err := os.ReadFile(p)
+		if err != nil {
+			t.Errorf("missing SKILL.md at %s: %v", p, err)
+			continue
+		}
+		if !strings.Contains(string(data), "name: flow") {
+			t.Errorf("SKILL.md at %s missing frontmatter", p)
+		}
+		// VERSION sidecar should be written per agent.
+		if _, err := os.Stat(filepath.Join(filepath.Dir(p), "VERSION")); err != nil {
+			t.Errorf("missing VERSION sidecar for %s: %v", agent, err)
+		}
+	}
+}
+
+// TestSkillInstallSkipsAbsentAgents verifies an agent home dir that
+// doesn't exist gets no install — we MUST NOT eagerly create
+// ~/.<agent>/ for agents the user doesn't have.
+func TestSkillInstallSkipsAbsentAgents(t *testing.T) {
+	home := withTempHome(t)
+	// Only ~/.codex is present; Cursor/Gemini stay absent.
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if rc := cmdSkill([]string{"install"}); rc != 0 {
+		t.Fatalf("install rc=%d", rc)
+	}
+
+	// Claude + Codex SHOULD exist.
+	for _, want := range []string{".claude", ".codex"} {
+		if _, err := os.Stat(filepath.Join(home, want, "skills", "flow", "SKILL.md")); err != nil {
+			t.Errorf("expected install for %s; got err=%v", want, err)
+		}
+	}
+	// Cursor + Gemini parents MUST NOT have been auto-created.
+	for _, absent := range []string{".cursor", ".gemini"} {
+		if _, err := os.Stat(filepath.Join(home, absent)); !os.IsNotExist(err) {
+			t.Errorf("install must not create ~/%s; stat err=%v", absent, err)
+		}
+	}
+}
+
+// TestSkillInstallRefusesIfAnyTargetExists pins the safety property:
+// even one existing SKILL.md across any target causes plain `install`
+// (without --force) to abort the whole batch.
+func TestSkillInstallRefusesIfAnyTargetExists(t *testing.T) {
+	home := withTempHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-create Codex SKILL.md only.
+	codexSkill := filepath.Join(home, ".codex", "skills", "flow", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(codexSkill), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(codexSkill, []byte("preexisting"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if rc := cmdSkill([]string{"install"}); rc == 0 {
+		t.Errorf("install must fail when any target SKILL.md exists; got rc=0")
+	}
+	// Pre-existing file MUST NOT be modified.
+	got, _ := os.ReadFile(codexSkill)
+	if string(got) != "preexisting" {
+		t.Errorf("refused install must not overwrite existing %s", codexSkill)
+	}
+	// And Claude MUST NOT have been written either (batch-or-nothing).
+	if _, err := os.Stat(filepath.Join(home, ".claude", "skills", "flow", "SKILL.md")); err == nil {
+		t.Errorf("refused install must not write Claude either; found one")
+	}
+}
+
+// TestSkillUpdateOverwritesAllAgents — `flow skill update` is force=true.
+// Should refresh SKILL.md in every discovered agent.
+func TestSkillUpdateOverwritesAllAgents(t *testing.T) {
+	home := withTempHome(t)
+	for _, sub := range []string{".codex", ".gemini"} {
+		if err := os.MkdirAll(filepath.Join(home, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if rc := cmdSkill([]string{"install"}); rc != 0 {
+		t.Fatalf("install rc=%d", rc)
+	}
+	// Stomp every installed SKILL.md so we can prove update refreshes them.
+	for _, agent := range []string{".claude", ".codex", ".gemini"} {
+		p := filepath.Join(home, agent, "skills", "flow", "SKILL.md")
+		if err := os.WriteFile(p, []byte("stale"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if rc := cmdSkill([]string{"update"}); rc != 0 {
+		t.Fatalf("update rc=%d", rc)
+	}
+
+	for _, agent := range []string{".claude", ".codex", ".gemini"} {
+		got, _ := os.ReadFile(filepath.Join(home, agent, "skills", "flow", "SKILL.md"))
+		if string(got) == "stale" {
+			t.Errorf("update did not refresh %s SKILL.md", agent)
+		}
+	}
+}
+
+// TestSkillUninstallRemovesAllAgents verifies uninstall sweeps the
+// flow/ dir from every agent's skills/ tree.
+func TestSkillUninstallRemovesAllAgents(t *testing.T) {
+	home := withTempHome(t)
+	for _, sub := range []string{".codex", ".cursor"} {
+		if err := os.MkdirAll(filepath.Join(home, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if rc := cmdSkill([]string{"install"}); rc != 0 {
+		t.Fatalf("install rc=%d", rc)
+	}
+	if rc := cmdSkill([]string{"uninstall"}); rc != 0 {
+		t.Fatalf("uninstall rc=%d", rc)
+	}
+	for _, agent := range []string{".claude", ".codex", ".cursor"} {
+		p := filepath.Join(home, agent, "skills", "flow")
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("uninstall should remove %s; stat err=%v", p, err)
+		}
+	}
+}
+
+// TestMaybeAutoUpgradeRefreshesAllAgents — version mismatch should
+// refresh SKILL.md in every installed agent target, not just Claude.
+func TestMaybeAutoUpgradeRefreshesAllAgents(t *testing.T) {
+	home := withTempHome(t)
+	for _, sub := range []string{".codex", ".cursor"} {
+		if err := os.MkdirAll(filepath.Join(home, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	withVersion(t, "v1.0.0")
+	if rc := cmdSkill([]string{"install"}); rc != 0 {
+		t.Fatalf("install rc=%d", rc)
+	}
+	// Stomp every SKILL.md so we can detect the refresh.
+	paths := []string{}
+	for _, agent := range []string{".claude", ".codex", ".cursor"} {
+		p := filepath.Join(home, agent, "skills", "flow", "SKILL.md")
+		paths = append(paths, p)
+		if err := os.WriteFile(p, []byte("stale"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	Version = "v2.0.0"
+	maybeAutoUpgradeSkill()
+
+	for _, p := range paths {
+		got, _ := os.ReadFile(p)
+		if string(got) == "stale" {
+			t.Errorf("auto-upgrade did not refresh %s", p)
+		}
+		v := readVersionAt(filepath.Join(filepath.Dir(p), "VERSION"))
+		if v != "v2.0.0" {
+			t.Errorf("%s VERSION=%q, want v2.0.0", p, v)
+		}
+	}
+}
+
 func TestSkillUnknownSubcommand(t *testing.T) {
 	if rc := cmdSkill([]string{"wat"}); rc != 2 {
 		t.Errorf("unknown subcommand rc=%d, want 2", rc)

--- a/internal/app/skill_test.go
+++ b/internal/app/skill_test.go
@@ -88,6 +88,32 @@ func TestSkillInstallWritesFile(t *testing.T) {
 	}
 }
 
+func TestSkillFrontmatterDescriptionFitsCodexLimit(t *testing.T) {
+	got := string(embeddedSkill)
+	const marker = "description: |"
+	start := strings.Index(got, marker)
+	if start == -1 {
+		t.Fatal("skill frontmatter missing description block")
+	}
+	rest := got[start+len(marker):]
+	end := strings.Index(rest, "\n---")
+	if end == -1 {
+		t.Fatal("skill frontmatter missing closing delimiter")
+	}
+
+	var desc strings.Builder
+	for _, line := range strings.Split(rest[:end], "\n") {
+		if line == "" {
+			continue
+		}
+		desc.WriteString(strings.TrimPrefix(line, "  "))
+		desc.WriteByte('\n')
+	}
+	if n := len(strings.TrimSpace(desc.String())); n > 1024 {
+		t.Fatalf("skill description is %d bytes, exceeds Codex limit of 1024", n)
+	}
+}
+
 func TestSkillInstallErrorsOnExisting(t *testing.T) {
 	withTempHome(t)
 	if rc := cmdSkill([]string{"install"}); rc != 0 {
@@ -361,7 +387,9 @@ func TestSkillTargetsDiscoversInstalledAgents(t *testing.T) {
 }
 
 // TestSkillInstallWritesAllAgentTargets verifies `flow skill install`
-// drops SKILL.md into every discovered agent's skills/flow/ dir.
+// drops SKILL.md into every discovered agent's install dir. Gemini's
+// install dir is `~/.agents/skills/flow/` (NOT `~/.gemini/`) because
+// Gemini scans the shared `~/.agents/skills/` root.
 func TestSkillInstallWritesAllAgentTargets(t *testing.T) {
 	home := withTempHome(t)
 	for _, sub := range []string{".codex", ".cursor", ".gemini"} {
@@ -374,11 +402,18 @@ func TestSkillInstallWritesAllAgentTargets(t *testing.T) {
 		t.Fatalf("install rc=%d", rc)
 	}
 
-	for _, agent := range []string{".claude", ".codex", ".cursor", ".gemini"} {
-		p := filepath.Join(home, agent, "skills", "flow", "SKILL.md")
+	// agent -> install subdir under $HOME.
+	wantPaths := map[string]string{
+		"claude": ".claude",
+		"codex":  ".codex",
+		"cursor": ".cursor",
+		"gemini": ".agents", // shared multi-agent skills root
+	}
+	for agent, sub := range wantPaths {
+		p := filepath.Join(home, sub, "skills", "flow", "SKILL.md")
 		data, err := os.ReadFile(p)
 		if err != nil {
-			t.Errorf("missing SKILL.md at %s: %v", p, err)
+			t.Errorf("missing SKILL.md for %s at %s: %v", agent, p, err)
 			continue
 		}
 		if !strings.Contains(string(data), "name: flow") {
@@ -389,11 +424,18 @@ func TestSkillInstallWritesAllAgentTargets(t *testing.T) {
 			t.Errorf("missing VERSION sidecar for %s: %v", agent, err)
 		}
 	}
+
+	// Gemini-specific safety property: no SKILL.md inside ~/.gemini/skills/
+	// even though `~/.gemini/` was created. Double-install would
+	// duplicate-load via Gemini's two scan roots.
+	if _, err := os.Stat(filepath.Join(home, ".gemini", "skills", "flow", "SKILL.md")); err == nil {
+		t.Error("Gemini install must go to ~/.agents/, NOT ~/.gemini/skills/ — both scan roots would double-load")
+	}
 }
 
-// TestSkillInstallSkipsAbsentAgents verifies an agent home dir that
-// doesn't exist gets no install — we MUST NOT eagerly create
-// ~/.<agent>/ for agents the user doesn't have.
+// TestSkillInstallSkipsAbsentAgents verifies an agent presence dir
+// that doesn't exist gets no install — we MUST NOT eagerly create
+// `~/.<agent>/` (or `~/.agents/`) for agents the user doesn't have.
 func TestSkillInstallSkipsAbsentAgents(t *testing.T) {
 	home := withTempHome(t)
 	// Only ~/.codex is present; Cursor/Gemini stay absent.
@@ -411,11 +453,38 @@ func TestSkillInstallSkipsAbsentAgents(t *testing.T) {
 			t.Errorf("expected install for %s; got err=%v", want, err)
 		}
 	}
-	// Cursor + Gemini parents MUST NOT have been auto-created.
-	for _, absent := range []string{".cursor", ".gemini"} {
+	// Cursor presence dir + Gemini presence dir + Gemini install dir
+	// (~/.agents) MUST NOT have been auto-created.
+	for _, absent := range []string{".cursor", ".gemini", ".agents"} {
 		if _, err := os.Stat(filepath.Join(home, absent)); !os.IsNotExist(err) {
 			t.Errorf("install must not create ~/%s; stat err=%v", absent, err)
 		}
+	}
+}
+
+// TestGeminiInstallsToAgentsRoot verifies the Gemini→.agents redirect
+// in isolation: when only ~/.gemini/ exists (no other agents present),
+// the install must land at ~/.agents/skills/flow/SKILL.md, NOT under
+// ~/.gemini/.
+func TestGeminiInstallsToAgentsRoot(t *testing.T) {
+	home := withTempHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".gemini"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if rc := cmdSkill([]string{"install"}); rc != 0 {
+		t.Fatalf("install rc=%d", rc)
+	}
+
+	// Must exist under ~/.agents/skills/flow/.
+	want := filepath.Join(home, ".agents", "skills", "flow", "SKILL.md")
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("Gemini install should land at %s; stat err=%v", want, err)
+	}
+	// Must NOT exist under ~/.gemini/skills/flow/.
+	bad := filepath.Join(home, ".gemini", "skills", "flow", "SKILL.md")
+	if _, err := os.Stat(bad); err == nil {
+		t.Errorf("Gemini install must NOT touch %s — would double-load", bad)
 	}
 }
 
@@ -451,7 +520,8 @@ func TestSkillInstallRefusesIfAnyTargetExists(t *testing.T) {
 }
 
 // TestSkillUpdateOverwritesAllAgents — `flow skill update` is force=true.
-// Should refresh SKILL.md in every discovered agent.
+// Should refresh SKILL.md in every discovered agent's install dir
+// (Gemini's is `.agents`, not `.gemini`).
 func TestSkillUpdateOverwritesAllAgents(t *testing.T) {
 	home := withTempHome(t)
 	for _, sub := range []string{".codex", ".gemini"} {
@@ -462,9 +532,10 @@ func TestSkillUpdateOverwritesAllAgents(t *testing.T) {
 	if rc := cmdSkill([]string{"install"}); rc != 0 {
 		t.Fatalf("install rc=%d", rc)
 	}
+	installSubdirs := []string{".claude", ".codex", ".agents"}
 	// Stomp every installed SKILL.md so we can prove update refreshes them.
-	for _, agent := range []string{".claude", ".codex", ".gemini"} {
-		p := filepath.Join(home, agent, "skills", "flow", "SKILL.md")
+	for _, sub := range installSubdirs {
+		p := filepath.Join(home, sub, "skills", "flow", "SKILL.md")
 		if err := os.WriteFile(p, []byte("stale"), 0o644); err != nil {
 			t.Fatal(err)
 		}
@@ -474,10 +545,10 @@ func TestSkillUpdateOverwritesAllAgents(t *testing.T) {
 		t.Fatalf("update rc=%d", rc)
 	}
 
-	for _, agent := range []string{".claude", ".codex", ".gemini"} {
-		got, _ := os.ReadFile(filepath.Join(home, agent, "skills", "flow", "SKILL.md"))
+	for _, sub := range installSubdirs {
+		got, _ := os.ReadFile(filepath.Join(home, sub, "skills", "flow", "SKILL.md"))
 		if string(got) == "stale" {
-			t.Errorf("update did not refresh %s SKILL.md", agent)
+			t.Errorf("update did not refresh %s SKILL.md", sub)
 		}
 	}
 }
@@ -507,9 +578,10 @@ func TestSkillUninstallRemovesAllAgents(t *testing.T) {
 
 // TestMaybeAutoUpgradeRefreshesAllAgents — version mismatch should
 // refresh SKILL.md in every installed agent target, not just Claude.
+// Includes the Gemini→.agents redirect.
 func TestMaybeAutoUpgradeRefreshesAllAgents(t *testing.T) {
 	home := withTempHome(t)
-	for _, sub := range []string{".codex", ".cursor"} {
+	for _, sub := range []string{".codex", ".cursor", ".gemini"} {
 		if err := os.MkdirAll(filepath.Join(home, sub), 0o755); err != nil {
 			t.Fatal(err)
 		}
@@ -518,10 +590,11 @@ func TestMaybeAutoUpgradeRefreshesAllAgents(t *testing.T) {
 	if rc := cmdSkill([]string{"install"}); rc != 0 {
 		t.Fatalf("install rc=%d", rc)
 	}
-	// Stomp every SKILL.md so we can detect the refresh.
+	// Stomp every SKILL.md so we can detect the refresh. Gemini's
+	// install dir is `.agents`, not `.gemini`.
 	paths := []string{}
-	for _, agent := range []string{".claude", ".codex", ".cursor"} {
-		p := filepath.Join(home, agent, "skills", "flow", "SKILL.md")
+	for _, sub := range []string{".claude", ".codex", ".cursor", ".agents"} {
+		p := filepath.Join(home, sub, "skills", "flow", "SKILL.md")
 		paths = append(paths, p)
 		if err := os.WriteFile(p, []byte("stale"), 0o644); err != nil {
 			t.Fatal(err)

--- a/internal/app/skill_test.go
+++ b/internal/app/skill_test.go
@@ -615,6 +615,106 @@ func TestMaybeAutoUpgradeRefreshesAllAgents(t *testing.T) {
 	}
 }
 
+// TestMaybeAutoUpgradeInstallsNewlyDetectedAgent pins Anshul's gap from
+// PR #45: user runs `flow init` with only Claude installed, later
+// installs Codex. The very next `flow` invocation's auto-upgrade pass
+// must drop SKILL.md into the new agent's dir — not wait for the user
+// to manually re-run `flow skill install --force`.
+func TestMaybeAutoUpgradeInstallsNewlyDetectedAgent(t *testing.T) {
+	home := withTempHome(t)
+	withVersion(t, "v1.0.0")
+	// Initial install with only Claude present.
+	if rc := cmdSkill([]string{"install"}); rc != 0 {
+		t.Fatalf("install rc=%d", rc)
+	}
+	codexSkill := filepath.Join(home, ".codex", "skills", "flow", "SKILL.md")
+	if _, err := os.Stat(codexSkill); err == nil {
+		t.Fatalf("precondition: codex skill should not exist yet")
+	}
+	// User installs Codex CLI later.
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Auto-upgrade runs on next `flow` invocation. Version unchanged —
+	// the trigger here is "newly-detected agent", not version drift.
+	maybeAutoUpgradeSkill()
+
+	if _, err := os.Stat(codexSkill); err != nil {
+		t.Fatalf("auto-upgrade should install for newly-detected codex; got err=%v", err)
+	}
+	if v := readVersionAt(filepath.Join(filepath.Dir(codexSkill), "VERSION")); v != "v1.0.0" {
+		t.Errorf("codex VERSION sidecar=%q, want v1.0.0", v)
+	}
+}
+
+// TestMaybeAutoUpgradeRespectsUninstallMarker pins the opt-out
+// contract: after `flow skill uninstall`, auto-upgrade must NOT
+// silently resurrect SKILL.md on the next `flow` invocation. This is
+// the legitimate "user opted out" case that the marker file makes
+// explicit (replacing the old absence-as-opt-out heuristic).
+func TestMaybeAutoUpgradeRespectsUninstallMarker(t *testing.T) {
+	home := withTempHome(t)
+	// Point flowRoot at the temp home so the marker lands in the
+	// sandbox. The existing skill tests don't init flow, so flowRoot
+	// resolves to $HOME/.flow which is already inside the tempdir.
+	withVersion(t, "v1.0.0")
+	if rc := cmdSkill([]string{"install"}); rc != 0 {
+		t.Fatalf("install rc=%d", rc)
+	}
+	if rc := cmdSkill([]string{"uninstall"}); rc != 0 {
+		t.Fatalf("uninstall rc=%d", rc)
+	}
+	if !skillUninstallOptOutSet() {
+		t.Fatal("uninstall must set opt-out marker")
+	}
+	claudeSkill := filepath.Join(home, ".claude", "skills", "flow", "SKILL.md")
+
+	Version = "v2.0.0"
+	maybeAutoUpgradeSkill()
+
+	if _, err := os.Stat(claudeSkill); err == nil {
+		t.Errorf("auto-upgrade resurrected uninstalled skill at %s", claudeSkill)
+	}
+}
+
+// TestSkillInstallClearsUninstallMarker pins the "explicit install =
+// opt back in" contract: running `flow skill install` after a previous
+// uninstall clears the marker, restoring auto-upgrade for future
+// invocations.
+func TestSkillInstallClearsUninstallMarker(t *testing.T) {
+	withTempHome(t)
+	if rc := cmdSkill([]string{"install"}); rc != 0 {
+		t.Fatalf("install rc=%d", rc)
+	}
+	if rc := cmdSkill([]string{"uninstall"}); rc != 0 {
+		t.Fatalf("uninstall rc=%d", rc)
+	}
+	if !skillUninstallOptOutSet() {
+		t.Fatal("precondition: uninstall should have set the marker")
+	}
+	if rc := cmdSkill([]string{"install"}); rc != 0 {
+		t.Fatalf("second install rc=%d", rc)
+	}
+	if skillUninstallOptOutSet() {
+		t.Error("install did not clear the uninstall marker")
+	}
+}
+
+// TestSkillUninstallNoopDoesNotSetMarker pins the gating on anyRemoved:
+// `flow skill uninstall` against an empty home is a true no-op and
+// must not leave a marker behind (which would block future
+// auto-installs after the user later runs `flow init`).
+func TestSkillUninstallNoopDoesNotSetMarker(t *testing.T) {
+	withTempHome(t)
+	if rc := cmdSkill([]string{"uninstall"}); rc != 0 {
+		t.Fatalf("uninstall rc=%d", rc)
+	}
+	if skillUninstallOptOutSet() {
+		t.Error("uninstall on empty home should not set opt-out marker")
+	}
+}
+
 func TestSkillUnknownSubcommand(t *testing.T) {
 	if rc := cmdSkill([]string{"wat"}); rc != 2 {
 		t.Errorf("unknown subcommand rc=%d, want 2", rc)

--- a/internal/app/version_test.go
+++ b/internal/app/version_test.go
@@ -38,7 +38,7 @@ func TestCmdInitWritesVersionSidecar(t *testing.T) {
 	if rc := cmdInit(nil); rc != 0 {
 		t.Fatalf("cmdInit rc=%d", rc)
 	}
-	if got := readSkillVersion(); got != "v1.2.3" {
+	if got := readVersionAt(filepath.Join(os.Getenv("HOME"), ".claude", "skills", "flow", "VERSION")); got != "v1.2.3" {
 		t.Errorf("readSkillVersion=%q, want v1.2.3", got)
 	}
 }
@@ -66,7 +66,7 @@ func TestMaybeAutoUpgradeUpgradesOnMismatch(t *testing.T) {
 	if string(got) == "stale" {
 		t.Error("auto-upgrade did not refresh SKILL.md")
 	}
-	if v := readSkillVersion(); v != "v2.0.0" {
+	if v := readVersionAt(filepath.Join(os.Getenv("HOME"), ".claude", "skills", "flow", "VERSION")); v != "v2.0.0" {
 		t.Errorf("VERSION sidecar=%q after upgrade, want v2.0.0", v)
 	}
 }


### PR DESCRIPTION
## Summary

`flow init` / `flow skill install` / `flow skill update` / `flow skill uninstall` / `maybeAutoUpgradeSkill` now operate over a list of per-agent install targets instead of the single hard-coded `~/.claude/skills/flow/`. Claude stays always-on; Codex, Cursor, and Gemini are auto-discovered when their parent home dirs exist on disk.

**Gemini specifically** installs to `~/.agents/skills/flow/` (not `~/.gemini/skills/`) because Gemini CLI scans both the shared `~/.agents/skills/` root and its per-agent dir — writing to both would double-load the skill.

## Why

The shipped SKILL.md already documents Codex behavior, but the binary only writes to `~/.claude/`. Other agents support the same SKILL.md format via their own `skills/` dirs and the shared `~/.agents/skills/` root. Filling those dirs is the minimum change required for those IDEs to discover and load the flow skill — no `flow do` runtime changes, no DB schema work, no agent-dispatch logic.

## Implementation

- `skillTarget` separates `presenceSubdir` (existence check) from `installSubdir` (where SKILL.md goes). Identical for Claude/Codex/Cursor; Gemini's presence dir is `~/.gemini/` but install dir is `~/.agents/`.
- `skillTargets()` discovers live targets at runtime. Claude is always included (preserves legacy behavior); others are auto-discovered. We **never** eagerly create `~/.<agent>/` for agents the user doesn't have.
- Per-agent `VERSION` sidecars (`~/.<install-dir>/skills/flow/VERSION`) so each agent upgrades independently.
- Install is **batch-or-nothing**: if any target SKILL.md already exists, plain `install` refuses without `--force`. One mental model, no partial-install states.
- `installSessionStartHook` stays Claude-only — other agents have their own hook mechanisms (or none), out of scope here.
- **Codex 1024-byte description limit**: paired change trims the embedded SKILL.md's `description:` frontmatter block so Codex will actually load the skill. `TestSkillFrontmatterDescriptionFitsCodexLimit` pins the invariant.

## What's intentionally out of scope

- `flow do --agent <codex|opencode|...>` runtime dispatch — partially built on unmerged `facets/codex-support` branch, separate work.
- `session_provider` DB column.
- Agent-specific hook installation beyond Claude's `SessionStart`.
- Opencode support — its `~/.opencode/` layout (node bin tree) doesn't match the global-skills-dir pattern; revisit if opencode adopts one.

## Test plan

- [x] `make test` passes (all packages, including 10 new tests in `internal/app/skill_test.go`):
  - `TestSkillTargetsClaudeAlwaysPresent` — Claude always in the list
  - `TestSkillTargetsDiscoversInstalledAgents` — Codex/Cursor/Gemini auto-discovered when their presence dirs exist
  - `TestSkillInstallWritesAllAgentTargets` — install lands in all 4 dirs; Gemini lands at `~/.agents/`, not `~/.gemini/skills/`
  - `TestSkillInstallSkipsAbsentAgents` — `~/.cursor`, `~/.gemini`, `~/.agents` NOT auto-created when their presence dirs are missing
  - `TestGeminiInstallsToAgentsRoot` — Gemini redirect in isolation
  - `TestSkillInstallRefusesIfAnyTargetExists` — batch-or-nothing safety
  - `TestSkillUpdateOverwritesAllAgents` — `update` refreshes everywhere
  - `TestSkillUninstallRemovesAllAgents` — uninstall sweeps all agents
  - `TestMaybeAutoUpgradeRefreshesAllAgents` — version mismatch refreshes every target
  - `TestSkillFrontmatterDescriptionFitsCodexLimit` — Codex 1024-byte description limit
- [x] End-to-end smoke against fake `\$HOME`:
  - All 4 agent dirs present → SKILL.md lands at 4 correct locations (Gemini at `~/.agents/`)
  - Re-run is idempotent
  - Only `~/.codex/` present → install to Claude + Codex; `~/.cursor`, `~/.gemini`, `~/.agents` NOT created
  - Only `~/.gemini/` present → install to Claude + `~/.agents/`; `~/.gemini/skills/` stays empty
- [ ] Reviewer sanity check: confirm the install matches your local agent layout assumptions (Claude always-on, others discover-only).

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)