### PR TITLE
flow run playbook --here + clean close-out sweep (#47)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -122,7 +122,8 @@ Workdirs:
 
 Playbooks:
   flow add playbook   "<name>" --work-dir <path> [--slug <s>] [--project <slug>] [--mkdir]
-  flow run playbook   <slug> [--dangerously-skip-permissions]
+  flow run playbook   <slug> [--dangerously-skip-permissions]   (spawn a new tab)
+  flow run playbook   <slug> --here                              (bind THIS Claude session to the new run; no new tab)
   flow show playbook  <ref>
   flow list playbooks [--project <slug>] [--include-archived]`)
 }

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -35,7 +35,8 @@ func cmdRunPlaybook(args []string) int {
 	}
 	slug := args[0]
 	fs := flagSet("run playbook")
-	dangerSkip := fs.Bool("dangerously-skip-permissions", false, "pass --dangerously-skip-permissions through to claude")
+	dangerSkip := fs.Bool("dangerously-skip-permissions", false, "pass --dangerously-skip-permissions through to claude (ignored when --here is set)")
+	here := fs.Bool("here", false, "bind THIS Claude session to the new playbook run (no new tab); requires running inside a Claude Code session")
 	if err := fs.Parse(args[1:]); err != nil {
 		return 2
 	}
@@ -56,6 +57,32 @@ func cmdRunPlaybook(args []string) int {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
+	}
+
+	// --here validation BEFORE the run-task row insert. Mirrors the
+	// pre-write checks in cmdDoHere — failing fast prevents a dangling
+	// backlog playbook_run task when env is wrong or this session is
+	// already owned by another task.
+	if *here {
+		sid := currentSessionID()
+		if sid == "" {
+			fmt.Fprintln(os.Stderr,
+				"error: --here requires running inside a Claude Code session ($CLAUDE_CODE_SESSION_ID is unset)")
+			return 1
+		}
+		if !sessionUUIDRe.MatchString(sid) {
+			fmt.Fprintf(os.Stderr,
+				"error: $CLAUDE_CODE_SESSION_ID is not a valid v4 UUID (got %q)\n", sid)
+			return 1
+		}
+		priorBinding, lookupErr := flowdb.TaskBySessionID(db, sid)
+		if lookupErr == nil {
+			fmt.Fprintf(os.Stderr,
+				"error: this Claude session is already bound to task %q. binding it to a new playbook run would orphan %q's transcript and is rejected by the session_id uniqueness invariant.\n"+
+					"  to start this playbook run in a separate session: flow run playbook %s\n",
+				priorBinding.Slug, priorBinding.Slug, pb.Slug)
+			return 1
+		}
 	}
 
 	root, err := flowRoot()
@@ -104,10 +131,17 @@ func cmdRunPlaybook(args []string) int {
 		return 1
 	}
 
-	// Close our DB handle so cmdDo can re-open it (cmdDo opens its own).
+	// Close our DB handle so the delegate (cmdDo or cmdDoHere) can
+	// re-open its own connection.
 	db.Close()
 
-	// Delegate to cmdDo to spawn the session.
+	if *here {
+		// In-session bind path: no terminal spawn. dangerSkip is dropped
+		// — there's no claude process to forward the flag to.
+		return cmdDoHere(runSlug, false)
+	}
+
+	// Default path: delegate to cmdDo to spawn the session in a new tab.
 	doArgs := []string{runSlug}
 	if *dangerSkip {
 		doArgs = append(doArgs, "--dangerously-skip-permissions")

--- a/internal/app/run_test.go
+++ b/internal/app/run_test.go
@@ -185,3 +185,171 @@ func TestCmdRunPlaybookMissing(t *testing.T) {
 		t.Errorf("expected non-zero rc for missing playbook")
 	}
 }
+
+// ---------- flow run playbook --here ----------
+
+// TestCmdRunPlaybookHereHappyPath pins the in-session bind contract
+// for playbook runs: with $CLAUDE_CODE_SESSION_ID set and a valid
+// playbook, --here creates the run-task row, snapshots the brief,
+// binds the current session, and flips status to in-progress —
+// without spawning a tab.
+func TestCmdRunPlaybookHereHappyPath(t *testing.T) {
+	setupFlowRoot(t)
+	wd := t.TempDir()
+	if rc := cmdAdd([]string{"playbook", "Triage", "--slug", "tri", "--work-dir", wd}); rc != 0 {
+		t.Fatal()
+	}
+	const sid = "f00ba111-2222-4333-8444-555555555555"
+	t.Setenv("CLAUDE_CODE_SESSION_ID", sid)
+	count, _ := stubITerm(t)
+
+	if rc := cmdRun([]string{"playbook", "tri", "--here"}); rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+	if *count != 0 {
+		t.Errorf("--here should not spawn; got %d spawns", *count)
+	}
+
+	db := openFlowDB(t)
+	var runSlug, status, sessionID string
+	err := db.QueryRow(
+		`SELECT slug, status, COALESCE(session_id,'') FROM tasks WHERE kind='playbook_run' AND playbook_slug='tri'`,
+	).Scan(&runSlug, &status, &sessionID)
+	if err != nil {
+		t.Fatalf("query run task: %v", err)
+	}
+	if sessionID != sid {
+		t.Errorf("session_id = %q, want %s", sessionID, sid)
+	}
+	if status != "in-progress" {
+		t.Errorf("status = %q, want in-progress", status)
+	}
+
+	// Brief snapshot is still produced on the --here path — bootstrap
+	// contract reads tasks/<run-slug>/brief.md, not the live playbook.
+	root, _ := flowRoot()
+	if _, err := os.ReadFile(filepath.Join(root, "tasks", runSlug, "brief.md")); err != nil {
+		t.Errorf("run brief.md missing on --here path: %v", err)
+	}
+}
+
+// TestCmdRunPlaybookHereNoEnvVar pins that --here without a Claude
+// session in env refuses with rc=1 AND does not create a dangling
+// run-task row. Early validation before INSERT is the contract.
+func TestCmdRunPlaybookHereNoEnvVar(t *testing.T) {
+	setupFlowRoot(t)
+	wd := t.TempDir()
+	if rc := cmdAdd([]string{"playbook", "P", "--slug", "p", "--work-dir", wd}); rc != 0 {
+		t.Fatal()
+	}
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "")
+	count, _ := stubITerm(t)
+
+	if rc := cmdRun([]string{"playbook", "p", "--here"}); rc != 1 {
+		t.Errorf("rc=%d, want 1 when CLAUDE_CODE_SESSION_ID unset", rc)
+	}
+	if *count != 0 {
+		t.Errorf("no spawn expected; got %d", *count)
+	}
+
+	db := openFlowDB(t)
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM tasks WHERE kind='playbook_run'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("playbook_run rows after refused --here: got %d, want 0 (no dangling row)", n)
+	}
+}
+
+// TestCmdRunPlaybookHereInvalidUUID pins UUID-shape validation. An
+// env var that isn't a v4 UUID is rejected; no dangling row created.
+func TestCmdRunPlaybookHereInvalidUUID(t *testing.T) {
+	setupFlowRoot(t)
+	wd := t.TempDir()
+	if rc := cmdAdd([]string{"playbook", "P", "--slug", "p", "--work-dir", wd}); rc != 0 {
+		t.Fatal()
+	}
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "not-a-uuid")
+	stubITerm(t)
+
+	if rc := cmdRun([]string{"playbook", "p", "--here"}); rc != 1 {
+		t.Errorf("rc=%d, want 1 when env is not a valid UUID", rc)
+	}
+	db := openFlowDB(t)
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM tasks WHERE kind='playbook_run'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("no run row should be created on UUID validation failure; got %d", n)
+	}
+}
+
+// TestCmdRunPlaybookHereRejectsCurrentSessionAlreadyBoundElsewhere
+// pins the session_id uniqueness invariant: if the current session
+// is already bound to another task, --here refuses (and does NOT
+// create a dangling run-task). Mirrors cmdDoHere semantics.
+func TestCmdRunPlaybookHereRejectsCurrentSessionAlreadyBoundElsewhere(t *testing.T) {
+	setupFlowRoot(t)
+	wd := t.TempDir()
+	if rc := cmdAdd([]string{"playbook", "P", "--slug", "p", "--work-dir", wd}); rc != 0 {
+		t.Fatal()
+	}
+	if rc := cmdAdd([]string{"task", "owner-task"}); rc != 0 {
+		t.Fatal()
+	}
+	const sid = "f00ba111-2222-4333-8444-555555555555"
+	db := openFlowDB(t)
+	if _, err := db.Exec(
+		`UPDATE tasks SET session_id=?, session_started=?, status='in-progress' WHERE slug='owner-task'`,
+		sid, flowdb.NowISO(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+	t.Setenv("CLAUDE_CODE_SESSION_ID", sid)
+	stubITerm(t)
+
+	if rc := cmdRun([]string{"playbook", "p", "--here"}); rc != 1 {
+		t.Errorf("rc=%d, want 1 when current session bound elsewhere", rc)
+	}
+
+	db = openFlowDB(t)
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM tasks WHERE kind='playbook_run'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("no run row should be created when session bound elsewhere; got %d", n)
+	}
+	var ownerSID string
+	if err := db.QueryRow(`SELECT session_id FROM tasks WHERE slug='owner-task'`).Scan(&ownerSID); err != nil {
+		t.Fatal(err)
+	}
+	if ownerSID != sid {
+		t.Errorf("owner-task session_id changed: got %q, want %s", ownerSID, sid)
+	}
+}
+
+// TestCmdRunPlaybookHereIgnoresDangerSkip pins that
+// --dangerously-skip-permissions is silently dropped on the --here
+// path (no claude process is spawned, so the flag is meaningless).
+// The bind should still succeed.
+func TestCmdRunPlaybookHereIgnoresDangerSkip(t *testing.T) {
+	setupFlowRoot(t)
+	wd := t.TempDir()
+	if rc := cmdAdd([]string{"playbook", "P", "--slug", "p", "--work-dir", wd}); rc != 0 {
+		t.Fatal()
+	}
+	const sid = "f00ba111-2222-4333-8444-555555555555"
+	t.Setenv("CLAUDE_CODE_SESSION_ID", sid)
+	count, _ := stubITerm(t)
+
+	if rc := cmdRun([]string{"playbook", "p", "--here", "--dangerously-skip-permissions"}); rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+	if *count != 0 {
+		t.Errorf("--here should not spawn even with --dangerously-skip-permissions; got %d", *count)
+	}
+}

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -191,6 +191,7 @@ Sessions
 
 Playbook runs
   flow run playbook <slug>          spawn a fresh run session (new task with kind=playbook_run)
+  flow run playbook <slug> --here   bind THIS Claude session to the new run (no new tab)
   flow list runs [<playbook-slug>]  list playbook runs (filter by playbook optional)
 
 Read
@@ -1122,13 +1123,41 @@ stop.
 
 **Recipe:**
 
-1. Ask session-mode (Regular vs Skip permissions) via AskUserQuestion —
-   reuses the §4.4 pattern. Skip if the user already specified.
-2. Run: `flow run playbook <slug>` (with `--dangerously-skip-permissions`
-   if chosen).
-3. The command creates a kind=playbook_run task, snapshots the brief,
-   and spawns a terminal tab. The new tab will boot the flow skill via its
-   bootstrap prompt and execute against the snapshotted brief.
+1. Probe binding with `flow show task` (no arg). If it errors with
+   `not bound to a task`, this is a dispatch (unbound) session — the
+   in-session bind option is available. If it resolves a task, this
+   session is already bound; only the new-tab path is available.
+
+2. Use AskUserQuestion to pick the run mode. **Unbound session — three
+   options** (header: "Run mode?"):
+
+   - **In this session (bind here)** — runs `flow run playbook <slug> --here`.
+     The new playbook-run task is created, the brief is snapshotted, and THIS
+     conversation is bound to it. No new tab. Pick when the user wants the
+     playbook to execute in the current chat (preserves transcript, no tab
+     switch). Implicitly skips the `--dangerously-skip-permissions` question
+     — there's no claude spawn to forward it to.
+   - **New tab — regular** — runs `flow run playbook <slug>`. Spawns a
+     fresh tab with tool-approval prompts.
+   - **New tab — skip permissions** — runs `flow run playbook <slug>
+     --dangerously-skip-permissions`. Spawns a fresh tab without
+     approval prompts (faster).
+
+   **Bound session — two options** (header: "Run mode?", same options
+   minus "In this session"): the binary refuses `--here` when the
+   current session is already bound (session_id uniqueness invariant;
+   `--force` does not override). Offering it would surface an option
+   the binary will reject — bad UX.
+
+3. Run the chosen invocation. Skip the session-mode question entirely
+   if the user already specified a mode in their request (e.g. "fire X
+   in this session", "run X in a new tab").
+
+4. The command creates a kind=playbook_run task and snapshots the brief
+   in both paths. On the new-tab path it spawns a terminal tab that
+   boots the flow skill. On the `--here` path it binds the current
+   session — your job is to invoke the flow skill yourself and proceed
+   against the snapshotted brief at `~/.flow/tasks/<run-slug>/brief.md`.
 
 **Anti-pattern (per §8):** never auto-fire. Manual trigger only. Even if
 the user mentions a playbook name in passing, do not run it without an

--- a/internal/app/transcript.go
+++ b/internal/app/transcript.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // cmdTranscript implements `flow transcript <task-slug>`. It reads the
@@ -79,7 +80,18 @@ func cmdTranscript(args []string) int {
 		return 1
 	}
 
-	return renderTranscript(jsonlPath, *compact)
+	// Compute the cutoff from session_started so the transcript output is
+	// scoped to the task's own conversation, not pre-bind dispatch chatter
+	// that --here-bound tasks accumulate. NULL/unparseable session_started
+	// → zero cutoff → filter is a no-op (pass everything through).
+	var cutoff time.Time
+	if task.SessionStarted.Valid && task.SessionStarted.String != "" {
+		if ts, perr := time.Parse(time.RFC3339Nano, task.SessionStarted.String); perr == nil {
+			cutoff = ts
+		}
+	}
+
+	return renderTranscript(jsonlPath, *compact, cutoff)
 }
 
 // sessionJSONLPath returns the absolute path to a task's session jsonl file.
@@ -99,9 +111,16 @@ func sessionJSONLPath(task *flowdb.Task) (string, error) {
 // ---------- jsonl record types ----------
 
 // jsonlRecord is the top-level structure of each line in a Claude session jsonl.
+//
+// Timestamp is parsed when present so the close-out sweep (and any caller
+// passing a cutoff) can scope the transcript to entries on-or-after a
+// specific moment — needed because --here-bound tasks carry pre-bind
+// dispatch chatter in their jsonl, which would otherwise leak into KB
+// distillation.
 type jsonlRecord struct {
-	Type    string          `json:"type"`
-	Message json.RawMessage `json:"message"`
+	Type      string          `json:"type"`
+	Message   json.RawMessage `json:"message"`
+	Timestamp string          `json:"timestamp"`
 }
 
 // jsonlMessage is the message body inside user/assistant records.
@@ -128,7 +147,12 @@ type contentBlock struct {
 const maxToolResultLen = 500
 
 // renderTranscript reads a jsonl file and prints a human-readable transcript.
-func renderTranscript(path string, compact bool) int {
+//
+// cutoff scopes the output to entries with timestamp >= cutoff. Pass the
+// zero time.Time to disable the filter. Entries with a missing or
+// unparseable `timestamp` field are kept regardless of cutoff — silent
+// data loss in a KB-distill input is worse than an over-inclusive sweep.
+func renderTranscript(path string, compact bool, cutoff time.Time) int {
 	f, err := os.Open(path)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -150,6 +174,18 @@ func renderTranscript(path string, compact bool) int {
 		var rec jsonlRecord
 		if err := json.Unmarshal(line, &rec); err != nil {
 			continue // skip malformed lines
+		}
+
+		// Filter: drop entries strictly before the cutoff. Defensive on
+		// parse failure / missing field — keep the entry rather than
+		// silently dropping it. RFC3339Nano accepts both the jsonl's
+		// fractional-second UTC form ("...T10:00:00.000Z") and the DB's
+		// offset form ("...+05:30") without fractional, so we use it as
+		// a single parser for both sources.
+		if !cutoff.IsZero() && rec.Timestamp != "" {
+			if ts, perr := time.Parse(time.RFC3339Nano, rec.Timestamp); perr == nil && ts.Before(cutoff) {
+				continue
+			}
 		}
 
 		switch rec.Type {

--- a/internal/app/transcript_test.go
+++ b/internal/app/transcript_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // sampleSessionJSONL is a minimal but representative session jsonl for
@@ -37,7 +38,7 @@ func TestTranscriptRender(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	rc := renderTranscript(jsonlPath, false)
+	rc := renderTranscript(jsonlPath, false, time.Time{})
 
 	w.Close()
 	os.Stdout = old
@@ -96,7 +97,7 @@ func TestTranscriptCompact(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	rc := renderTranscript(jsonlPath, true)
+	rc := renderTranscript(jsonlPath, true, time.Time{})
 
 	w.Close()
 	os.Stdout = old
@@ -185,5 +186,191 @@ func TestTranscriptCmdWithSession(t *testing.T) {
 	rc := cmdTranscript([]string{"tx-test"})
 	if rc != 0 {
 		t.Errorf("transcript with session: rc=%d, want 0", rc)
+	}
+}
+
+// ---------- timestamp cutoff filter ----------
+
+// preBindJSONL has two user messages: one before session_started (pre-bind
+// chatter from the dispatch session) and one after. The filter should drop
+// the pre-bind entry but keep the post-bind one.
+const preBindJSONL = `{"type":"user","message":{"role":"user","content":"PRE-BIND chatter"},"uuid":"u0","timestamp":"2026-05-14T10:00:00.000Z","sessionId":"sid"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"PRE-BIND reply"}]},"uuid":"a0","timestamp":"2026-05-14T10:00:01.000Z","sessionId":"sid"}
+{"type":"user","message":{"role":"user","content":"POST-BIND request"},"uuid":"u1","timestamp":"2026-05-14T11:00:00.000Z","sessionId":"sid"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"POST-BIND reply"}]},"uuid":"a1","timestamp":"2026-05-14T11:00:01.000Z","sessionId":"sid"}
+`
+
+// TestTranscriptFiltersByCutoff pins the --here close-out sweep contract:
+// entries with timestamp < cutoff are dropped. Entries at-or-after are kept.
+func TestTranscriptFiltersByCutoff(t *testing.T) {
+	tmp := t.TempDir()
+	jsonlPath := filepath.Join(tmp, "sid.jsonl")
+	if err := os.WriteFile(jsonlPath, []byte(preBindJSONL), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cutoff, _ := time.Parse(time.RFC3339Nano, "2026-05-14T10:30:00.000Z")
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	rc := renderTranscript(jsonlPath, false, cutoff)
+	w.Close()
+	os.Stdout = old
+	if rc != 0 {
+		t.Fatalf("rc=%d, want 0", rc)
+	}
+	buf := make([]byte, 64*1024)
+	n, _ := r.Read(buf)
+	out := string(buf[:n])
+
+	if strings.Contains(out, "PRE-BIND") {
+		t.Errorf("pre-bind content leaked through filter:\n%s", out)
+	}
+	if !strings.Contains(out, "POST-BIND request") {
+		t.Errorf("post-bind user message dropped:\n%s", out)
+	}
+	if !strings.Contains(out, "POST-BIND reply") {
+		t.Errorf("post-bind assistant message dropped:\n%s", out)
+	}
+}
+
+// TestTranscriptZeroCutoffNoFilter pins the no-op case: when cutoff is
+// the zero time.Time, the filter is bypassed and all entries pass.
+// This is what cmdTranscript should hand to renderTranscript when
+// task.session_started is NULL/empty.
+func TestTranscriptZeroCutoffNoFilter(t *testing.T) {
+	tmp := t.TempDir()
+	jsonlPath := filepath.Join(tmp, "sid.jsonl")
+	if err := os.WriteFile(jsonlPath, []byte(preBindJSONL), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	rc := renderTranscript(jsonlPath, false, time.Time{})
+	w.Close()
+	os.Stdout = old
+	if rc != 0 {
+		t.Fatalf("rc=%d, want 0", rc)
+	}
+	buf := make([]byte, 64*1024)
+	n, _ := r.Read(buf)
+	out := string(buf[:n])
+
+	if !strings.Contains(out, "PRE-BIND chatter") {
+		t.Errorf("zero cutoff should pass everything; pre-bind missing:\n%s", out)
+	}
+	if !strings.Contains(out, "POST-BIND request") {
+		t.Errorf("zero cutoff should pass everything; post-bind missing:\n%s", out)
+	}
+}
+
+// TestTranscriptKeepsEntriesWithMissingTimestamp pins the defensive
+// behavior: an entry without a `timestamp` field is KEPT regardless of
+// cutoff. The user explicitly asked: don't silently lose data.
+func TestTranscriptKeepsEntriesWithMissingTimestamp(t *testing.T) {
+	tmp := t.TempDir()
+	jsonlPath := filepath.Join(tmp, "sid.jsonl")
+	const j = `{"type":"user","message":{"role":"user","content":"NO TIMESTAMP entry"},"uuid":"u0","sessionId":"sid"}
+{"type":"user","message":{"role":"user","content":"BEFORE cutoff"},"uuid":"u1","timestamp":"2026-05-14T09:00:00.000Z","sessionId":"sid"}
+{"type":"user","message":{"role":"user","content":"AFTER cutoff"},"uuid":"u2","timestamp":"2026-05-14T11:00:00.000Z","sessionId":"sid"}
+`
+	if err := os.WriteFile(jsonlPath, []byte(j), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cutoff, _ := time.Parse(time.RFC3339Nano, "2026-05-14T10:00:00.000Z")
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	rc := renderTranscript(jsonlPath, false, cutoff)
+	w.Close()
+	os.Stdout = old
+	if rc != 0 {
+		t.Fatalf("rc=%d, want 0", rc)
+	}
+	buf := make([]byte, 64*1024)
+	n, _ := r.Read(buf)
+	out := string(buf[:n])
+
+	if !strings.Contains(out, "NO TIMESTAMP entry") {
+		t.Errorf("entry without timestamp dropped (should be kept defensively):\n%s", out)
+	}
+	if strings.Contains(out, "BEFORE cutoff") {
+		t.Errorf("entry with timestamp < cutoff was kept:\n%s", out)
+	}
+	if !strings.Contains(out, "AFTER cutoff") {
+		t.Errorf("entry with timestamp >= cutoff was dropped:\n%s", out)
+	}
+}
+
+// TestTranscriptKeepsEntriesWithUnparseableTimestamp pins the second
+// defensive case: an entry whose `timestamp` field is present but not
+// a valid RFC3339[Nano] is KEPT. Better over-inclusive than silently
+// lossy.
+func TestTranscriptKeepsEntriesWithUnparseableTimestamp(t *testing.T) {
+	tmp := t.TempDir()
+	jsonlPath := filepath.Join(tmp, "sid.jsonl")
+	const j = `{"type":"user","message":{"role":"user","content":"BAD TIMESTAMP entry"},"uuid":"u0","timestamp":"not-a-date","sessionId":"sid"}
+`
+	if err := os.WriteFile(jsonlPath, []byte(j), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cutoff, _ := time.Parse(time.RFC3339Nano, "2026-05-14T10:00:00.000Z")
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	rc := renderTranscript(jsonlPath, false, cutoff)
+	w.Close()
+	os.Stdout = old
+	if rc != 0 {
+		t.Fatalf("rc=%d, want 0", rc)
+	}
+	buf := make([]byte, 64*1024)
+	n, _ := r.Read(buf)
+	out := string(buf[:n])
+
+	if !strings.Contains(out, "BAD TIMESTAMP entry") {
+		t.Errorf("entry with unparseable timestamp dropped (should be kept defensively):\n%s", out)
+	}
+}
+
+// TestTranscriptRegularSpawnPassthrough pins the no-op property for
+// non-`--here` tasks: their session_started ≈ first jsonl message
+// (the binary pre-allocates the UUID before spawning the tab, so the
+// first message arrives strictly after session_started). The filter
+// should pass all entries through.
+func TestTranscriptRegularSpawnPassthrough(t *testing.T) {
+	tmp := t.TempDir()
+	jsonlPath := filepath.Join(tmp, "sid.jsonl")
+	if err := os.WriteFile(jsonlPath, []byte(sampleSessionJSONL), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// session_started slightly BEFORE the first jsonl entry (which is
+	// the normal `flow do` ordering).
+	cutoff, _ := time.Parse(time.RFC3339Nano, "2026-04-12T09:59:00.000Z")
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	rc := renderTranscript(jsonlPath, false, cutoff)
+	w.Close()
+	os.Stdout = old
+	if rc != 0 {
+		t.Fatalf("rc=%d, want 0", rc)
+	}
+	buf := make([]byte, 64*1024)
+	n, _ := r.Read(buf)
+	out := string(buf[:n])
+
+	// All the same checks as TestTranscriptRender should pass — filter
+	// is a no-op when session_started precedes everything.
+	for _, want := range []string{"Hello, can you help me?", "Sure, let me check.", "Done!"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("regular-spawn filter dropped %q; output:\n%s", want, out)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes #47. Adds `flow run playbook <slug> --here` so playbook runs can bind the **current** Claude session instead of always spawning a new tab — the parallel to `flow do --here` that didn't exist before. While exercising the new flag against a smoke-test playbook a follow-on bug surfaced (transcript scope), so this PR now has two commits:

1. **feat: flow run playbook --here for in-session bind** — adds the flag, the pre-insert validation, and the dispatch to `cmdDoHere`. Updates `SKILL.md` §4.13 so Claude sessions offer the in-session option in dispatch sessions.

2. **fix: scope flow transcript to session_started for --here cleanliness** — `flow transcript` (which the close-out sweep shells out to via `claude -p`) now drops entries with `timestamp < tasks.session_started`. Prevents pre-bind dispatch chatter from polluting KB distillation when `flow done` runs on a `--here`-bound task. No-op for regular `flow do`-spawned tasks since their `session_started ≈ first jsonl message`.

## Behavior

### Flag

- `flow run playbook <slug>` — unchanged. Spawns a new terminal tab.
- `flow run playbook <slug> --here` — new. Creates the playbook-run task row, snapshots the brief to `tasks/<run-slug>/brief.md`, and binds the current Claude session via `cmdDoHere`. No tab spawn. `--dangerously-skip-permissions` is silently ignored on this path.

### Pre-insert validation

`--here` validates `$CLAUDE_CODE_SESSION_ID` (set + valid v4 UUID) and confirms the current session isn't already bound to another task **before** inserting the run-task row. Prevents dangling `backlog` playbook_run rows on rejected `--here`.

### Transcript filter

`renderTranscript` now accepts a `cutoff time.Time`. `cmdTranscript` derives it from `tasks.session_started` (RFC3339Nano parses both the DB's `+05:30`-offset form and the jsonl's `.000Z` UTC form). Entries with parseable timestamps strictly before the cutoff are dropped. Entries with missing/unparseable timestamps are kept defensively — silent data loss in a KB-distill input is worse than over-inclusion.

### Refusal cases (each tested, none create a dangling row)

- `$CLAUDE_CODE_SESSION_ID` unset → rc=1.
- env var not a v4 UUID → rc=1.
- Current session already bound to another task → rc=1, error names the existing task.

## Doc updates

- `app.go` usage block surfaces the new `--here` form for playbook runs.
- `SKILL.md` §4.13 (Run a playbook) now branches on whether the current Claude session is bound: unbound sessions see the in-session option, bound sessions only see new-tab options (since the binary refuses `--here` for them).
- SKILL.md §4 command-reference cheat sheet adds the `--here` form.

## Test plan
- [x] `go test ./...` — 318 passed (313 prior + 5 new transcript filter tests; 5 `--here` cases live in `run_test.go`)
- [x] `flow run playbook X --here` from a bound session refuses cleanly
- [x] `CLAUDE_CODE_SESSION_ID= flow run playbook X --here` refuses, no dangling row
- [x] `CLAUDE_CODE_SESSION_ID=not-a-uuid flow run playbook X --here` refuses, no dangling row
- [x] `flow transcript <bound-task>` slices at the bind moment (validated end-to-end against this branch's own task; pre-bind intake content filtered, output starts at `flow do --here` invocation)
- [ ] Smoke regression: a fresh `playbook-smoke` run after this lands produces a clean KB sweep with only the run's own conversation