### PR TITLE
fix(transcript): render full session, drop session_started cutoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   dispatch-chatter-stripping the cutoff bought for early binds was
   deemed not worth the failure mode. `RenderTranscript`'s `cutoff`
   parameter is gone from the harness interface.
+  ([#65](https://github.com/Facets-cloud/flow/pull/65) by
+  [@rr0hit](https://github.com/rr0hit))
 
 ## [0.1.0-alpha.16] — 2026-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [0.1.0-alpha.17] — 2026-05-29
+
+### Fixed
+
+- **`flow transcript` elided pre-bind work on retrospective `--here`
+  binds, silently starving the close-out KB sweep.** `flow transcript`
+  filtered out every jsonl entry before `tasks.session_started`, on the
+  assumption that `session_started` ≈ the conversation's start. That
+  holds for `flow do` spawns (the UUID is pre-allocated, so the first
+  message lands just after `session_started`) but breaks for a
+  retrospective `flow do --here` bind: there `session_started` is
+  stamped at *bind time*, after all the real work. The cutoff then
+  dropped the entire conversation, so the `flow done` close-out sweep
+  mined an empty tail and wrote nothing to the KB — silent knowledge
+  loss. Hit live on 2026-05-29 (task `cp-mgmt-skill`), whose whole
+  session had to be hand-distilled into the KB. The fix removes the
+  time cutoff entirely: `flow transcript` (and therefore the sweep)
+  now always renders the full session. An over-inclusive sweep was
+  already the documented preference over silent data loss; the
+  dispatch-chatter-stripping the cutoff bought for early binds was
+  deemed not worth the failure mode. `RenderTranscript`'s `cutoff`
+  parameter is gone from the harness interface.
+
 ## [0.1.0-alpha.16] — 2026-05-28
 
 ### Fixed
@@ -288,7 +311,9 @@ Initial public release.
   against `macos-latest` and `ubuntu-latest`.
 - **License.** MIT.
 
-[Unreleased]: https://github.com/Facets-cloud/flow/compare/v0.1.0-alpha.15...HEAD
+[Unreleased]: https://github.com/Facets-cloud/flow/compare/v0.1.0-alpha.17...HEAD
+[0.1.0-alpha.17]: https://github.com/Facets-cloud/flow/releases/tag/v0.1.0-alpha.17
+[0.1.0-alpha.16]: https://github.com/Facets-cloud/flow/releases/tag/v0.1.0-alpha.16
 [0.1.0-alpha.15]: https://github.com/Facets-cloud/flow/releases/tag/v0.1.0-alpha.15
 [0.1.0-alpha.14]: https://github.com/Facets-cloud/flow/releases/tag/v0.1.0-alpha.14
 [0.1.0-alpha.8]: https://github.com/Facets-cloud/flow/releases/tag/v0.1.0-alpha.8

--- a/internal/app/transcript.go
+++ b/internal/app/transcript.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 )
 
 // cmdTranscript implements `flow transcript <task-slug>`. It delegates
@@ -69,17 +68,6 @@ func cmdTranscript(args []string) int {
 		return 1
 	}
 
-	// Compute the cutoff from session_started so the transcript output
-	// is scoped to the task's own conversation, not pre-bind dispatch
-	// chatter that --here-bound tasks accumulate. NULL/unparseable
-	// session_started → zero cutoff → filter is a no-op.
-	var cutoff time.Time
-	if task.SessionStarted.Valid && task.SessionStarted.String != "" {
-		if ts, perr := time.Parse(time.RFC3339Nano, task.SessionStarted.String); perr == nil {
-			cutoff = ts
-		}
-	}
-
 	// Spawn cwd == work_dir is an invariant for any task with a
 	// session_id (enforced at bind time in cmdDo + cmdDoHere). So
 	// the transcript file lives under work_dir's encoded path.
@@ -92,7 +80,7 @@ func cmdTranscript(args []string) int {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
 	}
-	if err := h.RenderTranscript(task.WorkDir, task.SessionID.String, *compact, cutoff, os.Stdout); err != nil {
+	if err := h.RenderTranscript(task.WorkDir, task.SessionID.String, *compact, os.Stdout); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		fmt.Fprintf(os.Stderr,
 			"hint: flow assumed the harness was started at work_dir=%q. "+

--- a/internal/app/transcript_test.go
+++ b/internal/app/transcript_test.go
@@ -6,14 +6,15 @@ import (
 	"flow/internal/iterm"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 // Parser-level tests live in internal/harness/claude/transcript_test.go
-// (the claude jsonl format and the cutoff-filter behavior are owned
-// by the harness impl). The tests here exercise the cmdTranscript
-// wiring: ref resolution, the "no session" gate, the happy-path
-// dispatch into the harness.
+// (the claude jsonl format is owned by the harness impl). The tests
+// here exercise the cmdTranscript wiring: ref resolution, the "no
+// session" gate, the happy-path dispatch into the harness, and the
+// retrospective-bind full-render guarantee.
 
 func TestTranscriptCmdNoSession(t *testing.T) {
 	tmp := t.TempDir()
@@ -71,5 +72,59 @@ func TestTranscriptCmdWithSession(t *testing.T) {
 	rc := cmdTranscript([]string{"tx-test"})
 	if rc != 0 {
 		t.Errorf("transcript with session: rc=%d, want 0", rc)
+	}
+}
+
+// TestTranscriptRetrospectiveBindFullOutput pins the bug this task
+// fixes: a retrospective `flow do --here` bind stamps session_started
+// at BIND time, which lands after all the real work in the jsonl. The
+// transcript (and therefore the `flow done` close-out sweep) must still
+// show the whole conversation — not just entries after the bind.
+func TestTranscriptRetrospectiveBindFullOutput(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FLOW_ROOT", filepath.Join(tmp, "flow"))
+	t.Setenv("HOME", tmp)
+
+	oldOsa := iterm.Runner
+	iterm.Runner = func(args []string) error { return nil }
+	t.Cleanup(func() { iterm.Runner = oldOsa })
+
+	cmdInit(nil)
+
+	repo := filepath.Join(tmp, "code", "myrepo")
+	os.MkdirAll(repo, 0o755)
+	cmdAdd([]string{"task", "Retro Bind", "--slug", "retro", "--work-dir", repo})
+
+	dbPath, _ := flowDBPath()
+	db, _ := flowdb.OpenDB(dbPath)
+	defer db.Close()
+
+	sid := "deadbeef-1234-5678-9abc-def012345678"
+	// session_started is stamped LATE (bind time) — after all the work
+	// below. This is exactly the retrospective `--here` scenario.
+	bindTime := "2026-05-29T18:00:00+05:30"
+	db.Exec(`UPDATE tasks SET session_id=?, session_started=?, updated_at=? WHERE slug=?`,
+		sid, bindTime, bindTime, "retro")
+
+	encoded := claude.EncodeCwd(repo)
+	sessionDir := filepath.Join(tmp, ".claude", "projects", encoded)
+	os.MkdirAll(sessionDir, 0o755)
+	// All entries predate the bind time by hours — the real work.
+	jsonl := `{"type":"user","message":{"role":"user","content":"EARLY WORK before the bind"},"uuid":"u1","timestamp":"2026-05-29T09:00:00.000Z","sessionId":"` + sid + `"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"EARLY REPLY before the bind"}]},"uuid":"a1","timestamp":"2026-05-29T09:01:00.000Z","sessionId":"` + sid + `"}
+`
+	os.WriteFile(filepath.Join(sessionDir, sid+".jsonl"), []byte(jsonl), 0o644)
+
+	out := captureStdout(t, func() {
+		if rc := cmdTranscript([]string{"retro"}); rc != 0 {
+			t.Errorf("transcript rc=%d, want 0", rc)
+		}
+	})
+
+	if !strings.Contains(out, "EARLY WORK before the bind") {
+		t.Errorf("pre-bind work elided from transcript on retrospective bind:\n%s", out)
+	}
+	if !strings.Contains(out, "EARLY REPLY before the bind") {
+		t.Errorf("pre-bind assistant reply elided from transcript:\n%s", out)
 	}
 }

--- a/internal/harness/claude/transcript.go
+++ b/internal/harness/claude/transcript.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 )
 
 // RenderTranscript opens the session jsonl at the claude convention
@@ -20,7 +19,7 @@ import (
 // tasks.session_cwd; callers in app/ fall back to task.work_dir for
 // legacy NULL rows). Claude keys its transcript path on its startup
 // cwd; the two can diverge for `flow do --here` binds.
-func (c *claude) RenderTranscript(cwd, sessionID string, compact bool, cutoff time.Time, w io.Writer) error {
+func (c *claude) RenderTranscript(cwd, sessionID string, compact bool, w io.Writer) error {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return fmt.Errorf("no home dir: %w", err)
@@ -39,7 +38,7 @@ func (c *claude) RenderTranscript(cwd, sessionID string, compact bool, cutoff ti
 		return fmt.Errorf("open claude transcript %s: %w", p, err)
 	}
 	defer f.Close()
-	return RenderJSONL(f, compact, cutoff, w)
+	return RenderJSONL(f, compact, w)
 }
 
 // RenderJSONL renders a claude session jsonl byte-stream to w. Exposed
@@ -47,12 +46,14 @@ func (c *claude) RenderTranscript(cwd, sessionID string, compact bool, cutoff ti
 // decoder against fixture data in tempdir without going through path
 // resolution.
 //
-// cutoff scopes the output to entries with timestamp >= cutoff. Pass
-// the zero time.Time to disable the filter. Entries with a missing or
-// unparseable `timestamp` field are kept regardless of cutoff —
-// silent data loss in a KB-distill input is worse than an over-
-// inclusive sweep.
-func RenderJSONL(r io.Reader, compact bool, cutoff time.Time, w io.Writer) error {
+// The entire stream is rendered. There is no time cutoff: an earlier
+// design dropped entries before tasks.session_started to strip pre-bind
+// dispatch chatter, but on a retrospective `flow do --here` bind
+// session_started lands AFTER the real work, so the cutoff silently
+// elided exactly what the close-out KB sweep needed to read. Rendering
+// everything is the safer contract — an over-inclusive sweep beats
+// silent data loss.
+func RenderJSONL(r io.Reader, compact bool, w io.Writer) error {
 	scanner := bufio.NewScanner(r)
 	// Session jsonl lines can be very long (tool results with file contents).
 	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
@@ -67,18 +68,6 @@ func RenderJSONL(r io.Reader, compact bool, cutoff time.Time, w io.Writer) error
 		var rec jsonlRecord
 		if err := json.Unmarshal(line, &rec); err != nil {
 			continue // skip malformed lines
-		}
-
-		// Filter: drop entries strictly before the cutoff. Defensive
-		// on parse failure / missing field — keep the entry rather
-		// than silently dropping it. RFC3339Nano accepts both the
-		// jsonl's fractional-second UTC form and the DB's offset
-		// form without fractional, so we use it as a single parser
-		// for both sources.
-		if !cutoff.IsZero() && rec.Timestamp != "" {
-			if ts, perr := time.Parse(time.RFC3339Nano, rec.Timestamp); perr == nil && ts.Before(cutoff) {
-				continue
-			}
 		}
 
 		switch rec.Type {

--- a/internal/harness/claude/transcript_test.go
+++ b/internal/harness/claude/transcript_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"strings"
 	"testing"
-	"time"
 )
 
 // sampleSessionJSONL is a minimal but representative session jsonl
@@ -24,17 +23,17 @@ const sampleSessionJSONL = `{"type":"permission-mode","permissionMode":"default"
 `
 
 // renderToString is a tiny test helper around RenderJSONL.
-func renderToString(t *testing.T, raw string, compact bool, cutoff time.Time) string {
+func renderToString(t *testing.T, raw string, compact bool) string {
 	t.Helper()
 	var buf bytes.Buffer
-	if err := RenderJSONL(strings.NewReader(raw), compact, cutoff, &buf); err != nil {
+	if err := RenderJSONL(strings.NewReader(raw), compact, &buf); err != nil {
 		t.Fatalf("RenderJSONL: %v", err)
 	}
 	return buf.String()
 }
 
 func TestRender(t *testing.T) {
-	out := renderToString(t, sampleSessionJSONL, false, time.Time{})
+	out := renderToString(t, sampleSessionJSONL, false)
 
 	checks := []struct {
 		label    string
@@ -71,7 +70,7 @@ func TestRender(t *testing.T) {
 }
 
 func TestRenderCompact(t *testing.T) {
-	out := renderToString(t, sampleSessionJSONL, true, time.Time{})
+	out := renderToString(t, sampleSessionJSONL, true)
 
 	if !strings.Contains(out, "Hello, can you help me?") {
 		t.Error("compact missing user message")
@@ -91,94 +90,40 @@ func TestRenderCompact(t *testing.T) {
 	}
 }
 
-// preBindJSONL has two user messages: one before session_started
-// (pre-bind chatter from the dispatch session) and one after. The
-// cutoff filter should drop the pre-bind entry but keep the post-bind
-// one.
-const preBindJSONL = `{"type":"user","message":{"role":"user","content":"PRE-BIND chatter"},"uuid":"u0","timestamp":"2026-05-14T10:00:00.000Z","sessionId":"sid"}
+// retroBindJSONL models a retrospective `flow do --here` bind: the
+// whole conversation predates the bind, and there is no later "post-
+// bind" turn. The renderer must surface every entry — this is the
+// exact case the old session_started cutoff broke (it stamped the bind
+// time after all of these and elided them).
+const retroBindJSONL = `{"type":"user","message":{"role":"user","content":"PRE-BIND chatter"},"uuid":"u0","timestamp":"2026-05-14T10:00:00.000Z","sessionId":"sid"}
 {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"PRE-BIND reply"}]},"uuid":"a0","timestamp":"2026-05-14T10:00:01.000Z","sessionId":"sid"}
-{"type":"user","message":{"role":"user","content":"POST-BIND request"},"uuid":"u1","timestamp":"2026-05-14T11:00:00.000Z","sessionId":"sid"}
-{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"POST-BIND reply"}]},"uuid":"a1","timestamp":"2026-05-14T11:00:01.000Z","sessionId":"sid"}
+{"type":"user","message":{"role":"user","content":"MORE work, still before bind"},"uuid":"u1","timestamp":"2026-05-14T11:00:00.000Z","sessionId":"sid"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"MORE reply"}]},"uuid":"a1","timestamp":"2026-05-14T11:00:01.000Z","sessionId":"sid"}
 `
 
-// TestFiltersByCutoff pins the --here close-out sweep contract:
-// entries with timestamp < cutoff are dropped, entries at-or-after
-// are kept.
-func TestFiltersByCutoff(t *testing.T) {
-	cutoff, _ := time.Parse(time.RFC3339Nano, "2026-05-14T10:30:00.000Z")
-	out := renderToString(t, preBindJSONL, false, cutoff)
+// TestRendersWholeTranscript pins the no-cutoff contract: every
+// user/assistant entry is rendered regardless of its timestamp, so a
+// retrospective `--here` bind (session_started after all of these)
+// still feeds the full conversation to the close-out sweep.
+func TestRendersWholeTranscript(t *testing.T) {
+	out := renderToString(t, retroBindJSONL, false)
 
-	if strings.Contains(out, "PRE-BIND") {
-		t.Errorf("pre-bind content leaked through filter:\n%s", out)
-	}
-	if !strings.Contains(out, "POST-BIND request") {
-		t.Errorf("post-bind user message dropped:\n%s", out)
-	}
-	if !strings.Contains(out, "POST-BIND reply") {
-		t.Errorf("post-bind assistant message dropped:\n%s", out)
+	for _, want := range []string{"PRE-BIND chatter", "PRE-BIND reply", "MORE work, still before bind", "MORE reply"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("entry dropped from full-render output; missing %q:\n%s", want, out)
+		}
 	}
 }
 
-// TestZeroCutoffNoFilter pins the no-op case: when cutoff is the
-// zero time.Time, the filter is bypassed and all entries pass.
-func TestZeroCutoffNoFilter(t *testing.T) {
-	out := renderToString(t, preBindJSONL, false, time.Time{})
-
-	if !strings.Contains(out, "PRE-BIND chatter") {
-		t.Errorf("zero cutoff should pass everything; pre-bind missing:\n%s", out)
-	}
-	if !strings.Contains(out, "POST-BIND request") {
-		t.Errorf("zero cutoff should pass everything; post-bind missing:\n%s", out)
-	}
-}
-
-// TestKeepsEntriesWithMissingTimestamp pins the defensive behavior:
-// an entry without a `timestamp` field is KEPT regardless of cutoff.
-// Don't silently lose data.
-func TestKeepsEntriesWithMissingTimestamp(t *testing.T) {
+// TestRendersEntriesWithoutTimestamp pins that entries lacking a
+// `timestamp` field still render — the renderer never inspects
+// timestamps, so a missing one is a non-event.
+func TestRendersEntriesWithoutTimestamp(t *testing.T) {
 	const j = `{"type":"user","message":{"role":"user","content":"NO TIMESTAMP entry"},"uuid":"u0","sessionId":"sid"}
-{"type":"user","message":{"role":"user","content":"BEFORE cutoff"},"uuid":"u1","timestamp":"2026-05-14T09:00:00.000Z","sessionId":"sid"}
-{"type":"user","message":{"role":"user","content":"AFTER cutoff"},"uuid":"u2","timestamp":"2026-05-14T11:00:00.000Z","sessionId":"sid"}
 `
-	cutoff, _ := time.Parse(time.RFC3339Nano, "2026-05-14T10:00:00.000Z")
-	out := renderToString(t, j, false, cutoff)
+	out := renderToString(t, j, false)
 
 	if !strings.Contains(out, "NO TIMESTAMP entry") {
-		t.Errorf("entry without timestamp dropped (should be kept defensively):\n%s", out)
-	}
-	if strings.Contains(out, "BEFORE cutoff") {
-		t.Errorf("entry with timestamp < cutoff was kept:\n%s", out)
-	}
-	if !strings.Contains(out, "AFTER cutoff") {
-		t.Errorf("entry with timestamp >= cutoff was dropped:\n%s", out)
-	}
-}
-
-// TestKeepsEntriesWithUnparseableTimestamp pins the second defensive
-// case: an entry whose `timestamp` field is present but not a valid
-// RFC3339[Nano] is KEPT. Better over-inclusive than silently lossy.
-func TestKeepsEntriesWithUnparseableTimestamp(t *testing.T) {
-	const j = `{"type":"user","message":{"role":"user","content":"BAD TIMESTAMP entry"},"uuid":"u0","timestamp":"not-a-date","sessionId":"sid"}
-`
-	cutoff, _ := time.Parse(time.RFC3339Nano, "2026-05-14T10:00:00.000Z")
-	out := renderToString(t, j, false, cutoff)
-
-	if !strings.Contains(out, "BAD TIMESTAMP entry") {
-		t.Errorf("entry with unparseable timestamp dropped (should be kept defensively):\n%s", out)
-	}
-}
-
-// TestRegularSpawnPassthrough pins the no-op property for non-`--here`
-// tasks: their session_started ≈ first jsonl message (the binary pre-
-// allocates the UUID before spawning, so first message lands strictly
-// after session_started). The filter should pass all entries through.
-func TestRegularSpawnPassthrough(t *testing.T) {
-	cutoff, _ := time.Parse(time.RFC3339Nano, "2026-04-12T09:59:00.000Z")
-	out := renderToString(t, sampleSessionJSONL, false, cutoff)
-
-	for _, want := range []string{"Hello, can you help me?", "Sure, let me check.", "Done!"} {
-		if !strings.Contains(out, want) {
-			t.Errorf("regular-spawn filter dropped %q; output:\n%s", want, out)
-		}
+		t.Errorf("entry without timestamp dropped:\n%s", out)
 	}
 }

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -25,7 +25,6 @@ package harness
 
 import (
 	"io"
-	"time"
 )
 
 // Name is the short identifier persisted on tasks.harness and used to
@@ -147,10 +146,13 @@ type Harness interface {
 	// cwd is the directory the harness session was started in (NOT
 	// necessarily the task's work_dir — see tasks.session_cwd; for
 	// legacy NULL rows callers fall back to work_dir). compact omits
-	// tool results and thinking blocks. cutoff filters entries
-	// strictly before the given time (use zero to disable). Returns
-	// an error if the transcript can't be found or decoded.
-	RenderTranscript(cwd, sessionID string, compact bool, cutoff time.Time, w io.Writer) error
+	// tool results and thinking blocks. The whole transcript is
+	// rendered — there is no time cutoff. (An earlier design scoped
+	// output to entries after tasks.session_started, but that elided
+	// all real work on retrospective `flow do --here` binds, where
+	// session_started is stamped at bind time AFTER the conversation.)
+	// Returns an error if the transcript can't be found or decoded.
+	RenderTranscript(cwd, sessionID string, compact bool, w io.Writer) error
 
 	// Skill / rules file -----------------------------------------------
 


### PR DESCRIPTION
## Problem

`flow transcript` filtered out every session-jsonl entry before `tasks.session_started`, on the assumption that `session_started` ≈ when the conversation started. That holds for `flow do` spawns (the UUID is pre-allocated, so the first message lands just after `session_started`), but breaks for a **retrospective `flow do --here` bind**: there `session_started` is stamped at *bind time*, after all the real work. The cutoff then dropped the entire conversation, so the `flow done` close-out sweep — which reads `flow transcript` — mined an empty tail and wrote nothing to the KB.

Silent knowledge loss. Hit live on 2026-05-29 with task `cp-mgmt-skill`, whose whole session had to be hand-distilled into `kb/{business,processes}.md`.

## Fix

Remove the time cutoff entirely. `flow transcript` (and therefore the close-out sweep) now always render the full session. An over-inclusive sweep was already the documented preference over silent data loss (`RenderJSONL`'s old doc comment), and the dispatch-chatter stripping the cutoff bought for early binds was deemed not worth the failure mode. `RenderTranscript`'s `cutoff` parameter is gone from the `harness.Harness` interface.

`session_started` stays as bind-time metadata (still shown in `flow show task`); it's just no longer used as a transcript boundary.

## Tests

- **app-level regression** (`TestTranscriptRetrospectiveBindFullOutput`): a task whose `session_started` is stamped *after* its jsonl entries still yields a full transcript through `cmdTranscript`. Verified red against the pre-fix code.
- Replaced the cutoff parser tests (`TestFiltersByCutoff`, `TestZeroCutoffNoFilter`, …) with a whole-transcript render contract (`TestRendersWholeTranscript`, `TestRendersEntriesWithoutTimestamp`).

`go vet ./...` clean, `go test ./...` green.

## Changelog

Adds the `[0.1.0-alpha.17]` section and repairs the footer link-reference chain (the `[Unreleased]` compare base was still stale at alpha.15 and alpha.16 had no link ref).

🤖 Generated with [Claude Code](https://claude.com/claude-code)