### PR TITLE
feat: flow do --with / --with-file one-shot instruction injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Added
 
+- **`flow do --with` / `--with-file`.** Inject a one-shot instruction
+  as the resumed/started session's first user message (prefixed with
+  `[via flow do --with]` so the model can distinguish injected from
+  typed input). `--with-file <path>` points the session at a file
+  (`read instructions at <abs-path>`) instead of embedding contents —
+  no size limits. `--with` on a `done` task auto-rolls it back to
+  in-progress. Rejected in combination with `--here` (no spawned
+  session to inject into). `flow run playbook <slug>` accepts the same
+  flags. The lane for nudging parked tasks and feeding ad-hoc
+  instructions to scheduled playbook runs without opening the tab. (#25)
 - **Warp as a first-class spawn backend.** `flow do` opens new tabs
   in Warp when invoked from a Warp shell (`TERM_PROGRAM=WarpTerminal`).
   Uses `warp://action/new_tab` to open the tab and osascript to

--- a/README.md
+++ b/README.md
@@ -236,6 +236,35 @@ from iTerm2, "Claude" if Claude Code is the host, etc.; add it via the
 + button if it's not listed). After the grant the spawn is silent.
 iTerm2 doesn't need this — it has a native `create tab` verb.
 
+### One-shot instructions with `--with`
+
+`flow do <task> --with "<instruction>"` resumes (or starts) the task's
+session and injects the instruction as the first user message —
+prefixed with `[via flow do --with]` so the model can tell injected
+input from typed input.
+
+`--with-file <path>` is the same idea for longer instructions: instead
+of embedding the file contents, flow injects `read instructions at
+<absolute path>` and the session uses its Read tool to load the file.
+No size limits. The flags are mutually exclusive, and cannot be
+combined with `--here` (there's no spawned session to inject into).
+
+```bash
+# Nudge a parked task without opening the tab.
+flow do auth --with "check if upstream PR merged and update the brief if so"
+
+# --with on a done task auto-rolls it back to in-progress, so playbooks
+# can fire on previously-closed work.
+flow do auth --with "are we still blocked on the security review?"
+
+# Hand the session a longer brief to follow.
+flow do auth --with-file ~/playbooks/triage-checklist.md
+```
+
+This is the lane scheduled playbooks use to fire instructions at
+existing tasks without manual intervention. `flow run playbook <slug>`
+accepts the same flags for ad-hoc per-run instructions.
+
 ## Your data — local, portable, yours
 
 Everything flow stores lives under `~/.flow/` (override with

--- a/internal/app/do.go
+++ b/internal/app/do.go
@@ -3,13 +3,62 @@ package app
 import (
 	"database/sql"
 	"errors"
+	"flag"
 	"flow/internal/flowdb"
 	"flow/internal/spawner"
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 )
+
+// withMarker prefixes the injected text so the receiving session can
+// distinguish a --with instruction from typed user input.
+const withMarker = "[via flow do --with]"
+
+// loadInjectionText resolves --with / --with-file into the text that
+// will be injected as the session's first user message. For
+// --with-file we don't embed the file's contents — we synthesize a
+// "read instructions at <abs-path>" prompt and let the session use its
+// Read tool. That keeps the shell-quoted blob short regardless of file
+// size and lets the receiving model reason about the file directly.
+func loadInjectionText(fs *flag.FlagSet, withInstr, withFile string) (string, int) {
+	passedWith, passedWithFile := false, false
+	fs.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "with":
+			passedWith = true
+		case "with-file":
+			passedWithFile = true
+		}
+	})
+	if !passedWith && !passedWithFile {
+		return "", 0
+	}
+	if passedWith && passedWithFile {
+		fmt.Fprintln(os.Stderr, "error: --with and --with-file are mutually exclusive")
+		return "", 2
+	}
+	if passedWith {
+		text := strings.TrimSpace(withInstr)
+		if text == "" {
+			fmt.Fprintln(os.Stderr, "error: --with instruction is empty")
+			return "", 2
+		}
+		return text, 0
+	}
+	if _, err := os.Stat(withFile); err != nil {
+		fmt.Fprintf(os.Stderr, "error: --with-file: %v\n", err)
+		return "", 1
+	}
+	abs, err := filepath.Abs(withFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: --with-file: %v\n", err)
+		return "", 1
+	}
+	return "read instructions at " + abs, 0
+}
 
 // openConcurrentDB opens flow.db with a generous busy_timeout so that two
 // concurrent `flow do` processes (or two goroutines in the tests) will
@@ -57,6 +106,8 @@ func cmdDo(args []string) int {
 	dangerSkip := fs.Bool("dangerously-skip-permissions", false, "pass --dangerously-skip-permissions through to claude")
 	force := fs.Bool("force", false, "open even if the task's Claude session is already running elsewhere")
 	here := fs.Bool("here", false, "bind THIS Claude session to the task (no new tab); requires running inside a Claude Code session")
+	withInstr := fs.String("with", "", "inject `<instruction>` as the first user message after the bootstrap/resume")
+	withFile := fs.String("with-file", "", "inject 'read instructions at <path>' (mutually exclusive with --with)")
 	// Two-pass parse so the slug positional may appear before OR after
 	// the flags: first absorb any leading flags, then take the next
 	// non-flag as the slug, then absorb any trailing flags.
@@ -69,6 +120,15 @@ func cmdDo(args []string) int {
 	}
 	query := fs.Arg(0)
 	if err := fs.Parse(fs.Args()[1:]); err != nil {
+		return 2
+	}
+
+	injectionText, rc := loadInjectionText(fs, *withInstr, *withFile)
+	if rc != 0 {
+		return rc
+	}
+	if injectionText != "" && *here {
+		fmt.Fprintln(os.Stderr, "error: --with/--with-file cannot be used with --here (no session is spawned to inject into)")
 		return 2
 	}
 
@@ -137,10 +197,13 @@ func cmdDo(args []string) int {
 		return 1
 	}
 	if curStatus == "done" {
-		fmt.Fprintf(os.Stderr,
-			"error: task %q is done; edit its status back to backlog or in-progress to reopen it\n",
-			task.Slug)
-		return 1
+		if injectionText == "" {
+			fmt.Fprintf(os.Stderr,
+				"error: task %q is done; edit its status back to backlog or in-progress to reopen it\n",
+				task.Slug)
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "--with on done task %q: reopening as in-progress\n", task.Slug)
 	}
 
 	// Decide bootstrap vs resume based on the row we re-read inside the tx.
@@ -167,12 +230,14 @@ func cmdDo(args []string) int {
 	}
 
 	now := flowdb.NowISO()
+	// 'done' is reachable here only via the --with auto-reopen path above.
+	const statusFilter = "status IN ('backlog','in-progress','done')"
 	if needsBootstrap {
 		if _, err := tx.Exec(
 			`UPDATE tasks SET status='in-progress',
 			 status_changed_at = CASE WHEN status != 'in-progress' THEN ? ELSE status_changed_at END,
 			 session_id=?, session_started=?, updated_at=?
-			 WHERE slug=? AND status IN ('backlog','in-progress')`,
+			 WHERE slug=? AND `+statusFilter,
 			now, sessionID, now, now, task.Slug,
 		); err != nil {
 			fmt.Fprintf(os.Stderr, "error: flip status: %v\n", err)
@@ -183,7 +248,7 @@ func cmdDo(args []string) int {
 			`UPDATE tasks SET status='in-progress',
 			 status_changed_at = CASE WHEN status != 'in-progress' THEN ? ELSE status_changed_at END,
 			 updated_at=?
-			 WHERE slug=? AND status IN ('backlog','in-progress')`,
+			 WHERE slug=? AND `+statusFilter,
 			now, now, task.Slug,
 		); err != nil {
 			fmt.Fprintf(os.Stderr, "error: flip status: %v\n", err)
@@ -255,11 +320,17 @@ func cmdDo(args []string) int {
 			isFirstRun = runCount <= 1
 		}
 		prompt := buildBootstrapPromptForKindV2(task.Slug, task.Kind, playbookSlug, isFirstRun)
+		if injectionText != "" {
+			prompt = prompt + "\n\n" + withMarker + "\n" + injectionText
+		}
 		command = fmt.Sprintf("claude --session-id %s %s", sessionID, spawner.ShellQuote(prompt))
 	} else {
 		// Resume path: the UUID we already have in the DB is what claude
 		// used to write its existing jsonl.
 		command = "claude --resume " + sessionID
+		if injectionText != "" {
+			command += " " + spawner.ShellQuote(withMarker+"\n"+injectionText)
+		}
 	}
 	if *dangerSkip {
 		command += " --dangerously-skip-permissions"

--- a/internal/app/do_test.go
+++ b/internal/app/do_test.go
@@ -5,6 +5,8 @@ import (
 	"flow/internal/flowdb"
 	"flow/internal/iterm"
 	"flow/internal/spawner"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -777,5 +779,203 @@ func TestCmdDoHereRejectsDoneTask(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_SESSION_ID", sid)
 	if rc := cmdDo([]string{"done-task", "--here"}); rc != 1 {
 		t.Errorf("rc=%d, want 1 (--here on done task should refuse)", rc)
+	}
+}
+
+func TestCmdDoWithFreshInjectsAfterBootstrap(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "with-fresh")
+	_, getScript := stubITerm(t)
+
+	if rc := cmdDo([]string{"with-fresh", "--with", "check upstream PR"}); rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+	script := getScript()
+	if !strings.Contains(script, "claude --session-id ") {
+		t.Errorf("fresh path should still use --session-id: %s", script)
+	}
+	if !strings.Contains(script, "execution session for flow task with-fresh") {
+		t.Errorf("bootstrap prompt should be intact: %s", script)
+	}
+	if !strings.Contains(script, "[via flow do --with]") {
+		t.Errorf("injected text should carry the marker: %s", script)
+	}
+	if !strings.Contains(script, "check upstream PR") {
+		t.Errorf("injected text body missing: %s", script)
+	}
+	bootstrapIdx := strings.Index(script, "execution session for flow task")
+	markerIdx := strings.Index(script, "[via flow do --with]")
+	if bootstrapIdx == -1 || markerIdx == -1 || markerIdx < bootstrapIdx {
+		t.Errorf("marker must come after bootstrap prompt: %s", script)
+	}
+}
+
+func TestCmdDoWithResumeAppendsPositionalArg(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "with-resume")
+
+	db := openFlowDB(t)
+	if _, err := db.Exec(`UPDATE tasks SET session_id='resume-sid', session_started=? WHERE slug='with-resume'`, flowdb.NowISO()); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+
+	_, getScript := stubITerm(t)
+	if rc := cmdDo([]string{"with-resume", "--with", "ping the user"}); rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+	script := getScript()
+	if !strings.Contains(script, "claude --resume resume-sid") {
+		t.Errorf("resume path should still emit --resume: %s", script)
+	}
+	if !strings.Contains(script, "[via flow do --with]") {
+		t.Errorf("resume path should carry the marker: %s", script)
+	}
+	if !strings.Contains(script, "ping the user") {
+		t.Errorf("resume path missing injected body: %s", script)
+	}
+}
+
+func TestCmdDoWithFile(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "with-file-task")
+
+	dir := t.TempDir()
+	p := filepath.Join(dir, "instr.txt")
+	if err := os.WriteFile(p, []byte("look at the failing tests\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, getScript := stubITerm(t)
+	if rc := cmdDo([]string{"with-file-task", "--with-file", p}); rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+	script := getScript()
+	if !strings.Contains(script, "[via flow do --with]") {
+		t.Errorf("with-file should carry the marker: %s", script)
+	}
+	abs, _ := filepath.Abs(p)
+	want := "read instructions at " + abs
+	if !strings.Contains(script, want) {
+		t.Errorf("with-file should inject %q (pointer, not contents); got: %s", want, script)
+	}
+	if strings.Contains(script, "look at the failing tests") {
+		t.Errorf("with-file should not embed the file body: %s", script)
+	}
+}
+
+func TestCmdDoWithMutualExclusivity(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "with-mutex")
+	dir := t.TempDir()
+	p := filepath.Join(dir, "instr.txt")
+	if err := os.WriteFile(p, []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	spawns, _ := stubITerm(t)
+	rc := cmdDo([]string{"with-mutex", "--with", "x", "--with-file", p})
+	if rc != 2 {
+		t.Errorf("rc=%d, want 2 for mutex violation", rc)
+	}
+	if atomic.LoadInt64(spawns) != 0 {
+		t.Errorf("mutex violation should not spawn: %d", *spawns)
+	}
+}
+
+func TestCmdDoWithEmptyString(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "with-empty")
+	spawns, _ := stubITerm(t)
+	rc := cmdDo([]string{"with-empty", "--with", "   "})
+	if rc != 2 {
+		t.Errorf("rc=%d, want 2 for empty --with", rc)
+	}
+	if atomic.LoadInt64(spawns) != 0 {
+		t.Errorf("empty --with should not spawn: %d", *spawns)
+	}
+}
+
+func TestCmdDoWithFileMissing(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "with-missing")
+	spawns, _ := stubITerm(t)
+	rc := cmdDo([]string{"with-missing", "--with-file", "/no/such/file/here.txt"})
+	if rc != 1 {
+		t.Errorf("rc=%d, want 1 for missing file", rc)
+	}
+	if atomic.LoadInt64(spawns) != 0 {
+		t.Errorf("missing --with-file should not spawn: %d", *spawns)
+	}
+}
+
+func TestCmdDoWithReopensDoneTask(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "with-done")
+
+	db := openFlowDB(t)
+	if _, err := db.Exec(
+		`UPDATE tasks SET status='done', session_id='done-sid', session_started=?, updated_at=? WHERE slug='with-done'`,
+		flowdb.NowISO(), flowdb.NowISO(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+
+	_, getScript := stubITerm(t)
+	if rc := cmdDo([]string{"with-done", "--with", "are we still blocked?"}); rc != 0 {
+		t.Fatalf("rc=%d, want 0 (--with should auto-reopen done)", rc)
+	}
+
+	db = openFlowDB(t)
+	task, err := flowdb.GetTask(db, "with-done")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.Status != "in-progress" {
+		t.Errorf("status=%q after --with on done, want in-progress", task.Status)
+	}
+	if task.SessionID.String != "done-sid" {
+		t.Errorf("session_id should be preserved across done->in-progress: got %q", task.SessionID.String)
+	}
+
+	script := getScript()
+	if !strings.Contains(script, "claude --resume done-sid") {
+		t.Errorf("reopen path should resume the existing session: %s", script)
+	}
+	if !strings.Contains(script, "[via flow do --with]") {
+		t.Errorf("reopen path should still inject the instruction: %s", script)
+	}
+}
+
+func TestCmdDoDoneStillRefusedWithoutWith(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "still-done")
+	db := openFlowDB(t)
+	if _, err := db.Exec(`UPDATE tasks SET status='done', session_id='still-done-sid', session_started=?, updated_at=? WHERE slug='still-done'`, flowdb.NowISO(), flowdb.NowISO()); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+	spawns, _ := stubITerm(t)
+	if rc := cmdDo([]string{"still-done"}); rc != 1 {
+		t.Errorf("rc=%d, want 1 for done without --with", rc)
+	}
+	if atomic.LoadInt64(spawns) != 0 {
+		t.Errorf("done without --with should not spawn: %d", *spawns)
+	}
+}
+
+func TestCmdDoWithRejectedWithHere(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "with-here")
+	spawns, _ := stubITerm(t)
+	sid := "abcdef12-3456-4789-8abc-def012345678"
+	t.Setenv("CLAUDE_CODE_SESSION_ID", sid)
+	rc := cmdDo([]string{"with-here", "--here", "--with", "do the thing"})
+	if rc != 2 {
+		t.Errorf("rc=%d, want 2 for --with + --here", rc)
+	}
+	if atomic.LoadInt64(spawns) != 0 {
+		t.Errorf("--with + --here should not spawn: %d", *spawns)
 	}
 }

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -37,7 +37,18 @@ func cmdRunPlaybook(args []string) int {
 	fs := flagSet("run playbook")
 	dangerSkip := fs.Bool("dangerously-skip-permissions", false, "pass --dangerously-skip-permissions through to claude (ignored when --here is set)")
 	here := fs.Bool("here", false, "bind THIS Claude session to the new playbook run (no new tab); requires running inside a Claude Code session")
+	withInstr := fs.String("with", "", "inject `<instruction>` as the run session's first user message (forwarded to flow do)")
+	withFile := fs.String("with-file", "", "inject 'read instructions at <path>' (forwarded to flow do)")
 	if err := fs.Parse(args[1:]); err != nil {
+		return 2
+	}
+
+	// Reject misuse before we materialize the run-task row.
+	if _, rc := loadInjectionText(fs, *withInstr, *withFile); rc != 0 {
+		return rc
+	}
+	if (*withInstr != "" || *withFile != "") && *here {
+		fmt.Fprintln(os.Stderr, "error: --with/--with-file cannot be used with --here (no session is spawned to inject into)")
 		return 2
 	}
 
@@ -145,6 +156,12 @@ func cmdRunPlaybook(args []string) int {
 	doArgs := []string{runSlug}
 	if *dangerSkip {
 		doArgs = append(doArgs, "--dangerously-skip-permissions")
+	}
+	if *withInstr != "" {
+		doArgs = append(doArgs, "--with", *withInstr)
+	}
+	if *withFile != "" {
+		doArgs = append(doArgs, "--with-file", *withFile)
 	}
 	return cmdDo(doArgs)
 }

--- a/internal/app/run_test.go
+++ b/internal/app/run_test.go
@@ -353,3 +353,45 @@ func TestCmdRunPlaybookHereIgnoresDangerSkip(t *testing.T) {
 		t.Errorf("--here should not spawn even with --dangerously-skip-permissions; got %d", *count)
 	}
 }
+
+func TestCmdRunPlaybookForwardsWith(t *testing.T) {
+	setupFlowRoot(t)
+	wd := t.TempDir()
+	if rc := cmdAdd([]string{"playbook", "Triage", "--slug", "tri-with", "--work-dir", wd}); rc != 0 {
+		t.Fatal()
+	}
+	_, lastScript := stubITerm(t)
+	if rc := cmdRun([]string{"playbook", "tri-with", "--with", "also check the Acme deal"}); rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+	script := lastScript()
+	if !strings.Contains(script, "[via flow do --with]") {
+		t.Errorf("playbook run with --with should carry the marker: %s", script)
+	}
+	if !strings.Contains(script, "also check the Acme deal") {
+		t.Errorf("playbook run with --with should inject the body: %s", script)
+	}
+	if !strings.Contains(script, "playbook `tri-with`") {
+		t.Errorf("playbook bootstrap must remain intact: %s", script)
+	}
+}
+
+func TestCmdRunPlaybookWithEmptyRejectedBeforeRowInsert(t *testing.T) {
+	setupFlowRoot(t)
+	wd := t.TempDir()
+	if rc := cmdAdd([]string{"playbook", "Triage", "--slug", "tri-empty", "--work-dir", wd}); rc != 0 {
+		t.Fatal()
+	}
+	stubITerm(t)
+	if rc := cmdRun([]string{"playbook", "tri-empty", "--with", "   "}); rc != 2 {
+		t.Errorf("rc=%d, want 2 for empty --with", rc)
+	}
+	db := openFlowDB(t)
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM tasks WHERE kind='playbook_run' AND playbook_slug='tri-empty'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("rejected --with should not insert a run row; got %d rows", n)
+	}
+}

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -186,11 +186,13 @@ Create
 
 Sessions
   flow do               <ref> [--fresh] [--dangerously-skip-permissions] [--force]
+                              [--with "<instruction>" | --with-file <path>]
   flow do --here        <ref> [--force]   (bind THIS Claude session to the task — no new tab)
   flow done             <ref>
 
 Playbook runs
-  flow run playbook <slug>          spawn a fresh run session (new task with kind=playbook_run)
+  flow run playbook <slug> [--with "<instr>" | --with-file <path>]
+                                    spawn a fresh run session (new task with kind=playbook_run)
   flow run playbook <slug> --here   bind THIS Claude session to the new run (no new tab)
   flow list runs [<playbook-slug>]  list playbook runs (filter by playbook optional)
 
@@ -635,6 +637,57 @@ Macros for this: do not invent more candidate apps to toggle, do not
 suggest the user reinstall flow, do not attempt to grant Accessibility
 yourself. macOS guards Accessibility deliberately — there is no CLI to
 self-grant it, and Claude cannot bypass that.
+
+#### Surgical instructions: `--with` and `--with-file`
+
+**Triggers:** the user wants to *fire a one-off instruction at a task*
+without opening the tab to type it themselves. Phrasings:
+
+- "tell <task> to <do X>"
+- "nudge <task> to check <Y>"
+- "have <task> verify <Z>"
+- "fire <instruction> at <task>"
+- "ping <task> with <instruction>"
+- "ask <task> whether <Q>"
+
+**Recipe:** add `--with "<instruction>"` to the `flow do` invocation.
+Quote the instruction as a single shell-safe string. The session
+receives it as its first user message, prefixed with
+`[via flow do --with]` so the model knows it's an injected instruction
+rather than typed input.
+
+**Use `--with-file <path>` when:** the instruction is a longer brief
+the user already wrote down (a checklist, a multi-step recipe, a
+one-pager). flow does NOT embed the file contents — it injects
+`read instructions at <abs-path>` and the session uses its Read tool
+to load it. No size limits. Use this whenever the user references a
+file ("the brief in ~/notes/X.md", "the checklist at triage.md").
+
+**The flags are mutually exclusive.** If the user mixes them, ask via
+AskUserQuestion which one they meant.
+
+**`--with` on a `done` task** auto-rolls it back to in-progress and
+proceeds. This is the supported lane for "nudge a parked task" — do
+NOT pre-flip status yourself; just pass `--with` and let `flow do`
+handle the reopen. The binary prints a stderr notice
+(`--with on done task "X": reopening as in-progress`) — relay it
+verbatim.
+
+**`--with` is incompatible with `--here`.** `--here` binds the
+current session with no spawn, so there's no first message to inject;
+the binary rejects the combination with rc=2. If the user wants to
+both bind-here AND act on an instruction, they're already in the
+session — just do the work directly, no `--with` needed.
+
+**Same flags work on `flow run playbook <slug>`** — use them when the
+user wants a one-off instruction layered on top of a fresh playbook
+run (e.g. a scheduled run that today should also "double-check the
+Acme deal status").
+
+**When NOT to use `--with`:** if the user is opening the tab to work
+in it themselves. `--with` is for fire-and-forget nudges, not for
+"open the tab with this prompt pre-typed for me". When the user will
+be at the keyboard, run plain `flow do <slug>`.
 
 ### 4.5 Save a progress note
 


### PR DESCRIPTION
Closes #25.

## Summary

- `flow do <task> --with "<instruction>"` injects the instruction as the resumed/started session's **first user message**, prefixed with `[via flow do --with]` so the model can distinguish it from typed input.
- `flow do <task> --with-file <path>` is the same for longer instructions — flow does **not** embed file contents; it injects `read instructions at <abs-path>` and the session uses its Read tool. No size limits.
- `--with` on a `done` task **auto-reopens** it to in-progress (matches `flow update task --status` intent) and prints a stderr notice.
- Flags are **mutually exclusive** and **rejected with `--here`** (no spawned session to inject into).
- `flow run playbook <slug>` accepts the same flags (forwarded to `cmdDo`), validated before the run-task row is materialized.
- Skill (`SKILL.md`), README, CHANGELOG updated.

Resolved the issue's open questions:
- *`--with` on done?* → auto-rollback to in-progress (per brief).
- *`--fresh` interaction?* → instruction comes **after** the bootstrap prompt, so task context loads first.
- *trigger-source identification?* → generic `[via flow do --with]` marker.

## Design note

`--with-file` started as an embed-with-64KiB-cap; reworked per review into a file **pointer** — cleaner, no shell-blob bloat, no arbitrary cap. Branch was also re-ported onto current `main` after the `iterm`→`spawner` refactor + `--here`/`--force` two-pass flag parsing landed (#46/#48).

## Smoke test results

**1. CLI contract — does `claude` accept a positional prompt arg with `--session-id` and `--resume`?** (the load-bearing assumption from #25's open questions)

```
$ claude --print --session-id <uuid> "respond with the single word ACK"
ACK
$ claude --print --resume <uuid> "respond with the single word YES"
YES
$ jq '... user messages ...' <uuid>.jsonl
2026-05-15T07:58:33Z  respond with the single word ACK and nothing else
2026-05-15T07:58:44Z  respond with the single word YES and nothing else
```

Both messages landed in the same session jsonl, in order — confirms claude treats the positional arg as the next user message on both fresh and resume.

**2. Exact spawn command flow emits** (captured via the real code path, iTerm stubbed):

Resume + `--with`:
```
claude --resume SID-RESUME '[via flow do --with]
check if upstream PR merged'
```

Fresh bootstrap + `--with-file` (bootstrap prompt preserved in full, marker+pointer appended):
```
claude --session-id <uuid> 'You are the execution session for flow task ...
... (full bootstrap prompt) ...

[via flow do --with]
read instructions at /tmp/flow-smoke-test/instr.txt'
```

**3. Flag wiring via the built binary:**
```
$ flow do nope --with x --with-file /tmp/y
error: --with and --with-file are mutually exclusive            (rc=2)
$ flow do nope --here --with x
error: --with/--with-file cannot be used with --here ...         (rc=2)
$ flow run playbook nope --here --with x
error: --with/--with-file cannot be used with --here ...         (rc=2)
```

## Test plan

- [x] `go test ./...` — full suite green (12 new tests: 10 in do_test, 2 in run_test)
- [x] `go vet ./...` — clean
- [x] Unit: both flags happy path, mutual exclusivity, done-task auto-reopen, file-not-found, empty string, `--with`+`--here` rejection, playbook forwarding, no-row-on-early-reject
- [x] CLI contract verified against real `claude` binary
- [ ] Interactive iTerm spawn → live session reads injected text (requires Accessibility grant; unit-tested at the spawn-command boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)