### PR TITLE
feat: Warp as a first-class spawn backend + FLOW_TERM override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+
+- **Warp as a first-class spawn backend.** `flow do` opens new tabs
+  in Warp when invoked from a Warp shell (`TERM_PROGRAM=WarpTerminal`).
+  Uses `warp://action/new_tab` to open the tab and osascript to
+  keystroke a self-deleting bootstrap script, since Warp has no
+  AppleScript dictionary or command-running CLI. Requires macOS
+  Accessibility for Warp.
+- **`FLOW_TERM` env override.** Set `FLOW_TERM=warp|iterm|terminal|zellij`
+  to force a specific spawn backend regardless of `$TERM_PROGRAM`.
+  `$ZELLIJ` still wins; unrecognized values fall through to
+  `$TERM_PROGRAM` detection.
+
 ## [0.1.0-alpha.8] — 2026-05-09
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,8 +56,16 @@ flow/
 │   ├── flowdb/                      # SQLite data layer
 │   │   ├── db.go                    # schema, models, CRUD queries
 │   │   └── db_test.go
-│   └── iterm/                       # iTerm2 tab spawning
-│       └── iterm.go
+│   ├── iterm/                       # iTerm2 tab spawning
+│   │   └── iterm.go
+│   ├── terminal/                    # macOS Terminal.app tab spawning
+│   │   └── terminal.go
+│   ├── warp/                        # Warp tab spawning (warp:// URI + osascript keystroke)
+│   │   └── warp.go
+│   ├── zellij/                      # zellij tab spawning
+│   │   └── zellij.go
+│   └── spawner/                     # backend selection + dispatch
+│       └── spawner.go
 ├── Makefile
 ├── README.md
 ├── CLAUDE.md
@@ -68,9 +76,13 @@ flow/
 
 ## Package responsibilities
 
-- **`internal/app`** — all CLI command handlers, dispatch, shared helpers. One file per subcommand. Imports `flowdb` and `iterm`.
+- **`internal/app`** — all CLI command handlers, dispatch, shared helpers. One file per subcommand. Imports `flowdb` and `spawner`.
 - **`internal/flowdb`** — schema DDL, model structs (`Project`, `Task`, `Workdir`), scan helpers, CRUD queries, migrations. All DB access via `database/sql` + `modernc.org/sqlite`.
-- **`internal/iterm`** — osascript-based iTerm2 tab spawning. Exposes `iterm.Runner` var for test mocking.
+- **`internal/spawner`** — picks a terminal backend at runtime (`$ZELLIJ` > `$FLOW_TERM` > `$TERM_PROGRAM` > historical iTerm default) and forwards `SpawnTab` to it. Exposes `Override` for test pinning.
+- **`internal/iterm`** — osascript-based iTerm2 tab spawning. Exposes `iterm.Runner` for test mocking.
+- **`internal/terminal`** — osascript-based macOS Terminal.app tab spawning. Requires Accessibility for the cmd-T keystroke via System Events.
+- **`internal/warp`** — Warp tab spawning via `warp://action/new_tab` URI + osascript keystroke of a self-deleting per-spawn shell script. Exposes `warp.Runner`, `warp.OpenURL`, `warp.WriteScript` for test mocking. Requires Accessibility (same gate as Terminal.app).
+- **`internal/zellij`** — zellij CLI–based tab spawning. Active when `$ZELLIJ` is set in the environment.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -187,11 +187,13 @@ handles the rest.
 ## What you get
 
 - **One task, one Claude session, one tab.** `flow do <task>`
-  spawns a dedicated tab in iTerm2, stock macOS Terminal, kitty
+  spawns a dedicated tab in iTerm2, Warp, stock macOS Terminal, kitty
   (requires `allow_remote_control yes` in `kitty.conf`), or your
   current zellij session (requires zellij ≥ 0.40) — flow picks
-  whichever you launched it from. Tomorrow's `flow do <task>`
-  resumes the same conversation.
+  whichever you launched it from. Override with
+  `FLOW_TERM=warp|iterm|terminal|zellij|kitty` when you're on a
+  non-standard host. Tomorrow's `flow do <task>` resumes the same
+  conversation.
 - **Interview-driven task capture.** No forms. flow asks
   what / why / where / done-when, then writes a structured brief.
 - **A knowledge base that grows.** Five markdown buckets for
@@ -210,10 +212,12 @@ handles the rest.
 
 `flow do <task>` pre-allocates a session UUID, writes it to the
 task row, and spawns a tab in zellij (when `$ZELLIJ` is set), kitty
-(when `$KITTY_WINDOW_ID` is set or `$TERM=xterm-kitty`), iTerm2, or
-stock Terminal.app — chosen in that priority order, with iTerm as
-the historical fallback — running `claude --session-id <uuid>` with
-`FLOW_TASK` / `FLOW_PROJECT` inlined. The jsonl file lands at the deterministic path
+(when `$KITTY_WINDOW_ID` is set or `$TERM=xterm-kitty`), the backend
+named in `$FLOW_TERM` (when set), or Warp / iTerm2 / stock
+Terminal.app (auto-detected from `$TERM_PROGRAM`) — chosen in that
+priority order, with iTerm as the historical fallback — running
+`claude --session-id <uuid>` with `FLOW_TASK` / `FLOW_PROJECT` inlined.
+The jsonl file lands at the deterministic path
 `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`, so future
 `flow do` calls run `claude --resume <uuid>` to continue the same
 conversation. A SessionStart hook re-injects the task brief,
@@ -295,8 +299,8 @@ and reinstall the skill + hook.
 
 ## Where flow runs (and where we'd love help)
 
-Today flow runs on **macOS (iTerm2, stock Terminal.app, kitty, or
-zellij) + Claude Code only**. That's the stack we use, and that's
+Today flow runs on **macOS (iTerm2, Warp, stock Terminal.app, kitty,
+or zellij) + Claude Code only**. That's the stack we use, and that's
 what the session-spawn layer was built and tested against. zellij
 and kitty work on Linux too as a side effect — both are
 cross-platform and flow's zellij / kitty backends don't depend on

--- a/internal/spawner/spawner.go
+++ b/internal/spawner/spawner.go
@@ -1,19 +1,23 @@
-// Package spawner picks a terminal backend (zellij, kitty, iTerm2, or
-// macOS Terminal.app) at runtime and forwards SpawnTab to it.
+// Package spawner picks a terminal backend (zellij, kitty, Warp, iTerm2,
+// or macOS Terminal.app) at runtime and forwards SpawnTab to it.
 //
-// Selection priority:
+// Selection priority (highest first):
 //
 //	$ZELLIJ set                                    → internal/zellij
 //	$KITTY_WINDOW_ID set or $TERM=xterm-kitty      → internal/kitty
+//	$FLOW_TERM=<valid backend>                     → that backend (user override)
+//	TERM_PROGRAM=WarpTerminal                      → internal/warp
 //	TERM_PROGRAM=Apple_Terminal                    → internal/terminal
 //	TERM_PROGRAM=iTerm.app                         → internal/iterm
 //	anything else (or unset)                       → internal/iterm  (historical default)
 //
-// $ZELLIJ wins over everything because if the user is inside a zellij
-// session, that's where their workflow lives — the host terminal is a
-// substrate detail. Kitty sits same tier as zellij (explicit
-// per-window session marker set by the terminal itself) and beats the
-// TERM_PROGRAM fallback because kitty does not set TERM_PROGRAM.
+// $ZELLIJ and kitty's per-window markers win over $FLOW_TERM because if
+// the user is inside a session-manager terminal, that's where their
+// workflow lives — the host terminal is a substrate detail. $FLOW_TERM
+// lets users on non-standard hosts (tmux inside Warp, shell-script
+// invocations, Hyper, wezterm, etc.) opt into a specific backend
+// without relying on TERM_PROGRAM. Unknown values silently fall
+// through to TERM_PROGRAM detection.
 //
 // The Override var lets tests pin the backend deterministically without
 // having to set env vars via t.Setenv.
@@ -23,6 +27,7 @@ import (
 	"flow/internal/iterm"
 	"flow/internal/kitty"
 	"flow/internal/terminal"
+	"flow/internal/warp"
 	"flow/internal/zellij"
 	"os"
 )
@@ -35,6 +40,7 @@ const (
 	BackendTerminal Backend = "terminal"
 	BackendZellij   Backend = "zellij"
 	BackendKitty    Backend = "kitty"
+	BackendWarp     Backend = "warp"
 )
 
 // Override, if non-empty, forces a backend regardless of env vars.
@@ -54,19 +60,27 @@ func Detect() Backend {
 	if os.Getenv("KITTY_WINDOW_ID") != "" || os.Getenv("TERM") == "xterm-kitty" {
 		return BackendKitty
 	}
+	if v := os.Getenv("FLOW_TERM"); v != "" {
+		switch Backend(v) {
+		case BackendITerm, BackendTerminal, BackendZellij, BackendKitty, BackendWarp:
+			return Backend(v)
+		}
+		// Unknown value falls through to TERM_PROGRAM detection.
+	}
 	switch os.Getenv("TERM_PROGRAM") {
 	case "Apple_Terminal":
 		return BackendTerminal
 	case "iTerm.app":
 		return BackendITerm
+	case "WarpTerminal":
+		return BackendWarp
 	default:
 		return BackendITerm
 	}
 }
 
 // SpawnTab opens a tab in the auto-detected backend. The contract
-// matches iterm.SpawnTab, terminal.SpawnTab, zellij.SpawnTab, and
-// kitty.SpawnTab.
+// matches every backend's SpawnTab.
 func SpawnTab(title, cwd, command string, envVars map[string]string) error {
 	switch Detect() {
 	case BackendZellij:
@@ -75,6 +89,8 @@ func SpawnTab(title, cwd, command string, envVars map[string]string) error {
 		return kitty.SpawnTab(title, cwd, command, envVars)
 	case BackendTerminal:
 		return terminal.SpawnTab(title, cwd, command, envVars)
+	case BackendWarp:
+		return warp.SpawnTab(title, cwd, command, envVars)
 	default:
 		return iterm.SpawnTab(title, cwd, command, envVars)
 	}

--- a/internal/spawner/spawner_test.go
+++ b/internal/spawner/spawner_test.go
@@ -4,14 +4,15 @@ import (
 	"flow/internal/iterm"
 	"flow/internal/kitty"
 	"flow/internal/terminal"
+	"flow/internal/warp"
 	"flow/internal/zellij"
 	"strings"
 	"testing"
 )
 
 // TestDetectFromEnv verifies the TERM_PROGRAM → backend mapping. The
-// Override knob and the kitty / ZELLIJ checks have higher precedence
-// and are checked separately below.
+// Override knob and the ZELLIJ / kitty / FLOW_TERM checks have higher
+// precedence and are checked separately below.
 func TestDetectFromEnv(t *testing.T) {
 	cases := []struct {
 		termProgram string
@@ -19,6 +20,7 @@ func TestDetectFromEnv(t *testing.T) {
 	}{
 		{"iTerm.app", BackendITerm},
 		{"Apple_Terminal", BackendTerminal},
+		{"WarpTerminal", BackendWarp},
 		{"", BackendITerm},
 		{"WezTerm", BackendITerm},
 		{"vscode", BackendITerm},
@@ -28,6 +30,7 @@ func TestDetectFromEnv(t *testing.T) {
 			t.Setenv("ZELLIJ", "")
 			t.Setenv("KITTY_WINDOW_ID", "")
 			t.Setenv("TERM", "")
+			t.Setenv("FLOW_TERM", "")
 			t.Setenv("TERM_PROGRAM", tc.termProgram)
 			Override = ""
 			if got := Detect(); got != tc.want {
@@ -45,32 +48,29 @@ func TestOverrideBeatsEnv(t *testing.T) {
 	t.Setenv("ZELLIJ", "")
 	t.Setenv("KITTY_WINDOW_ID", "")
 	t.Setenv("TERM", "")
+	t.Setenv("FLOW_TERM", "iterm")
 	t.Setenv("TERM_PROGRAM", "iTerm.app")
 	t.Cleanup(func() { Override = "" })
 
-	Override = BackendTerminal
-	if got := Detect(); got != BackendTerminal {
-		t.Errorf("Override=Terminal: got %q, want %q", got, BackendTerminal)
-	}
-	Override = BackendITerm
-	if got := Detect(); got != BackendITerm {
-		t.Errorf("Override=ITerm: got %q, want %q", got, BackendITerm)
-	}
-	Override = BackendKitty
-	if got := Detect(); got != BackendKitty {
-		t.Errorf("Override=Kitty: got %q, want %q", got, BackendKitty)
+	for _, want := range []Backend{
+		BackendTerminal, BackendWarp, BackendITerm, BackendKitty, BackendZellij,
+	} {
+		Override = want
+		if got := Detect(); got != want {
+			t.Errorf("Override=%q: got %q, want %q", want, got, want)
+		}
 	}
 }
 
-// TestDetectZellij verifies the ZELLIJ env var beats TERM_PROGRAM, kitty,
-// and everything else. zellij sets ZELLIJ in every shell it spawns, so
-// its presence means the user is inside a zellij session regardless of
-// which terminal hosts it.
+// TestDetectZellij verifies the ZELLIJ env var beats every other signal.
+// zellij sets ZELLIJ in every shell it spawns, so its presence means the
+// user is inside a zellij session regardless of which terminal hosts it.
 func TestDetectZellij(t *testing.T) {
 	t.Setenv("ZELLIJ", "0")
-	t.Setenv("KITTY_WINDOW_ID", "1") // proves ZELLIJ wins over kitty
-	t.Setenv("TERM", "xterm-kitty")  // ditto
-	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	t.Setenv("KITTY_WINDOW_ID", "1")      // proves ZELLIJ wins over kitty
+	t.Setenv("TERM", "xterm-kitty")       // ditto
+	t.Setenv("FLOW_TERM", "iterm")        // proves ZELLIJ wins over FLOW_TERM
+	t.Setenv("TERM_PROGRAM", "iTerm.app") // proves ZELLIJ wins over TERM_PROGRAM
 	Override = ""
 	if got := Detect(); got != BackendZellij {
 		t.Errorf("Detect() with ZELLIJ=0: got %q, want %q", got, BackendZellij)
@@ -99,6 +99,7 @@ func TestDetectKitty(t *testing.T) {
 			t.Setenv("ZELLIJ", "")
 			t.Setenv("KITTY_WINDOW_ID", tc.kittyWindowID)
 			t.Setenv("TERM", tc.term)
+			t.Setenv("FLOW_TERM", "")
 			t.Setenv("TERM_PROGRAM", tc.termProgram)
 			Override = ""
 			if got := Detect(); got != BackendKitty {
@@ -108,20 +109,80 @@ func TestDetectKitty(t *testing.T) {
 	}
 }
 
+// TestDetectFlowTermOverride — FLOW_TERM with a valid backend value
+// wins over TERM_PROGRAM but loses to ZELLIJ and kitty. Iterates over
+// every valid backend value so we catch regressions where a new
+// backend is added but missed in Detect()'s FLOW_TERM filter.
+func TestDetectFlowTermOverride(t *testing.T) {
+	cases := []struct {
+		flowTerm string
+		want     Backend
+	}{
+		{"iterm", BackendITerm},
+		{"terminal", BackendTerminal},
+		{"zellij", BackendZellij},
+		{"kitty", BackendKitty},
+		{"warp", BackendWarp},
+	}
+	for _, tc := range cases {
+		t.Run(tc.flowTerm, func(t *testing.T) {
+			t.Setenv("ZELLIJ", "")
+			t.Setenv("KITTY_WINDOW_ID", "")
+			t.Setenv("TERM", "")
+			t.Setenv("FLOW_TERM", tc.flowTerm)
+			t.Setenv("TERM_PROGRAM", "Apple_Terminal") // proves FLOW_TERM wins over TERM_PROGRAM
+			Override = ""
+			if got := Detect(); got != tc.want {
+				t.Errorf("Detect() with FLOW_TERM=%q: got %q, want %q",
+					tc.flowTerm, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDetectKittyBeatsFlowTerm — kitty's per-window markers beat
+// FLOW_TERM, matching ZELLIJ's behavior. Rationale: if the user is
+// inside kitty, that's where their workflow lives.
+func TestDetectKittyBeatsFlowTerm(t *testing.T) {
+	t.Setenv("ZELLIJ", "")
+	t.Setenv("KITTY_WINDOW_ID", "42")
+	t.Setenv("TERM", "")
+	t.Setenv("FLOW_TERM", "iterm")
+	t.Setenv("TERM_PROGRAM", "")
+	Override = ""
+	if got := Detect(); got != BackendKitty {
+		t.Errorf("Detect() with KITTY_WINDOW_ID + FLOW_TERM=iterm: got %q, want %q", got, BackendKitty)
+	}
+}
+
+// TestDetectFlowTermInvalidFallsThrough — an unrecognized FLOW_TERM
+// value is silently ignored and TERM_PROGRAM detection takes over.
+func TestDetectFlowTermInvalidFallsThrough(t *testing.T) {
+	t.Setenv("ZELLIJ", "")
+	t.Setenv("KITTY_WINDOW_ID", "")
+	t.Setenv("TERM", "")
+	t.Setenv("FLOW_TERM", "garbage-not-a-backend")
+	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	Override = ""
+	if got := Detect(); got != BackendITerm {
+		t.Errorf("Detect() with garbage FLOW_TERM: got %q, want %q", got, BackendITerm)
+	}
+}
+
 // TestSpawnTabRoutesToITerm asserts the iterm Runner is the one called
 // when Detect() resolves to BackendITerm.
 func TestSpawnTabRoutesToITerm(t *testing.T) {
 	Override = BackendITerm
 	t.Cleanup(func() { Override = "" })
 
-	itermCalled, terminalCalled, zellijCalled, kittyCalled := stubAllRunners(t)
+	calls := stubAllRunners(t)
 	if err := SpawnTab("title", "/tmp", "echo hi", nil); err != nil {
 		t.Fatalf("SpawnTab: %v", err)
 	}
-	if !*itermCalled {
+	if !*calls.iterm {
 		t.Error("expected iterm.Runner to be called")
 	}
-	if *terminalCalled || *zellijCalled || *kittyCalled {
+	if *calls.terminal || *calls.zellij || *calls.kitty || *calls.warp {
 		t.Error("only iterm.Runner should be called")
 	}
 }
@@ -132,14 +193,14 @@ func TestSpawnTabRoutesToTerminal(t *testing.T) {
 	Override = BackendTerminal
 	t.Cleanup(func() { Override = "" })
 
-	itermCalled, terminalCalled, zellijCalled, kittyCalled := stubAllRunners(t)
+	calls := stubAllRunners(t)
 	if err := SpawnTab("title", "/tmp", "echo hi", nil); err != nil {
 		t.Fatalf("SpawnTab: %v", err)
 	}
-	if !*terminalCalled {
+	if !*calls.terminal {
 		t.Error("expected terminal.Runner to be called")
 	}
-	if *itermCalled || *zellijCalled || *kittyCalled {
+	if *calls.iterm || *calls.zellij || *calls.kitty || *calls.warp {
 		t.Error("only terminal.Runner should be called")
 	}
 }
@@ -150,14 +211,14 @@ func TestSpawnTabRoutesToZellij(t *testing.T) {
 	Override = BackendZellij
 	t.Cleanup(func() { Override = "" })
 
-	itermCalled, terminalCalled, zellijCalled, kittyCalled := stubAllRunners(t)
+	calls := stubAllRunners(t)
 	if err := SpawnTab("title", "/tmp", "echo hi", nil); err != nil {
 		t.Fatalf("SpawnTab: %v", err)
 	}
-	if !*zellijCalled {
+	if !*calls.zellij {
 		t.Error("expected zellij.Runner to be called")
 	}
-	if *itermCalled || *terminalCalled || *kittyCalled {
+	if *calls.iterm || *calls.terminal || *calls.kitty || *calls.warp {
 		t.Error("only zellij.Runner should be called")
 	}
 }
@@ -168,35 +229,71 @@ func TestSpawnTabRoutesToKitty(t *testing.T) {
 	Override = BackendKitty
 	t.Cleanup(func() { Override = "" })
 
-	itermCalled, terminalCalled, zellijCalled, kittyCalled := stubAllRunners(t)
+	calls := stubAllRunners(t)
 	if err := SpawnTab("title", "/tmp", "echo hi", nil); err != nil {
 		t.Fatalf("SpawnTab: %v", err)
 	}
-	if !*kittyCalled {
+	if !*calls.kitty {
 		t.Error("expected kitty backend to be called")
 	}
-	if *itermCalled || *terminalCalled || *zellijCalled {
+	if *calls.iterm || *calls.terminal || *calls.zellij || *calls.warp {
 		t.Error("only kitty backend should be called")
 	}
 }
 
+// TestSpawnTabRoutesToWarp asserts the warp Runner is the one called
+// when Detect() resolves to BackendWarp.
+func TestSpawnTabRoutesToWarp(t *testing.T) {
+	Override = BackendWarp
+	t.Cleanup(func() { Override = "" })
+
+	calls := stubAllRunners(t)
+	if err := SpawnTab("title", "/tmp", "echo hi", nil); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+	if !*calls.warp {
+		t.Error("expected warp.Runner to be called")
+	}
+	if *calls.iterm || *calls.terminal || *calls.zellij || *calls.kitty {
+		t.Error("only warp backend should be called")
+	}
+}
+
 // TestShellQuoteParity makes sure the re-exported helper matches
-// iterm's implementation. All backends quote identically.
+// every backend's implementation. All backends quote identically.
 func TestShellQuoteParity(t *testing.T) {
-	cases := []string{"plain", "with space", "with'quote", `back\slash`}
+	cases := []string{"plain", "with space", "with'quote", `back\slash`, ""}
 	for _, in := range cases {
-		if got, want := ShellQuote(in), iterm.ShellQuote(in); got != want {
-			t.Errorf("ShellQuote(%q): got %q, want %q", in, got, want)
+		exp := iterm.ShellQuote(in)
+		if got := ShellQuote(in); got != exp {
+			t.Errorf("spawner.ShellQuote(%q) = %q; want %q", in, got, exp)
+		}
+		if got := terminal.ShellQuote(in); got != exp {
+			t.Errorf("terminal.ShellQuote(%q) = %q; want %q", in, got, exp)
+		}
+		if got := zellij.ShellQuote(in); got != exp {
+			t.Errorf("zellij.ShellQuote(%q) = %q; want %q", in, got, exp)
+		}
+		if got := warp.ShellQuote(in); got != exp {
+			t.Errorf("warp.ShellQuote(%q) = %q; want %q", in, got, exp)
 		}
 	}
 }
 
-// stubAllRunners replaces all backend Runner vars with no-op stubs that
-// flip a per-runner boolean when called. Restores originals on test
-// cleanup. Returns pointers so callers can read post-call.
-func stubAllRunners(t *testing.T) (*bool, *bool, *bool, *bool) {
+// runnerFlags bundles per-backend "was called" flags so routing tests
+// can assert on which backend SpawnTab dispatched to without an
+// awkward multi-return-value tuple.
+type runnerFlags struct {
+	iterm, terminal, zellij, kitty, warp *bool
+}
+
+// stubAllRunners replaces every backend's Runner (plus warp's
+// OpenURL/WriteScript and kitty's RunnerOutput) with no-op stubs that
+// flip a per-backend boolean when called. Restores originals on test
+// cleanup.
+func stubAllRunners(t *testing.T) runnerFlags {
 	t.Helper()
-	var itermCalled, terminalCalled, zellijCalled, kittyCalled bool
+	var itermCalled, terminalCalled, zellijCalled, kittyCalled, warpCalled bool
 
 	oldITerm := iterm.Runner
 	iterm.Runner = func(args []string) error {
@@ -248,5 +345,31 @@ func stubAllRunners(t *testing.T) (*bool, *bool, *bool, *bool) {
 	}
 	t.Cleanup(func() { kitty.RunnerOutput = oldKittyRO })
 
-	return &itermCalled, &terminalCalled, &zellijCalled, &kittyCalled
+	oldWarp := warp.Runner
+	warp.Runner = func(args []string) error {
+		warpCalled = true
+		if len(args) >= 2 && !strings.Contains(args[1], `"dev.warp.Warp-Stable"`) {
+			t.Errorf("warp script does not target dev.warp.Warp-Stable: %s", args[1])
+		}
+		return nil
+	}
+	t.Cleanup(func() { warp.Runner = oldWarp })
+
+	// warp also has OpenURL and WriteScript — stub them so the routing
+	// test doesn't actually fire `open` or touch the filesystem.
+	oldOpenURL := warp.OpenURL
+	warp.OpenURL = func(string) error { return nil }
+	t.Cleanup(func() { warp.OpenURL = oldOpenURL })
+
+	oldWriteScript := warp.WriteScript
+	warp.WriteScript = func(string) (string, error) { return "/tmp/flow-warp-stub.sh", nil }
+	t.Cleanup(func() { warp.WriteScript = oldWriteScript })
+
+	return runnerFlags{
+		iterm:    &itermCalled,
+		terminal: &terminalCalled,
+		zellij:   &zellijCalled,
+		kitty:    &kittyCalled,
+		warp:     &warpCalled,
+	}
 }

--- a/internal/warp/warp.go
+++ b/internal/warp/warp.go
@@ -1,0 +1,285 @@
+// Package warp provides Warp terminal tab spawning on macOS.
+//
+// Warp has no AppleScript dictionary, no `-e` flag, and no CLI for
+// running commands (warpdotdev/warp#3364). The only programmatic
+// surface is `warp://action/new_tab?path=<cwd>`, which opens a tab in
+// cwd but accepts no command, env vars, or title. Launch configs
+// can theoretically run commands but silently fail when triggered
+// via URI (warpdotdev/warp#9007).
+//
+// So SpawnTab does the only reliable thing:
+//
+//  1. Write a self-deleting bootstrap script to os.TempDir(). The
+//     script sets the tab title via OSC 2, cds to work_dir, and
+//     `exec env`s the real command with the requested env vars.
+//  2. `open warp://action/new_tab?path=<cwd>` opens the tab.
+//  3. osascript activates Warp, then keystrokes `bash <script-path>`
+//     + ASCII char 13 into the front session.
+//
+// The keystroke step needs macOS Accessibility for Warp — same gate
+// the Terminal.app backend uses.
+package warp
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Runner runs osascript. Tests override this to capture the AppleScript
+// argv without invoking osascript.
+var Runner = func(args []string) error {
+	cmd := exec.Command("osascript", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("osascript failed: %v: %s", err, string(out))
+	}
+	return nil
+}
+
+// OpenURL runs the macOS `open` command on a URL. Tests override this
+// to capture the warp:// URI without launching Warp.
+var OpenURL = func(uri string) error {
+	cmd := exec.Command("open", uri)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("open %s failed: %v: %s", uri, err, string(out))
+	}
+	return nil
+}
+
+// WriteScript writes the bootstrap script body to a per-user temp
+// file and returns the absolute path. Tests override this to avoid
+// touching the real filesystem.
+var WriteScript = func(body string) (string, error) {
+	path, err := tempScriptPath()
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		return "", fmt.Errorf("write warp bootstrap script: %w", err)
+	}
+	return path, nil
+}
+
+// removeScript deletes the temp script on the error path. The happy
+// path leaves cleanup to the script's own `rm -- "$0"` first line.
+// Tests override to observe error-path cleanup.
+var removeScript = func(path string) error {
+	return os.Remove(path)
+}
+
+// SpawnTab opens a new Warp tab in cwd via the warp:// URI, then
+// injects `command` (with envVars set, title set, and cwd entered)
+// by keystroking the path to a per-spawn shell script.
+//
+// `command` is interpolated raw into the script as `exec env … <command>`
+// — it MUST already be a valid, shell-safe command line. Callers are
+// responsible for quoting any embedded arguments (typically via
+// ShellQuote). This matches the iterm/terminal/zellij contract.
+//
+// envVars are attached as an `exec env` prefix to `command` inside
+// the script — so they are present in the spawned process's
+// environment but do NOT persist in the tab's shell after the command
+// exits.
+//
+// The script writes its own `rm -- "$0"` first, so the temp file is
+// unlinked the moment bash starts executing it. Bash has already
+// read the script into memory at that point, so the rest of the
+// script still runs after the unlink.
+//
+// If anything fails after the script is written, removeScript is
+// called to clean up the orphaned temp file.
+func SpawnTab(title, cwd, command string, envVars map[string]string) error {
+	body := buildScript(title, cwd, command, envVars)
+
+	scriptPath, err := WriteScript(body)
+	if err != nil {
+		return err
+	}
+
+	uri := "warp://action/new_tab?path=" + url.QueryEscape(cwd)
+	if err := OpenURL(uri); err != nil {
+		_ = removeScript(scriptPath)
+		return err
+	}
+
+	script := buildAppleScript(scriptPath)
+	if err := Runner([]string{"-e", script}); err != nil {
+		_ = removeScript(scriptPath)
+		if isAccessibilityDenied(err) {
+			return wrapAccessibilityError(err)
+		}
+		return err
+	}
+	return nil
+}
+
+// ShellQuote wraps s in single quotes with proper escaping. Identical
+// to iterm.ShellQuote / terminal.ShellQuote / zellij.ShellQuote.
+func ShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// buildScript produces the bash script body that the keystroked
+// `bash <path>` line invokes. Shape:
+//
+//	#!/bin/bash
+//	rm -- "$0"
+//	printf '\033]2;%s\007' '<title>'
+//	cd '<cwd>' || exit 1
+//	exec env FOO='bar' BAZ='qux' <command>
+//
+// Notes:
+//   - Env vars are sorted alphabetically for stable test output,
+//     matching the iterm/terminal/zellij contract exactly.
+//   - When envVars is empty, the final line is `exec <command>` with
+//     no `env` wrapper, so the command process isn't a child of env.
+//   - When title is empty, the OSC 2 line is omitted.
+func buildScript(title, cwd, command string, envVars map[string]string) string {
+	var b strings.Builder
+	b.WriteString("#!/bin/bash\n")
+	b.WriteString(`rm -- "$0"`)
+	b.WriteString("\n")
+	if title != "" {
+		fmt.Fprintf(&b, "printf '\\033]2;%%s\\007' %s\n", ShellQuote(title))
+	}
+	fmt.Fprintf(&b, "cd %s || exit 1\n", ShellQuote(cwd))
+
+	if len(envVars) == 0 {
+		fmt.Fprintf(&b, "exec %s\n", command)
+		return b.String()
+	}
+
+	keys := make([]string, 0, len(envVars))
+	for k := range envVars {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(envVars))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", k, ShellQuote(envVars[k])))
+	}
+	fmt.Fprintf(&b, "exec env %s %s\n", strings.Join(parts, " "), command)
+	return b.String()
+}
+
+// buildAppleScript activates Warp, waits for the new tab from
+// `open warp://...` to take key focus, then keystrokes
+// `bash <scriptPath>` + Return into the front Warp session.
+//
+// Why `keystroke (ASCII character 13)` instead of `keystroke return`
+// or `key code 36`: Warp v0.2026.04 filters synthetic Return-key
+// events for ~2s after typed input. Empirically:
+//
+//	key code 36              → swallowed (text typed, never submits)
+//	keystroke return         → swallowed
+//	key code 36 + Cmd        → swallowed
+//	paste + key code 36      → swallowed
+//	delay 2.0 + key code 36  → submits (filter window closes)
+//	ASCII character 13       → submits immediately
+//
+// ASCII char 13 flows through Warp's input field to the shell PTY,
+// where the line discipline interprets CR as line submission, before
+// any UI-layer filter fires.
+//
+// `tell application "Warp" to activate` is needed because when flow
+// runs from a non-Warp host (FLOW_TERM=warp, shell script), `open
+// warp://...` opens the new tab but macOS may not foreground Warp —
+// keystrokes would then hit the invoking app. Same guard as
+// terminal.go.
+//
+// Delays calibrated against Warp v0.2026.04:
+//   - 0.6s warm  — focus settle after activate (0.3s misfired on slow boxes).
+//   - 1.8s cold  — cold-start Warp launch.
+//   - 0.5s mid   — between typed text and CR; needed for ~90-char temp paths.
+func buildAppleScript(scriptPath string) string {
+	safePath := escapeAppleScriptString(scriptPath)
+	return fmt.Sprintf(`set wasRunning to application id "dev.warp.Warp-Stable" is running
+tell application "Warp" to activate
+if wasRunning then
+  delay 0.6
+else
+  delay 1.8
+end if
+tell application "System Events"
+  tell process "Warp"
+    keystroke "bash %s"
+    delay 0.5
+    keystroke (ASCII character 13)
+  end tell
+end tell
+`, safePath)
+}
+
+// tempScriptPath returns os.TempDir()/flow-warp-<uuid>.sh. UUID is 16
+// crypto/rand bytes hex-encoded — sufficient uniqueness for concurrent
+// spawns. No dependency on internal/app's UUID helper because backend
+// packages shouldn't import app.
+func tempScriptPath() (string, error) {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", fmt.Errorf("generate warp script id: %w", err)
+	}
+	name := fmt.Sprintf("flow-warp-%s.sh", hex.EncodeToString(buf[:]))
+	return filepath.Join(os.TempDir(), name), nil
+}
+
+// isAccessibilityDenied reports whether an osascript failure looks
+// like a missing-Accessibility-permission error. Matches the same
+// fragments as internal/terminal.isAccessibilityDenied — macOS uses
+// the same wording regardless of the target app being scripted.
+func isAccessibilityDenied(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, pat := range []string{
+		"not allowed assistive access",
+		"is not allowed to send keystrokes",
+		"is not allowed sending keystrokes",
+		"not authorized to send Apple events",
+		"(-1002)",
+		"(-1719)",
+		"(-1743)",
+		"(-25211)",
+	} {
+		if strings.Contains(msg, pat) {
+			return true
+		}
+	}
+	return false
+}
+
+// wrapAccessibilityError returns a Warp-specific multi-line error
+// pointing at the right System Settings pane and naming "Warp" (not
+// "Terminal" — that wording belongs to the Terminal.app backend).
+func wrapAccessibilityError(err error) error {
+	return fmt.Errorf(`Warp tab spawn requires macOS Accessibility permission for Warp.
+
+Why this is needed: Warp exposes no AppleScript dictionary, no -e flag, and no CLI for running commands. The only way flow can inject a command into a new Warp tab is to keystroke it via System Events, which checks Accessibility against the parent app — Warp itself.
+
+How to grant it:
+  1. Open the right pane: open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+  2. In the Accessibility list, enable the toggle for "Warp". If "Warp" is not listed, click + and add /Applications/Warp.app.
+  3. Re-run the same "flow do" command.
+
+After the grant, future "flow do" invocations from Warp spawn tabs silently with no further prompts.
+
+Underlying osascript error: %w`, err)
+}
+
+// escapeAppleScriptString escapes a string for safe embedding in a
+// double-quoted AppleScript string literal. Same implementation as
+// the sibling packages — duplicated to avoid cross-package coupling.
+func escapeAppleScriptString(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return s
+}

--- a/internal/warp/warp_test.go
+++ b/internal/warp/warp_test.go
@@ -1,0 +1,378 @@
+package warp
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// warpStubs captures every interaction with the four mockable vars
+// (Runner, OpenURL, WriteScript, removeScript) so tests can assert on
+// exactly what SpawnTab did. Restore originals on cleanup.
+type warpStubs struct {
+	writeCalls    []string // bodies passed to WriteScript
+	openCalls     []string // URIs passed to OpenURL
+	runnerCalls   [][]string
+	removeCalls   []string
+	scriptPath    string // returned by WriteScript stub
+	writeErr      error
+	openErr       error
+	runnerErr     error
+	removeErr     error
+	t             *testing.T
+}
+
+func newWarpStubs(t *testing.T) *warpStubs {
+	t.Helper()
+	s := &warpStubs{t: t, scriptPath: "/tmp/flow-warp-deadbeef.sh"}
+
+	oldWrite := WriteScript
+	WriteScript = func(body string) (string, error) {
+		s.writeCalls = append(s.writeCalls, body)
+		if s.writeErr != nil {
+			return "", s.writeErr
+		}
+		return s.scriptPath, nil
+	}
+	t.Cleanup(func() { WriteScript = oldWrite })
+
+	oldOpen := OpenURL
+	OpenURL = func(uri string) error {
+		s.openCalls = append(s.openCalls, uri)
+		return s.openErr
+	}
+	t.Cleanup(func() { OpenURL = oldOpen })
+
+	oldRunner := Runner
+	Runner = func(args []string) error {
+		s.runnerCalls = append(s.runnerCalls, append([]string(nil), args...))
+		return s.runnerErr
+	}
+	t.Cleanup(func() { Runner = oldRunner })
+
+	oldRemove := removeScript
+	removeScript = func(path string) error {
+		s.removeCalls = append(s.removeCalls, path)
+		return s.removeErr
+	}
+	t.Cleanup(func() { removeScript = oldRemove })
+
+	return s
+}
+
+// TestSpawnTabBasicNoEnv — happy path with no env vars. WriteScript is
+// called once with the expected body shape, OpenURL with the correct
+// URL-encoded warp:// URI, Runner with `-e <applescript>`. removeScript
+// is NOT called on the happy path.
+func TestSpawnTabBasicNoEnv(t *testing.T) {
+	s := newWarpStubs(t)
+
+	if err := SpawnTab("my-task", "/Users/me/repo", "claude --session-id abc", nil); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+
+	if len(s.writeCalls) != 1 {
+		t.Fatalf("WriteScript calls = %d, want 1", len(s.writeCalls))
+	}
+	body := s.writeCalls[0]
+	if !strings.HasPrefix(body, "#!/bin/bash\n") {
+		t.Errorf("script body missing shebang: %q", body)
+	}
+	if !strings.Contains(body, "cd '/Users/me/repo' || exit 1") {
+		t.Errorf("script body missing cd line: %q", body)
+	}
+	if !strings.Contains(body, "exec claude --session-id abc") {
+		t.Errorf("script body missing exec line: %q", body)
+	}
+
+	if len(s.openCalls) != 1 {
+		t.Fatalf("OpenURL calls = %d, want 1", len(s.openCalls))
+	}
+	wantURI := "warp://action/new_tab?path=%2FUsers%2Fme%2Frepo"
+	if s.openCalls[0] != wantURI {
+		t.Errorf("OpenURL URI = %q, want %q", s.openCalls[0], wantURI)
+	}
+
+	if len(s.runnerCalls) != 1 {
+		t.Fatalf("Runner calls = %d, want 1", len(s.runnerCalls))
+	}
+	if len(s.runnerCalls[0]) != 2 || s.runnerCalls[0][0] != "-e" {
+		t.Errorf("Runner argv = %v, want [-e <script>]", s.runnerCalls[0])
+	}
+
+	if len(s.removeCalls) != 0 {
+		t.Errorf("removeScript called %d times on happy path, want 0", len(s.removeCalls))
+	}
+}
+
+// TestSpawnTabEnvVarsSorted — env vars sorted alphabetically and
+// shell-quoted into the `exec env …` line. Exact parity with the
+// zellij/iterm contract.
+func TestSpawnTabEnvVarsSorted(t *testing.T) {
+	s := newWarpStubs(t)
+
+	envVars := map[string]string{
+		"FLOW_TASK":    "my-task",
+		"FLOW_PROJECT": "flow",
+		"ZEBRA":        "stripes and spaces",
+	}
+	if err := SpawnTab("flow/my-task", "/repo", "claude --resume abc", envVars); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+
+	body := s.writeCalls[0]
+	want := "exec env FLOW_PROJECT='flow' FLOW_TASK='my-task' ZEBRA='stripes and spaces' claude --resume abc\n"
+	if !strings.Contains(body, want) {
+		t.Errorf("script body missing exec env line.\n got: %q\nwant: %q\nfull body:\n%s", "(see body)", want, body)
+	}
+}
+
+// TestSpawnTabSetsTitleViaOSC2 — when title is non-empty, the OSC 2
+// escape sequence is emitted as a printf line before cd.
+func TestSpawnTabSetsTitleViaOSC2(t *testing.T) {
+	s := newWarpStubs(t)
+
+	if err := SpawnTab("warp-smoke", "/tmp", "echo hi", nil); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+
+	body := s.writeCalls[0]
+	want := `printf '\033]2;%s\007' 'warp-smoke'`
+	if !strings.Contains(body, want) {
+		t.Errorf("script body missing OSC 2 title line.\n got body:\n%s\nwant substring: %q", body, want)
+	}
+}
+
+// TestSpawnTabNoTitleOmitsOSC2 — empty title skips the OSC 2 line
+// entirely (no stray printf in the script).
+func TestSpawnTabNoTitleOmitsOSC2(t *testing.T) {
+	s := newWarpStubs(t)
+
+	if err := SpawnTab("", "/tmp", "echo hi", nil); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+
+	body := s.writeCalls[0]
+	if strings.Contains(body, `printf '\033]2;`) {
+		t.Errorf("empty title should not emit OSC 2 line, but body has one:\n%s", body)
+	}
+}
+
+// TestScriptBodySelfDeletes — first non-shebang line is rm -- "$0".
+// This is what makes the temp script disappear ~immediately on
+// successful execution.
+func TestScriptBodySelfDeletes(t *testing.T) {
+	s := newWarpStubs(t)
+
+	if err := SpawnTab("t", "/tmp", "echo hi", nil); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+
+	body := s.writeCalls[0]
+	lines := strings.Split(body, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("script body too short: %q", body)
+	}
+	if lines[0] != "#!/bin/bash" {
+		t.Errorf("line 0 = %q, want shebang", lines[0])
+	}
+	if lines[1] != `rm -- "$0"` {
+		t.Errorf("line 1 = %q, want self-delete line", lines[1])
+	}
+}
+
+// TestScriptBodyExecReplaces — the final non-empty line is exec, so
+// bash is replaced by the command process. No orphan bash, clean ^C.
+func TestScriptBodyExecReplaces(t *testing.T) {
+	s := newWarpStubs(t)
+
+	if err := SpawnTab("t", "/tmp", "claude", nil); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+
+	body := s.writeCalls[0]
+	// Last non-empty line.
+	lines := strings.Split(strings.TrimRight(body, "\n"), "\n")
+	last := lines[len(lines)-1]
+	if !strings.HasPrefix(last, "exec ") {
+		t.Errorf("last line = %q, want it to start with `exec `", last)
+	}
+}
+
+// TestAppleScriptHasWasRunningBranch — the keystroke AppleScript
+// contains the warm/cold delay branch and keystrokes `bash <path>`
+// + Return. Validates the cold-start fix is in place.
+func TestAppleScriptHasWasRunningBranch(t *testing.T) {
+	s := newWarpStubs(t)
+
+	if err := SpawnTab("t", "/tmp", "echo hi", nil); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+
+	if len(s.runnerCalls) != 1 || len(s.runnerCalls[0]) != 2 {
+		t.Fatalf("expected one Runner call with 2 args, got %v", s.runnerCalls)
+	}
+	script := s.runnerCalls[0][1]
+	for _, want := range []string{
+		`application id "dev.warp.Warp-Stable" is running`,
+		`tell application "Warp" to activate`,
+		"if wasRunning then",
+		"delay 0.6",
+		"delay 1.8",
+		"end if",
+		`keystroke "bash `,
+		"delay 0.5", // settle delay between typed text and CR — load-bearing
+		`keystroke (ASCII character 13)`, // PTY-level CR — bypasses Warp's synthetic-Return filter
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("AppleScript missing %q. Full script:\n%s", want, script)
+		}
+	}
+	// The AppleScript must reference the exact path WriteScript
+	// returned — not some other string accidentally interpolated.
+	// Without this assertion, a refactor that mis-wired the path
+	// argument to buildAppleScript would pass every other test.
+	if !strings.Contains(script, s.scriptPath) {
+		t.Errorf("AppleScript should reference scriptPath %q, got:\n%s", s.scriptPath, script)
+	}
+	// Guard against regressions: Warp v0.2026.04+ blocks "Return key"
+	// events (key code 36, keystroke return). The only working
+	// submission is ASCII character 13.
+	for _, bad := range []string{
+		"keystroke return",
+		"key code 36",
+	} {
+		if strings.Contains(script, bad) {
+			t.Errorf("AppleScript should NOT use %q (Warp filters Return-key events; use ASCII char 13). Full script:\n%s", bad, script)
+		}
+	}
+}
+
+// TestSpawnTabPropagatesWriteScriptError — when WriteScript fails,
+// OpenURL and Runner are never invoked.
+func TestSpawnTabPropagatesWriteScriptError(t *testing.T) {
+	s := newWarpStubs(t)
+	s.writeErr = errors.New("disk full")
+
+	err := SpawnTab("t", "/tmp", "echo hi", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if len(s.openCalls) != 0 {
+		t.Errorf("OpenURL called %d times after write failure, want 0", len(s.openCalls))
+	}
+	if len(s.runnerCalls) != 0 {
+		t.Errorf("Runner called %d times after write failure, want 0", len(s.runnerCalls))
+	}
+	if len(s.removeCalls) != 0 {
+		t.Errorf("removeScript called %d times after write failure, want 0", len(s.removeCalls))
+	}
+}
+
+// TestSpawnTabPropagatesOpenURLError — when OpenURL fails, Runner is
+// never invoked and removeScript cleans up the orphaned temp file.
+func TestSpawnTabPropagatesOpenURLError(t *testing.T) {
+	s := newWarpStubs(t)
+	s.openErr = errors.New("simulated open failure")
+
+	err := SpawnTab("t", "/tmp", "echo hi", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if len(s.runnerCalls) != 0 {
+		t.Errorf("Runner called %d times after open failure, want 0", len(s.runnerCalls))
+	}
+	if len(s.removeCalls) != 1 || s.removeCalls[0] != s.scriptPath {
+		t.Errorf("removeScript calls = %v, want [%q]", s.removeCalls, s.scriptPath)
+	}
+}
+
+// TestSpawnTabPropagatesRunnerError — when Runner fails,
+// removeScript cleans up the orphaned temp file and the error is
+// returned unwrapped (for non-Accessibility, non-AppNotFound cases).
+func TestSpawnTabPropagatesRunnerError(t *testing.T) {
+	s := newWarpStubs(t)
+	s.runnerErr = errors.New("simulated osascript failure: ambient")
+
+	err := SpawnTab("t", "/tmp", "echo hi", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if len(s.removeCalls) != 1 || s.removeCalls[0] != s.scriptPath {
+		t.Errorf("removeScript calls = %v, want [%q]", s.removeCalls, s.scriptPath)
+	}
+}
+
+// TestSpawnTabWrapsAccessibilityError — when Runner returns one of
+// the documented Accessibility-denied error patterns, the returned
+// error string names "Warp" (not "Terminal") and includes the
+// System Settings deeplink.
+func TestSpawnTabWrapsAccessibilityError(t *testing.T) {
+	cases := []string{
+		"osascript failed: exit status 1: System Events got an error: Warp (Warp) is not allowed to send keystrokes. (-1719)",
+		"some other framing: not allowed assistive access",
+		"not authorized to send Apple events",
+		"err (-25211)",
+	}
+	for _, msg := range cases {
+		t.Run(msg, func(t *testing.T) {
+			s := newWarpStubs(t)
+			s.runnerErr = errors.New(msg)
+
+			err := SpawnTab("t", "/tmp", "echo hi", nil)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			es := err.Error()
+			for _, want := range []string{
+				"Warp",
+				"Accessibility",
+				"x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
+			} {
+				if !strings.Contains(es, want) {
+					t.Errorf("wrapped error missing %q:\n%s", want, es)
+				}
+			}
+			if strings.Contains(es, "Terminal.app") || strings.Contains(es, `toggle for "Terminal"`) {
+				t.Errorf("wrapped error mentions Terminal (wrong copy):\n%s", es)
+			}
+		})
+	}
+}
+
+// TestShellQuote — same contract as iterm.ShellQuote / terminal.ShellQuote
+// / zellij.ShellQuote.
+func TestShellQuote(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"plain", "'plain'"},
+		{"with space", "'with space'"},
+		{"with'quote", `'with'\''quote'`},
+		{"", "''"},
+		{`back\slash`, `'back\slash'`},
+	}
+	for _, tc := range cases {
+		if got := ShellQuote(tc.in); got != tc.want {
+			t.Errorf("ShellQuote(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestEscapeAppleScriptString covers the embedded helper directly so
+// regressions in the script-path escape don't slip through.
+func TestEscapeAppleScriptString(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{`plain`, `plain`},
+		{`with "quote"`, `with \"quote\"`},
+		{`with\backslash`, `with\\backslash`},
+		{`/tmp/flow-warp-deadbeef.sh`, `/tmp/flow-warp-deadbeef.sh`},
+	}
+	for _, tc := range cases {
+		if got := escapeAppleScriptString(tc.in); got != tc.want {
+			t.Errorf("escapeAppleScriptString(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds [Warp](https://github.com/warpdotdev/warp) Terminal as a first-class spawn backend so `flow do <task>` opens a new Warp tab when invoked from a Warp shell (`TERM_PROGRAM=WarpTerminal`). Also adds a `FLOW_TERM` env override (`iterm|terminal|zellij|kitty|warp`) for users running flow from non-standard hosts where `TERM_PROGRAM` isn't authoritative (tmux, shell scripts, Hyper, wezterm, etc.).

## Why

Warp is one of the more popular alternative macOS terminals and currently isn't in flow's backend list — Warp users either get the iTerm fallback (which doesn't open) or fall through to a path that doesn't fit their workflow. This adds parity with the existing iTerm2 / Terminal.app / zellij / kitty backends.

## How

Warp has no AppleScript dictionary, no `-e` flag, and no command-running CLI ([warpdotdev/warp#3364](https://github.com/warpdotdev/warp/issues/3364)). Launch configurations (`warp://launch/<name>`) can theoretically run commands, but [warpdotdev/warp#9007](https://github.com/warpdotdev/warp/issues/9007) reports `commands`/`exec` entries silently fail when triggered via URI. So the backend does the only reliable thing:

1. Write a self-deleting bootstrap script to `os.TempDir()`. The script sets the tab title via OSC 2, `cd`s to the work_dir, and `exec env`s the real command with the requested env vars.
2. `open warp://action/new_tab?path=<cwd>` opens the tab in cwd.
3. `osascript` activates Warp, then keystrokes `bash <script-path>` + `ASCII character 13` into the front session.

**`keystroke (ASCII character 13)` not `keystroke return` / `key code 36`** — Warp v0.2026.04 filters synthetic Return-key events for ~2s after typed input. Empirically:

| Submission method | Result |
|---|---|
| `key code 36` | swallowed (text typed, never submits) |
| `keystroke return` | swallowed |
| `key code 36` + Cmd | swallowed |
| paste + `key code 36` | swallowed |
| `delay 2.0` + `key code 36` | submits (filter window closes) |
| `ASCII character 13` | submits immediately |

ASCII char 13 flows through Warp's input field as a typed character to the shell PTY, where line discipline interprets CR as line submission, before any UI-layer filter fires.

## Backend selection priority

Coexists with `internal/kitty` from #37:

```
Override (test-only)                       → pinned
$ZELLIJ set                                → zellij
$KITTY_WINDOW_ID set or $TERM=xterm-kitty  → kitty
$FLOW_TERM=<valid backend>                 → that backend
TERM_PROGRAM=WarpTerminal                  → warp
TERM_PROGRAM=Apple_Terminal                → terminal
TERM_PROGRAM=iTerm.app                     → iterm
anything else                              → iterm (historical default)
```

ZELLIJ and kitty win over `$FLOW_TERM` because they signal "you're inside a session-manager terminal" — the host terminal is a substrate detail. `$FLOW_TERM` lets users on non-standard hosts opt into a specific backend without relying on `TERM_PROGRAM`. Unrecognized `FLOW_TERM` values silently fall through to `TERM_PROGRAM` detection.

## Requirements

macOS Accessibility for **Warp** (same gate the Terminal.app backend uses — System Events `keystroke` checks Accessibility against the parent app). When the gate isn't granted, the backend returns a Warp-specific multi-line error pointing at the right System Settings pane and naming "Warp" — not "Terminal" or "Claude".

## Test coverage

- **`internal/warp/warp_test.go`** — 9 unit tests covering: script body shape (shebang, self-delete, `cd`, OSC 2 title, `exec env` env-var sorting), AppleScript content with regression guards against `key code 36` and `keystroke return`, error-path script cleanup, Accessibility error wrapping.
- **`internal/spawner/spawner_test.go`** — extended with `TestSpawnTabRoutesToWarp`, `TestDetectFlowTermOverride` (iterates all valid values including warp + kitty), `TestDetectKittyBeatsFlowTerm`, `TestDetectFlowTermInvalidFallsThrough`, and the existing `TestDetectFromEnv` now covering `WarpTerminal`.
- Mockable `warp.Runner`, `warp.OpenURL`, `warp.WriteScript`, `warp.removeScript` (matching the existing `iterm.Runner` / `terminal.Runner` / `zellij.Runner` pattern) so tests never touch the real filesystem or invoke `osascript`.
- `make test` green on macOS (Apple Silicon, Warp v0.2026.04).
- Manual smoke: live `flow do` spawning a Warp tab from a Warp shell, with env-var propagation verified end-to-end via `printenv`.

## Out of scope

- Non-macOS support (Warp Linux). The backend uses `osascript` and the macOS `open` URL handler — would need a separate code path.
- Cold-launch behavior beyond the 1.8s delay heuristic (the AppleScript probes `application id "dev.warp.Warp-Stable" is running` and uses 0.6s warm / 1.8s cold).
