### PR TITLE
docs: add Claude shell aliases to Install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,10 +176,10 @@ doesn't refuse to run the unsigned binary.
 ### For those who use Claude's agents view
 
 If you use the agents view and you use flow, these aliases will help.
-`flow do` and `flow run` don't pass `--bg` today — the aliases do, so
-flow's sessions (and your own direct invocations) land in the agents
-view. Add to your shell rc (`~/.zshrc` or `~/.bashrc`) and `source`
-it.
+`flow do` and `flow run` don't pass `--bg` today — the aliases below
+will, so flow's sessions (and your own direct invocations) land in
+the agents view. Add to your shell rc (`~/.zshrc` or `~/.bashrc`) and
+`source` it.
 
 ```bash
 # Bare `claude` now drops into the agents view. Add

--- a/README.md
+++ b/README.md
@@ -186,11 +186,11 @@ the agents view. Add to your shell rc (`~/.zshrc` or `~/.bashrc`) and
 # sessions to skip per-tool permission prompts (optional flavor).
 alias claude='claude --bg'
 
-# Shortcut: `ca` opens the agents view via its subcommand. `command`
-# bypasses the `claude` alias above so the subcommand sees a clean
-# argv — apply the same `command claude <sub>` pattern if you want
-# shortcuts for any other subcommand (`mcp`, `doctor`, etc.) while
-# the `claude` alias is in place.
+# Since `claude` is now aliased, any `claude <sub>` invocation would
+# also pick up `--bg`. For each subcommand you use, add an alias that
+# routes through `command claude` to bypass the outer alias. The one
+# below is for the agents subcommand — the same shape works for
+# `mcp`, `doctor`, etc.
 alias ca='command claude agents'
 ```
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,6 @@ doesn't refuse to run the unsigned binary.
 
 ### For those who use Claude's agents view
 
-If you use the agents view and you use flow, these aliases will help.
 `flow do` and `flow run` don't pass `--bg` today — the aliases below
 will, so flow's sessions (and your own direct invocations) land in
 the agents view. Add to your shell rc (`~/.zshrc` or `~/.bashrc`) and

--- a/README.md
+++ b/README.md
@@ -173,6 +173,22 @@ doesn't refuse to run the unsigned binary.
 
 </details>
 
+### Optional: Claude shell aliases
+
+Two aliases that make day-to-day Claude Code use a little nicer. Add to
+your shell rc (`~/.zshrc` or `~/.bashrc`) and `source` it.
+
+```bash
+# Default `claude` skips per-tool permission prompts and runs in the
+# background. Drop either flag if you'd rather keep the prompts or stay
+# in the foreground.
+alias claude='claude --dangerously-skip-permissions --bg'
+
+# Shortcut for Claude agents mode. `command` bypasses the `claude` alias
+# above so the agents subcommand sees a clean argv.
+alias ca='command claude agents'
+```
+
 ## Upgrade
 
 In any Claude Code session:

--- a/README.md
+++ b/README.md
@@ -175,11 +175,11 @@ doesn't refuse to run the unsigned binary.
 
 ### For those who use Claude's agents view
 
-flow opens Claude sessions for you (`flow do`, `flow run playbook`,
-etc.). If you've made the agents view your home base, these two
-aliases route every Claude session — flow's and your own — there,
-without `--bg` to type each time. Add to your shell rc (`~/.zshrc` or
-`~/.bashrc`) and `source` it.
+If you use the agents view and you use flow, these aliases will help.
+`flow do` and `flow run` don't pass `--bg` today — the aliases do, so
+flow's sessions (and your own direct invocations) land in the agents
+view. Add to your shell rc (`~/.zshrc` or `~/.bashrc`) and `source`
+it.
 
 ```bash
 # Bare `claude` now drops into the agents view. Add

--- a/README.md
+++ b/README.md
@@ -175,10 +175,11 @@ doesn't refuse to run the unsigned binary.
 
 ### For those who use Claude's agents view
 
-If Claude Code's agents view is where you live, these two aliases make
-it the default destination for every `claude` invocation — no `--bg`
-to type each time. Add to your shell rc (`~/.zshrc` or `~/.bashrc`)
-and `source` it.
+flow opens Claude sessions for you (`flow do`, `flow run playbook`,
+etc.). If you've made the agents view your home base, these two
+aliases route every Claude session — flow's and your own — there,
+without `--bg` to type each time. Add to your shell rc (`~/.zshrc` or
+`~/.bashrc`) and `source` it.
 
 ```bash
 # Bare `claude` now drops into the agents view. Add

--- a/README.md
+++ b/README.md
@@ -175,13 +175,14 @@ doesn't refuse to run the unsigned binary.
 
 ### For those who use Claude's agents view
 
-Claude Code's `agents` view is the dashboard for managing background
-agents. Two aliases that make reaching it a one- or two-letter trip —
-add to your shell rc (`~/.zshrc` or `~/.bashrc`) and `source` it.
+If Claude Code's agents view is where you live, these two aliases make
+it the default destination for every `claude` invocation — no `--bg`
+to type each time. Add to your shell rc (`~/.zshrc` or `~/.bashrc`)
+and `source` it.
 
 ```bash
-# Bare `claude` drops straight into the agents view via --bg. Add
-# `--dangerously-skip-permissions` too if you'd also like dispatched
+# Bare `claude` now drops into the agents view. Add
+# `--dangerously-skip-permissions` if you'd also like dispatched
 # sessions to skip per-tool permission prompts (optional flavor).
 alias claude='claude --bg'
 

--- a/README.md
+++ b/README.md
@@ -173,19 +173,23 @@ doesn't refuse to run the unsigned binary.
 
 </details>
 
-### Optional: Claude shell aliases
+### For those who use Claude's agents view
 
-Two aliases that make day-to-day Claude Code use a little nicer. Add to
-your shell rc (`~/.zshrc` or `~/.bashrc`) and `source` it.
+Claude Code's `agents` view is the dashboard for managing background
+agents. Two aliases that make reaching it a one- or two-letter trip —
+add to your shell rc (`~/.zshrc` or `~/.bashrc`) and `source` it.
 
 ```bash
-# Default `claude` skips per-tool permission prompts and runs in the
-# background. Drop either flag if you'd rather keep the prompts or stay
-# in the foreground.
-alias claude='claude --dangerously-skip-permissions --bg'
+# Bare `claude` drops straight into the agents view via --bg. Add
+# `--dangerously-skip-permissions` too if you'd also like dispatched
+# sessions to skip per-tool permission prompts (optional flavor).
+alias claude='claude --bg'
 
-# Shortcut for Claude agents mode. `command` bypasses the `claude` alias
-# above so the agents subcommand sees a clean argv.
+# Shortcut: `ca` opens the agents view via its subcommand. `command`
+# bypasses the `claude` alias above so the subcommand sees a clean
+# argv — apply the same `command claude <sub>` pattern if you want
+# shortcuts for any other subcommand (`mcp`, `doctor`, etc.) while
+# the `claude` alias is in place.
 alias ca='command claude agents'
 ```
 


### PR DESCRIPTION
## Summary

Adds an "Optional: Claude shell aliases" subsection at the end of the Install section with two aliases:

- `claude` → `claude --dangerously-skip-permissions --bg` (skip per-tool prompts, run in background)
- `ca` → `command claude agents` (Claude agents-mode shortcut; `command` bypasses the first alias so the `agents` subcommand sees a clean argv)

Request from Anshul Sao via DM so others can enable agents mode by sourcing two lines. Generalized away from his personal `/Users/anshulsao/.local/bin/claude` path — `command claude` works wherever the binary lives on PATH.

## Test plan

- [ ] Render README on github.com and confirm the new H3 sits cleanly between the manual-install details block and `## Upgrade`
- [ ] Source the aliases in a fresh shell and verify `ca --help` resolves to agents mode without picking up the `claude` alias's flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)