### PR TITLE
feat: Ghostty as a first-class spawn backend

### DIFF
--- a/internal/ghostty/ghostty.go
+++ b/internal/ghostty/ghostty.go
@@ -1,0 +1,88 @@
+// Package ghostty provides Ghostty tab spawning via osascript.
+//
+// Mirrors the contract of internal/iterm — same SpawnTab signature,
+// same env-injection semantics, same Runner mock var for tests. Two
+// places differ from iterm:
+//
+//   - Ghostty's `name` property on tab and terminal classes is
+//     read-only (`access="r"` in the .sdef). AppleScript can read
+//     it but cannot set it. We set the tab title by prepending an
+//     OSC 2 escape sequence to the typed command; Ghostty intercepts
+//     it like every other modern xterm-compatible terminal.
+//
+//   - Ghostty's `new tab` command REQUIRES an `in <window>`
+//     parameter. Calling it bare errors -1708. We branch on whether
+//     any windows exist and call `new window` first when none do.
+package ghostty
+
+import (
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// Runner is the function used to execute osascript. Tests override
+// this to capture arguments without touching real Ghostty.
+var Runner = func(args []string) error {
+	cmd := exec.Command("osascript", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("osascript failed: %v: %s", err, string(out))
+	}
+	return nil
+}
+
+// SpawnTab opens a new Ghostty tab with the given title, cwd, and
+// command. envVars are attached as an inline prefix to `command` only
+// — so they are present in the spawned process's environment but do
+// NOT persist in the tab's shell after the command exits.
+//
+// The typed line is prefixed with a single space so shells with
+// `histignorespace` (zsh) or `HISTCONTROL=ignorespace`/`ignoreboth`
+// (bash) skip writing it to the shared history file.
+func SpawnTab(title, cwd, command string, envVars map[string]string) error {
+	envPrefix := ""
+	if len(envVars) > 0 {
+		keys := make([]string, 0, len(envVars))
+		for k := range envVars {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		parts := make([]string, 0, len(envVars))
+		for _, k := range keys {
+			parts = append(parts, fmt.Sprintf("%s=%s", k, ShellQuote(envVars[k])))
+		}
+		envPrefix = strings.Join(parts, " ") + " "
+	}
+
+	titlePrefix := fmt.Sprintf(`printf '\033]2;%%s\007' %s ; `, ShellQuote(title))
+	fullCommand := fmt.Sprintf(" %scd %s && %s%s", titlePrefix, ShellQuote(cwd), envPrefix, command)
+	safeCommand := escapeAppleScriptString(fullCommand)
+
+	script := fmt.Sprintf(`tell application "Ghostty"
+  activate
+  if (count of windows) is 0 then
+    set newWin to (new window)
+    set targetTerm to focused terminal of (first tab of newWin)
+  else
+    set newTab to (new tab in front window)
+    set targetTerm to focused terminal of newTab
+  end if
+  input text "%s" & return to targetTerm
+end tell
+`, safeCommand)
+
+	return Runner([]string{"-e", script})
+}
+
+// ShellQuote wraps s in single quotes with proper escaping.
+func ShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+func escapeAppleScriptString(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return s
+}

--- a/internal/ghostty/ghostty_test.go
+++ b/internal/ghostty/ghostty_test.go
@@ -1,0 +1,96 @@
+package ghostty
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSpawnTabScriptShape verifies the AppleScript emitted to osascript
+// targets Ghostty, embeds env-var assignments before the command,
+// sets the tab title via an OSC 2 escape sequence (Ghostty's `name`
+// property is read-only), and uses `new tab in front window` when a
+// window already exists. The osascript binary is mocked via Runner.
+func TestSpawnTabScriptShape(t *testing.T) {
+	var captured string
+	old := Runner
+	Runner = func(args []string) error {
+		if len(args) >= 2 {
+			captured = args[1]
+		}
+		return nil
+	}
+	t.Cleanup(func() { Runner = old })
+
+	envVars := map[string]string{
+		"FLOW_TASK":    "my-task",
+		"FLOW_PROJECT": "flow",
+	}
+	if err := SpawnTab("flow/my-task", "/Users/me/repo", "claude --resume abc", envVars); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+
+	mustContain := []string{
+		`tell application "Ghostty"`,
+		`activate`,
+		`if (count of windows) is 0 then`,
+		`set newWin to (new window)`,
+		`set targetTerm to focused terminal of (first tab of newWin)`,
+		`set newTab to (new tab in front window)`,
+		`input text "`,
+		` & return to targetTerm`,
+		// OSC 2 title set inline via printf — Ghostty's name property is read-only.
+		`printf '\\033]2;%s\\007' 'flow/my-task' ;`,
+		// env vars assigned alphabetically, before the command, all on one line:
+		`FLOW_PROJECT='flow' FLOW_TASK='my-task' claude --resume abc`,
+		// cd is the first thing in the typed line, single-leading-space
+		// for histignorespace:
+		` cd '/Users/me/repo' && `,
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(captured, s) {
+			t.Errorf("script missing %q\n--- script ---\n%s", s, captured)
+		}
+	}
+}
+
+// TestSpawnTabNoEnvVars covers the env-prefix branch when envVars is
+// nil — the line should still cd and run the command, just with no
+// VAR=value assignments in front.
+func TestSpawnTabNoEnvVars(t *testing.T) {
+	var captured string
+	old := Runner
+	Runner = func(args []string) error {
+		if len(args) >= 2 {
+			captured = args[1]
+		}
+		return nil
+	}
+	t.Cleanup(func() { Runner = old })
+
+	if err := SpawnTab("t", "/tmp", "echo hi", nil); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+	if !strings.Contains(captured, ` cd '/tmp' && echo hi`) {
+		t.Errorf("expected bare `cd … && echo hi` line; got:\n%s", captured)
+	}
+	if strings.Contains(captured, "echo hi=") {
+		t.Errorf("unexpected env assignment in command line: %s", captured)
+	}
+}
+
+// TestShellQuote is a sanity check on the local helper — same contract
+// as iterm.ShellQuote and terminal.ShellQuote.
+func TestShellQuote(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"plain", "'plain'"},
+		{"with space", "'with space'"},
+		{"with'quote", `'with'\''quote'`},
+	}
+	for _, tc := range cases {
+		if got := ShellQuote(tc.in); got != tc.want {
+			t.Errorf("ShellQuote(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/spawner/spawner.go
+++ b/internal/spawner/spawner.go
@@ -1,5 +1,5 @@
 // Package spawner picks a terminal backend (zellij, kitty, Warp, iTerm2,
-// or macOS Terminal.app) at runtime and forwards SpawnTab to it.
+// Ghostty, or macOS Terminal.app) at runtime and forwards SpawnTab to it.
 //
 // Selection priority (highest first):
 //
@@ -9,6 +9,7 @@
 //	TERM_PROGRAM=WarpTerminal                      → internal/warp
 //	TERM_PROGRAM=Apple_Terminal                    → internal/terminal
 //	TERM_PROGRAM=iTerm.app                         → internal/iterm
+//	TERM_PROGRAM=ghostty                           → internal/ghostty
 //	anything else (or unset)                       → internal/iterm  (historical default)
 //
 // $ZELLIJ and kitty's per-window markers win over $FLOW_TERM because if
@@ -24,6 +25,7 @@
 package spawner
 
 import (
+	"flow/internal/ghostty"
 	"flow/internal/iterm"
 	"flow/internal/kitty"
 	"flow/internal/terminal"
@@ -41,6 +43,7 @@ const (
 	BackendZellij   Backend = "zellij"
 	BackendKitty    Backend = "kitty"
 	BackendWarp     Backend = "warp"
+	BackendGhostty  Backend = "ghostty"
 )
 
 // Override, if non-empty, forces a backend regardless of env vars.
@@ -62,7 +65,7 @@ func Detect() Backend {
 	}
 	if v := os.Getenv("FLOW_TERM"); v != "" {
 		switch Backend(v) {
-		case BackendITerm, BackendTerminal, BackendZellij, BackendKitty, BackendWarp:
+		case BackendITerm, BackendTerminal, BackendZellij, BackendKitty, BackendWarp, BackendGhostty:
 			return Backend(v)
 		}
 		// Unknown value falls through to TERM_PROGRAM detection.
@@ -74,6 +77,8 @@ func Detect() Backend {
 		return BackendITerm
 	case "WarpTerminal":
 		return BackendWarp
+	case "ghostty":
+		return BackendGhostty
 	default:
 		return BackendITerm
 	}
@@ -91,6 +96,8 @@ func SpawnTab(title, cwd, command string, envVars map[string]string) error {
 		return terminal.SpawnTab(title, cwd, command, envVars)
 	case BackendWarp:
 		return warp.SpawnTab(title, cwd, command, envVars)
+	case BackendGhostty:
+		return ghostty.SpawnTab(title, cwd, command, envVars)
 	default:
 		return iterm.SpawnTab(title, cwd, command, envVars)
 	}

--- a/internal/spawner/spawner_test.go
+++ b/internal/spawner/spawner_test.go
@@ -1,6 +1,7 @@
 package spawner
 
 import (
+	"flow/internal/ghostty"
 	"flow/internal/iterm"
 	"flow/internal/kitty"
 	"flow/internal/terminal"
@@ -21,6 +22,7 @@ func TestDetectFromEnv(t *testing.T) {
 		{"iTerm.app", BackendITerm},
 		{"Apple_Terminal", BackendTerminal},
 		{"WarpTerminal", BackendWarp},
+		{"ghostty", BackendGhostty},
 		{"", BackendITerm},
 		{"WezTerm", BackendITerm},
 		{"vscode", BackendITerm},
@@ -53,7 +55,7 @@ func TestOverrideBeatsEnv(t *testing.T) {
 	t.Cleanup(func() { Override = "" })
 
 	for _, want := range []Backend{
-		BackendTerminal, BackendWarp, BackendITerm, BackendKitty, BackendZellij,
+		BackendTerminal, BackendWarp, BackendITerm, BackendKitty, BackendZellij, BackendGhostty,
 	} {
 		Override = want
 		if got := Detect(); got != want {
@@ -123,6 +125,7 @@ func TestDetectFlowTermOverride(t *testing.T) {
 		{"zellij", BackendZellij},
 		{"kitty", BackendKitty},
 		{"warp", BackendWarp},
+		{"ghostty", BackendGhostty},
 	}
 	for _, tc := range cases {
 		t.Run(tc.flowTerm, func(t *testing.T) {
@@ -182,7 +185,7 @@ func TestSpawnTabRoutesToITerm(t *testing.T) {
 	if !*calls.iterm {
 		t.Error("expected iterm.Runner to be called")
 	}
-	if *calls.terminal || *calls.zellij || *calls.kitty || *calls.warp {
+	if *calls.terminal || *calls.zellij || *calls.kitty || *calls.warp || *calls.ghostty {
 		t.Error("only iterm.Runner should be called")
 	}
 }
@@ -200,7 +203,7 @@ func TestSpawnTabRoutesToTerminal(t *testing.T) {
 	if !*calls.terminal {
 		t.Error("expected terminal.Runner to be called")
 	}
-	if *calls.iterm || *calls.zellij || *calls.kitty || *calls.warp {
+	if *calls.iterm || *calls.zellij || *calls.kitty || *calls.warp || *calls.ghostty {
 		t.Error("only terminal.Runner should be called")
 	}
 }
@@ -218,7 +221,7 @@ func TestSpawnTabRoutesToZellij(t *testing.T) {
 	if !*calls.zellij {
 		t.Error("expected zellij.Runner to be called")
 	}
-	if *calls.iterm || *calls.terminal || *calls.kitty || *calls.warp {
+	if *calls.iterm || *calls.terminal || *calls.kitty || *calls.warp || *calls.ghostty {
 		t.Error("only zellij.Runner should be called")
 	}
 }
@@ -236,7 +239,7 @@ func TestSpawnTabRoutesToKitty(t *testing.T) {
 	if !*calls.kitty {
 		t.Error("expected kitty backend to be called")
 	}
-	if *calls.iterm || *calls.terminal || *calls.zellij || *calls.warp {
+	if *calls.iterm || *calls.terminal || *calls.zellij || *calls.warp || *calls.ghostty {
 		t.Error("only kitty backend should be called")
 	}
 }
@@ -254,8 +257,26 @@ func TestSpawnTabRoutesToWarp(t *testing.T) {
 	if !*calls.warp {
 		t.Error("expected warp.Runner to be called")
 	}
-	if *calls.iterm || *calls.terminal || *calls.zellij || *calls.kitty {
+	if *calls.iterm || *calls.terminal || *calls.zellij || *calls.kitty || *calls.ghostty {
 		t.Error("only warp backend should be called")
+	}
+}
+
+// TestSpawnTabRoutesToGhostty asserts the ghostty Runner is the one
+// called when Detect() resolves to BackendGhostty.
+func TestSpawnTabRoutesToGhostty(t *testing.T) {
+	Override = BackendGhostty
+	t.Cleanup(func() { Override = "" })
+
+	calls := stubAllRunners(t)
+	if err := SpawnTab("title", "/tmp", "echo hi", nil); err != nil {
+		t.Fatalf("SpawnTab: %v", err)
+	}
+	if !*calls.ghostty {
+		t.Error("expected ghostty.Runner to be called")
+	}
+	if *calls.iterm || *calls.terminal || *calls.zellij || *calls.kitty || *calls.warp {
+		t.Error("only ghostty backend should be called")
 	}
 }
 
@@ -277,6 +298,9 @@ func TestShellQuoteParity(t *testing.T) {
 		if got := warp.ShellQuote(in); got != exp {
 			t.Errorf("warp.ShellQuote(%q) = %q; want %q", in, got, exp)
 		}
+		if got := ghostty.ShellQuote(in); got != exp {
+			t.Errorf("ghostty.ShellQuote(%q) = %q; want %q", in, got, exp)
+		}
 	}
 }
 
@@ -284,7 +308,7 @@ func TestShellQuoteParity(t *testing.T) {
 // can assert on which backend SpawnTab dispatched to without an
 // awkward multi-return-value tuple.
 type runnerFlags struct {
-	iterm, terminal, zellij, kitty, warp *bool
+	iterm, terminal, zellij, kitty, warp, ghostty *bool
 }
 
 // stubAllRunners replaces every backend's Runner (plus warp's
@@ -293,7 +317,7 @@ type runnerFlags struct {
 // cleanup.
 func stubAllRunners(t *testing.T) runnerFlags {
 	t.Helper()
-	var itermCalled, terminalCalled, zellijCalled, kittyCalled, warpCalled bool
+	var itermCalled, terminalCalled, zellijCalled, kittyCalled, warpCalled, ghosttyCalled bool
 
 	oldITerm := iterm.Runner
 	iterm.Runner = func(args []string) error {
@@ -365,11 +389,22 @@ func stubAllRunners(t *testing.T) runnerFlags {
 	warp.WriteScript = func(string) (string, error) { return "/tmp/flow-warp-stub.sh", nil }
 	t.Cleanup(func() { warp.WriteScript = oldWriteScript })
 
+	oldGhostty := ghostty.Runner
+	ghostty.Runner = func(args []string) error {
+		ghosttyCalled = true
+		if len(args) >= 2 && !strings.Contains(args[1], `"Ghostty"`) {
+			t.Errorf("ghostty script does not target Ghostty: %s", args[1])
+		}
+		return nil
+	}
+	t.Cleanup(func() { ghostty.Runner = oldGhostty })
+
 	return runnerFlags{
 		iterm:    &itermCalled,
 		terminal: &terminalCalled,
 		zellij:   &zellijCalled,
 		kitty:    &kittyCalled,
 		warp:     &warpCalled,
+		ghostty:  &ghosttyCalled,
 	}
 }


### PR DESCRIPTION
Adds Ghostty (https://ghostty.org) alongside iTerm2, Terminal.app, zellij, kitty, and Warp. Mirrors the convention every other backend follows: a self-contained `internal/ghostty` package plus a single case added to `spawner.Detect()` and `spawner.SpawnTab()`. Picked up automatically when `TERM_PROGRAM=ghostty`, or via the existing `FLOW_TERM=ghostty` opt-in for users on non-standard hosts.

Motivation: without a Ghostty-native backend, `flow do` from inside Ghostty silently falls through to the iTerm2 default in `Detect()`, which then runs iTerm2 AppleScript against whichever app happens to own the bundle id — at best a tab opens in a Ghostty instance the user did not invoke; at worst osascript fails with cryptic errors when iTerm2 isn't running. Tracks issue #3 (Linux support via pluggable terminal spawner), which named Ghostty as a target.

Two Ghostty quirks worth pointing out for reviewers:

- The `name` property on `tab` and `terminal` classes is read-only (`access="r"` in the .sdef). AppleScript cannot set the title directly, so we prepend an OSC 2 escape sequence to the typed command — Ghostty intercepts it like every other xterm-compatible terminal.

- `new tab` requires an `in <window>` parameter (calling it bare errors -1708). The script branches on `count of windows`: when zero, `new window` first, then operate on its first tab; otherwise `new tab in front window`.

No Accessibility wrapper needed: Ghostty's `input text` is a native AppleScript verb, not a System Events keystroke, so this backend sidesteps the Accessibility gate that `internal/terminal` handles.

Tests follow the existing pattern: script-shape, no-env-vars, and ShellQuote parity in `internal/ghostty`; FLOW_TERM coverage, Detect case, and routing assertion in `internal/spawner`. `make test` passes. No new dependencies; no behavioral change for non-Ghostty hosts.

<!--
Thanks for sending a PR. A few quick prompts to keep reviews tight.
-->

## What

<!-- One-line summary of what changes. -->

## Why

<!--
Why this change? Link an issue if there is one. If you're changing
behaviour the embedded skill (`internal/app/skill/SKILL.md`) describes,
mention it explicitly — the skill is part of the contract.
-->

## Test plan

- [ ] `make test` passes
- [ ] CI green (`go vet`, `go test ./...`, build on macOS + Ubuntu)
- [ ] Manually exercised the changed command(s) where applicable
- [ ] If the skill changed: rebuilt and ran `flow skill update`
- [ ] If `hookCommand` in `internal/app/skill.go` changed: called out
      in the description (this is a breaking change for existing
      installs)

## Notes

<!-- Anything reviewers should know — alternatives considered, things
deliberately left out, follow-ups planned. -->
