### PR TITLE
feat: autonomous owner harness — self-prompting controllers over flow

### DIFF
--- a/docs/superpowers/specs/2026-06-08-autonomous-owner-harness-design.md
+++ b/docs/superpowers/specs/2026-06-08-autonomous-owner-harness-design.md
@@ -1,0 +1,468 @@
+# Autonomous Owner Harness — Design
+
+**Status:** Design (not yet build)
+**Date:** 2026-06-08
+**Task:** `auto-loop-harness` · Project: `flow`
+**Author:** design brainstorm (Anshul + Claude)
+**Build approach:** MVP-first — see §10 for the v0 slice (no Slack, no
+notifications, no stats, no smart bootstrap).
+
+---
+
+## 1. Problem
+
+flow today can start work autonomously but cannot *keep* a responsibility alive
+over time:
+
+- `flow do --auto` runs a task **once**, headlessly, and self-`flow done`s. One
+  shot, then it stops.
+- **Playbooks** are reusable procedures, but each run is manually (or
+  externally, via launchd) triggered and is itself one-shot.
+
+The gap: nothing **takes durable responsibility for an outcome** — re-waking,
+re-evaluating the world, re-acting, creating follow-on work, asking the human
+when it must, and continuing until the outcome holds. Today a "responsibility"
+lives only in the user's head and in scattered task rows.
+
+The thesis (borrowed, and it fits exactly):
+
+> "You're not supposed to prompt Claude. You're supposed to build a system that
+> prompts itself." — Daisy Hollman (Anthropic)
+
+We want flow to host **self-prompting systems** that own an outcome: *create
+tasks, trackers, callbacks, and playbooks to accomplish a goal — except the
+owner is not a single Claude session.*
+
+### Motivating use cases (the requirements, in the user's words)
+
+1. **"Make sure all PRs raised have CI green."** A standing invariant over a
+   *set* (every open PR in a repo). Membership changes over time; never "done."
+2. **"Raise PR, answer/fix the PR review by humans/CodeRabbit, get it approved &
+   merged, deploy and monitor (via Facets/other tools) the fix, and file new
+   bugs when a new exception is encountered."** A multi-step responsibility that
+   spawns new work (a discovered exception → a new bug → a new fix).
+
+These are the two species the design must express with one mechanism.
+
+---
+
+## 2. Core concept: the `owner`
+
+An **owner** is a durable, named, repo/goal-scoped **self-prompting
+controller** — *not* a long-running Claude chat. It is **state + a clock**:
+
+- **state** — a charter (its operating manual) and a ledger (what it's doing and
+  has done)
+- **a clock** — a self-paced *callback* that re-invokes the owner on a time
+  interval
+
+Each time the callback fires, the owner runs one **tick**: a *fresh* headless
+Claude run that reads its durable state, observes the world, acts, schedules its
+next wake, and exits. The owner persists across ticks; the sessions are
+disposable workers it summons. This is precisely "a system that prompts itself,"
+and it is explicitly **multi-session**.
+
+> **Naming:** chosen as `owner` for the simplest reading of "the thing that takes
+> responsibility." (`agent` was rejected as overloaded by Claude
+> subagents / the `agent-factory` repo.)
+
+### What an owner owns
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ OWNER  "agent-factory-maintainer"                                      │
+│   owns: maintenance + bug-fixes for Facets-cloud/agent-factory         │
+│   charter: how to build/test/deploy/health-check, approval gates,      │
+│            escalation rules, notify channel                            │
+│   ledger: in-flight work units + their stage + running stats           │
+│        │ each tick (every N): observe → act → set next wake → exit      │
+│        ▼                                                                │
+│   work units (flow tasks tagged owner:<slug>) ── "trackers"           │
+│     #482 (in review)   #485 (CI red)   #491 (deploying)                │
+│        │ a tick can spawn new units: exception found → flow add task    │
+│        ▼                                                                │
+│   open questions parked on the human (question-tagged tasks) → Slack ping│
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### v1 simplification — single loop per owner
+
+The **owner is the only looping thing.** Its single self-paced tick advances
+*all* of its in-flight work units each wake. Work units are tracked as task rows
+("trackers") but do **not** independently self-wake. No loops-within-loops.
+
+Rationale: avoids nested-scheduler complexity, one wake-source per owner, trivial
+to reason about. Per-unit independent loops (real parallelism across many
+in-flight units) are a deliberate later extension, not v1.
+
+### How the two use cases map onto one owner
+
+```
+"all PRs green"  (standing invariant)
+  tick: gh pr list --state open
+        for each PR with red CI → ensure a work-unit task exists & advance it
+        set next wake (+30m)
+  predicate is ~never permanently true (new PRs appear) → behaves standing
+
+"raise→review→merge→deploy→monitor→file bug"  (multi-step responsibility)
+  tick 1: raise PR        → park on CodeRabbit/CI       → waiting_on, sleep
+  tick 2: answer review   → re-request review           → sleep
+  tick 3: CI green+approved→ (needs human approve?) ask  → park, Slack, sleep
+  tick 4: merge → deploy  → park on deploy               → sleep
+  tick 5: monitor (facets)→ exception found → flow add task "fix exc Y" (new unit)
+        outcome held (deployed + stable N hrs) → close that unit
+```
+
+Both are the *same* owner mechanism with different charters. (This is the
+earlier "termination is just a predicate" unification: a bounded goal is the
+special case where the predicate eventually stays true.)
+
+---
+
+## 3. Stateful systems
+
+The heart of the new layer is **what persists between ticks**. Six systems:
+
+| # | System | Stored as | Purpose |
+|---|---|---|---|
+| 1 | **Owner registry** | `owners` table | identity, scope, schedule, next callback, lifecycle |
+| 2 | **Charter** | `owners/<slug>/charter.md` (+ structured fields) | operating knowledge: build/test/deploy/health-check, approval gates, escalation rules, notify channel. **Grows** as runtime answers arrive |
+| 3 | **Ledger** | **task rows tagged `owner:<slug>`** + a summary in `ledger.md` | in-flight work units, their stage, and the running stats the user wants to see |
+| 4 | **Human questions** | **question-tasks** — regular flow tasks tagged `question` + `owner:<slug>`, assigned to you, *not* run with `--auto` | open questions parked on the human, surfaced in your normal `flow list tasks` queue; answered in-context on the task |
+| 5 | **Callback / scheduler** | `owners.next_wake_at` + a runner | the time-based trigger that fires the next tick |
+| 6 | **Tick log** | `owners/<slug>/ticks/<ts>.log` files | append-only audit of what each tick observed / decided / did |
+
+### On-disk layout (mirrors tasks/projects)
+
+```
+~/.flow/owners/<slug>/
+  charter.md          # operating manual (grows over time)
+  ledger.md           # human-readable rollup of in-flight work + stats
+  updates/            # progress notes (same convention as tasks/projects)
+  ticks/<ts>.log      # per-tick audit log (mirrors tasks/<slug>/auto-runs/)
+```
+
+### Schema addition (SQLite, additive + nullable — same migration discipline as PR #58)
+
+The **only** new table is `owners`. Owner↔task linkage and the question marker
+reuse flow's existing **tag** system, so there are **no new task columns and no
+new `kind` value**.
+
+```
+owners (
+  slug TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  work_dir TEXT NOT NULL,
+  project_slug TEXT,                 -- nullable FK to projects
+  status TEXT NOT NULL,              -- active | paused | retired
+  every TEXT NOT NULL,               -- interval, e.g. "30m" (time-based v1)
+  next_wake_at TEXT,                 -- RFC3339; the callback
+  last_tick_at TEXT,
+  last_tick_status TEXT,             -- ok | escalated | error
+  harness TEXT,                      -- which harness runs its ticks
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+)
+
+-- No new task columns, no new kind. Linkage + marking reuse the EXISTING tag
+-- system (free-form key:value tags, already in flow — see skill §4.16a):
+--   owner:<slug>   tag → links a task (work unit OR question) to its owner
+--   question       tag → marks a human-answered task (never run with --auto)
+```
+
+**Questions need no new table and no new column** — they are tasks tagged
+`question` + `owner:<slug>` (system #4 above). The owner creates the tagged task,
+the human answers it in-context and marks it done, and the owner reads the answer
+back on its next tick. (See §5.2.) Caveat: tags are a string convention, not an
+FK — see §11 for the dangling-tag / behavioral-gate trade-off.
+
+Tick history can stay as log files (system #6) rather than a table, mirroring how
+`--auto` already logs to `tasks/<slug>/auto-runs/`.
+
+---
+
+## 4. The tick — what each callback runs
+
+A tick **reuses the existing `--auto` machinery**: a detached, headless Claude
+run launched via the harness `AutoRunArgv` shape. Unlike `--auto`, the tick is a
+*fresh* session each time (the "not a single session" requirement) — its memory
+is the durable ledger, not a resumed transcript.
+
+The tick prompt (sketch):
+
+```
+You are owner <slug>. Your charter is owners/<slug>/charter.md; your ledger is
+owners/<slug>/ledger.md; your work units are the tasks tagged owner:<slug>.
+
+1. Read charter + ledger + owned task rows.
+2. Observe the world per the charter (gh PRs/CI, praxis/facets health, etc.).
+3. Decide & act:
+     - advance or create work-unit tasks (flow add task --owner <slug>)
+     - file bugs for new exceptions (= new work units)
+     - reply to reviews, request human approval where the charter requires it
+4. If blocked on a human decision/fact → enqueue an owner_question, park that
+   work unit (waiting_on), notify via the charter's channel (Slack).
+5. Update ledger + stats. Set next_wake_at. EXIT.
+```
+
+The hard-blocker / persist-until-closeable discipline from `--auto` carries over:
+exhaust avenues before escalating; never spin uselessly; on a true blocker,
+enqueue a question and sleep rather than loop.
+
+---
+
+## 5. Human interaction — how the owner asks questions
+
+The owner is headless, so "ask the user" can never be a blocking prompt. Two
+channels:
+
+### 5.1 Setup-time — a guided interview (human present)
+
+`flow add owner` runs an intake like flow's task-intake, but **operational**:
+where's the repo, how to build/test, how to deploy, how to check health, what
+counts as "broken," what must the human approve vs. what can it just do, where to
+notify. Output = the **charter**.
+
+Critically, **bootstrap from what flow already knows; ask only the gaps**:
+
+- repo path → workdir registry + `gh`
+- build/test/conventions → the repo's `CLAUDE.md`
+- deploy timing, CI checks, branch protection → already in the user's **KB**
+  (`processes.md` holds these for real repos today)
+- health checks / deployment status → praxis/facets tooling the user already uses
+
+Health-check command and approval/escalation rules are usually the only genuine
+gaps, keeping setup short.
+
+### 5.2 Runtime — questions are *tasks* for the human
+
+A runtime question is **not** a new queue and is **not** an autonomous run. The
+owner simply **creates a normal flow task for the human** — tagged `question` +
+`owner:<slug>`, assigned to you, with the full context + the question in its
+brief — and parks the dependent work unit on it. It is explicitly **not** run
+with `--auto`: it's a human task that surfaces in your ordinary `flow list tasks`
+queue.
+
+```
+  tick: hits unknown ──► flow add task --tag question --tag owner:<slug> --assignee you
+                                  │  + park the work unit: waiting_on = that task
+                                  ▼
+                         MVP: NO notification — it just appears in your
+                         `flow list tasks` queue. (Slack ping is a later add.)
+                                  │
+   ...you answer in-context, on your own time:
+        - read it in `flow show task`, OR `flow do` it for a real back-and-forth
+        - capture the answer on the task (an update / the session), mark it done
+                                  ▼
+  next tick: owner sees its question-task is done ──► reads the answer
+                         ├──► applies it, unparks the work unit
+                         └──► PERSISTS it into the charter (never asks again)
+```
+
+Why this beats a bespoke queue: it reuses tasks wholesale, the answer is captured
+**in the context of that task** (durable, re-readable), and questions land in the
+*same* inbox you already triage — no separate surface to check. `waiting_on`
+already models "parked on you," and the owner just watches its own
+`question`-tagged tasks for completion. (In the MVP you simply see the question in
+your task queue; a Slack ping is a later add — see §10.)
+
+**Consequence — the owner gets quieter over time.** Cold-start it asks a lot;
+every answer becomes durable charter knowledge, so by week two it barely asks.
+The "setup needs lots of answers" concern is front-loaded, partly pre-filled, and
+self-extinguishing.
+
+---
+
+## 6. The accountability surface
+
+This is the user-facing payoff: *an owner is responsible / here's what it owns /
+here are its working stats.* `flow owner show <slug>`:
+
+```
+  OWNER  agent-factory-maintainer     owns: maintenance+bugfix for Facets-cloud/agent-factory
+  ──────────────────────────────────────────────────────────────────────
+  in flight   3 fixes:  #482 (review)  #485 (CI red)  #491 (deploying)
+  this week   7 bugs filed · 5 PRs merged · 4 deploys verified
+  parked on   you: 1 PR awaiting your approval (#482)
+  escalated   1: cannot reproduce exception in #488 — needs your call
+  next tick   in 22m   ·   last acted 8m ago   ·   health: ok
+```
+
+**MVP note:** v0 renders this as a plain *live list* — the owner's `owner:<slug>`
+tasks + its open `question` tasks + next tick — *without* the computed weekly
+stats (`7 bugs filed · 5 PRs merged …`). Those counts are a "Next" nicety (§10),
+not part of the MVP.
+
+---
+
+## 7. New flow commands
+
+```
+Create + setup
+  flow add owner "<name>" --work-dir <p> [--project <s>] [--slug <s>] [--every <dur>]
+       → runs the setup interview (charter authoring), bootstrapping from
+         CLAUDE.md + KB + workdir registry + gh; asks only the gaps
+
+Lifecycle
+  flow owner start  <slug>     begin ticking (sets next_wake_at = now)
+  flow owner pause  <slug>     stop ticking, keep all state
+  flow owner retire <slug>     archive (state preserved, like task archive)
+  flow owner edit   <slug>     edit charter.md
+
+Observe (accountability surface)
+  flow owner list  (or flow list owners)   all owners: status, owns, next tick
+  flow owner show  <slug>                   identity + owns + stats + parked + escalations + next tick
+  flow owner log   <slug>                   recent tick logs / activity
+
+Human Q&A (async) — questions are tagged tasks; reuses existing commands
+  flow owner questions [<slug>]   convenience filter = flow list tasks --tag owner:<slug> --tag question
+  (to answer: just answer the question-task — add a note or `flow do` it, then mark it done;
+   the owner reads the answer on its next tick. No special 'answer' command, no new queue.)
+
+Internal (not user-facing)
+  flow __owner-tick <slug>     the detached tick supervisor (≈ flow __auto-exec)
+  flow owner tick-due          scheduler entry: scan owners, spawn due ticks
+```
+
+Work-unit linkage: spawned tasks are tagged `owner:<slug>` (the tick passes
+`--tag owner:<slug>`), so the ledger is just `flow list tasks --tag owner:<slug>`.
+An optional `--owner <slug>` sugar flag on `flow add task` could expand to that
+tag, but no new column is required.
+
+---
+
+## 8. The trigger substrate (time-based, v1) — and the architecture decision
+
+Each owner has an interval (`--every 30m`). Something durable must, at
+`next_wake_at`, re-spawn the tick after the previous one exits. **A live process
+is never held across the interval** — every tick exits and hands a future
+wake-time to the substrate. Three candidate substrates, which also decide the
+in-flow-vs-outside-flow boundary:
+
+| Substrate | Boundary | Mechanism | Trade-off |
+|---|---|---|---|
+| **launchd tick-scanner** *(recommended v1)* | mostly in-flow, reuses external OS timer | one launchd timer (or 1-min scanner) calls `flow owner tick-due`; it finds owners with `next_wake_at <= now` and detaches `flow __owner-tick <slug>` per the `--auto` pattern | reuses proven scheduled-playbook infra; survives reboot; **no new daemon**. macOS-only; ~1-min granularity |
+| **flow daemon (`flow ownerd`)** | fully in-flow | a long-running flow process holds timers, spawns ticks, is event-ready for the future | cross-platform & self-contained, but a real daemon to install/supervise — heaviest new surface; *it* still needs launchd to survive reboot |
+| **self-rescheduling one-shot** | in-between | each tick schedules exactly one future wake of itself before exiting | no central component, but rests on fragile primitives (`at`/detached `sleep`) that don't survive reboot well |
+
+**Recommendation:** launchd tick-scanner for v1 — lowest new surface, reboot-safe,
+reuses what scheduled playbooks already do. Revisit a daemon only if/when
+event-based triggers (CI webhooks, etc.) are added (explicitly out of scope for
+v1, where triggers are time-based only, like `/loop`).
+
+### Approaches weighed (the in-flow vs outside-flow decision)
+
+- **A — in-flow native `owner` primitive (RECOMMENDED).** flow grows the `owner`
+  entity + `flow owner *` commands, reusing tasks/playbooks/`--auto`/sessions/
+  `waiting_on`/Slack/launchd. A local, single-binary, laptop-native
+  responsibility layer.
+  *Pros:* maximal reuse, one tool, one DB, owner state lives next to the work it
+  drives, smallest mental model. *Cons:* flow grows a meaningfully new surface
+  (a scheduler concept and a long-lived entity) it didn't have before.
+
+- **B — outside-flow supervisor layer.** A separate orchestrator owns
+  charters/ledgers/scheduling and drives flow purely as an execution backend
+  (`flow add task` + `flow do --auto`).
+  *Pros:* keeps flow a clean execution substrate; the "responsibility brain"
+  evolves independently. *Cons:* two tools, two stores, duplicated identity/state,
+  and the ledger↔task linkage spans a process boundary; loses the reuse that
+  makes A cheap.
+
+- **C — standalone tool.** A new binary that reimplements task/session
+  management for owners.
+  *Cons:* throws away flow's entire execution substrate; rejected.
+
+**Decision: A (in-flow native `owner`).** Every capability the owner needs
+already exists in flow except the owner entity itself, its callback/scheduler,
+and the question queue — so the cheapest, most coherent home is inside flow. B is
+the fallback if the owner layer later needs to outgrow a personal CLI.
+
+---
+
+## 9. Reused vs. genuinely new
+
+| Reused as-is | New |
+|---|---|
+| tasks + the **tag system** (= trackers/work units **and** human questions, via `owner:<slug>` + `question` tags), `waiting_on` (= parked-on-you), `assignee`, playbooks (= reusable pipelines), `flow do --auto` machinery (= the tick), sessions, harness abstraction, Slack (= optional notify), KB + CLAUDE.md (= charter bootstrap), launchd (= scheduler), the additive-nullable migration discipline | `owners` table + on-disk dir (**the only schema change**), charter, ledger/stats rollup, the `owner:<slug>` / `question` tag conventions, the `flow owner *` commands, the tick prompt, `flow __owner-tick` + `flow owner tick-due` |
+
+---
+
+## 10. Scope & build order — MVP first
+
+Build the thinnest end-to-end loop first; layer niceties only after it works.
+
+### MVP (v0) — the thinnest slice that takes responsibility
+
+The smallest thing that wakes itself, acts, and asks the human when stuck —
+**no Slack, no notifications, no smart bootstrap, no stats:**
+
+- `owners` table + `owners/<slug>/charter.md` (free-form, **authored by hand**).
+- `flow add owner "<name>" --work-dir <p> --every <dur>`, `flow owner start|pause`,
+  and `flow owner show` (a **live view**: charter + its `owner:<slug>` tasks +
+  open `question` tasks + next tick — *no* stats rollup).
+- The tick: `flow __owner-tick <slug>` — a fresh headless run (reuses `--auto`)
+  that reads the charter + its tagged tasks, acts (create/advance tasks tagged
+  `owner:<slug>`), sets `next_wake_at`, exits. Single loop per owner.
+- Scheduler: launchd tick-scanner → `flow owner tick-due`.
+- Questions: the tick creates a task tagged `question` + `owner:<slug>`, assigned
+  to you, and parks the work unit (`waiting_on`). **No notification of any kind** —
+  you find it in your normal `flow list tasks` queue (and in `flow owner show`),
+  answer it in-context, mark it done; the owner reads it on its next tick.
+
+That is a complete responsibility loop with zero new surfaces beyond the `owners`
+table, the tick, and the scheduler.
+
+### Next (only after the MVP proves out)
+
+- **Notifications** — a Slack ping when a question is created (Slack is already
+  wired); later terminal/push. *(Explicitly NOT in the MVP.)*
+- **Gaps-only setup bootstrap** — read CLAUDE.md + KB + workdir registry + `gh`
+  so setup asks only what's missing (MVP: hand-write the charter).
+- **Stats / generated `ledger.md`** — the weekly rollup shown in the §6 mock.
+- **Lifecycle niceties** — `flow owner retire` (archive), `flow owner edit`,
+  `flow owner log`, `flow owner questions` sugar.
+
+### Later / out of scope
+
+- Event-based triggers (CI webhooks, PR-comment hooks, prod-exception streams) —
+  the substrate allows them later (they only move `next_wake_at` earlier).
+- Per-work-unit independent loops / cross-unit parallel scheduling.
+- A `flow ownerd` daemon (kept as a documented alternative).
+- Non-claude harness support for owners (claude-only first, like `--auto`).
+- Cross-machine / server-hosted owners.
+
+---
+
+## 11. Open questions
+
+- **Runtime notify channel default** — Slack assumed; confirm vs. terminal/push/a
+  review inbox.
+- **Ledger source of truth** — derive stats purely from tagged task rows, or also
+  let the tick maintain a hand-written `ledger.md` summary? (Leaning: tasks are
+  the source; `ledger.md` is a generated human view.)
+- **Answer read-back convention** — settled approach: the human marks the
+  `question`-tagged task done and the owner reads the answer from its
+  updates/transcript on the next tick. Open: is a lighter "answered" signal
+  wanted (e.g. a note without full done), and does the answer need a designated
+  field vs. free-form (the tick is a Claude run, so free-form is readable)?
+- **Tags vs. structural column/kind** — linkage (`owner:<slug>`) and the question
+  marker (`question`) are tags, not an FK column or a `kind` value. Trade-off:
+  zero schema churn and free `flow list --tag` queries, but tags are string
+  conventions — they can dangle if an owner is renamed/retired, and "never
+  `--auto` a question-task" is a convention rather than a structural gate.
+  Acceptable for v1 (nothing auto-runs tasks unasked); revisit if owners get
+  renamed often or a hard gate is needed.
+- **Charter format** — free-form markdown (agent uses judgment, flow-native) vs.
+  some structured fields for approval-gates/health-checks. Leaning free-form +
+  a few structured fields (`every`, `notify_channel`, `approval_required`).
+- **Naming of sub-nouns** — "work unit" vs. "tracker" vs. just "task with an
+  owner."
+
+---
+
+## 12. Done-when (from the task brief) — status
+
+- [x] A written design doc capturing the harness architecture, the loop
+  lifecycle, and the in-flow vs. outside-flow boundary decision. *(this doc)*
+- [x] 2–3 approaches weighed with a recommendation. *(§8 — A/B/C + the substrate
+  table, recommending in-flow native `owner` on a launchd tick-scanner)*

--- a/internal/app/add.go
+++ b/internal/app/add.go
@@ -37,6 +37,8 @@ func cmdAdd(args []string) int {
 		return addTask(args[1:])
 	case "playbook":
 		return addPlaybook(args[1:])
+	case "owner":
+		return addOwner(args[1:])
 	}
 	fmt.Fprintf(os.Stderr, "error: unknown add subcommand %q\n", args[0])
 	return 2
@@ -150,6 +152,8 @@ func addTask(args []string) int {
 	priority := fs.String("priority", "medium", "high|medium|low")
 	dueFlag := fs.String("due", "", "due date (YYYY-MM-DD, today, tomorrow, monday, 3d)")
 	assigneeFlag := fs.String("assignee", "", "optional assignee (default: self)")
+	var tags stringSliceFlag
+	fs.Var(&tags, "tag", "attach a tag (repeatable: --tag foo --tag bar)")
 	mkdir := fs.Bool("mkdir", false, "create --work-dir if it does not exist")
 	if err := fs.Parse(args[1:]); err != nil {
 		return 2
@@ -275,6 +279,13 @@ func addTask(args []string) int {
 	if err := flowdb.UpsertWorkdir(db, absWorkDir, "", "", ""); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
+	}
+
+	for _, tg := range tags {
+		if err := flowdb.AddTaskTag(db, slug, tg); err != nil {
+			fmt.Fprintf(os.Stderr, "error: add tag %q: %v\n", tg, err)
+			return 1
+		}
 	}
 
 	if projectSlug == nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -137,5 +137,14 @@ Playbooks:
   flow run playbook   <slug> --here                              (bind THIS Claude session to the new run; no new tab)
   flow run playbook   <slug> --auto                              (run the playbook headlessly in the background)
   flow show playbook  <ref>
-  flow list playbooks [--project <slug>] [--include-archived]`)
+  flow list playbooks [--project <slug>] [--include-archived]
+
+Owners (autonomous, self-prompting controllers — see flow skill §4.17):
+  flow add owner     "<name>" --work-dir <path> [--every <dur>] [--slug <s>] [--project <slug>] [--mkdir]
+  flow owner list                              (alias: flow list owners)
+  flow owner show    <slug>                     (alias: flow show owner <slug>)
+  flow owner start|pause <slug>                 (start reactivates a paused OR retired owner)
+  flow owner tick    <slug> [--auto]            (wake now; interactive by default, --auto = headless)
+  flow owner next    <slug> --in <dur> | --at <when>   (self-pace the next wake)
+  flow owner retire  <slug> [--delete]`)
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -25,7 +25,7 @@ func Run(args []string) int {
 	// and `--version` — those manage the skill themselves or need to
 	// run before any install state exists. See maybeAutoUpgradeSkill.
 	switch cmd {
-	case "init", "skill", "--version", "-v", "version", "-h", "--help", "help", "__auto-exec":
+	case "init", "skill", "--version", "-v", "version", "-h", "--help", "help", "__auto-exec", "__owner-tick":
 		// no auto-upgrade
 	default:
 		maybeAutoUpgradeSkill()
@@ -45,6 +45,10 @@ func Run(args []string) int {
 		// Hidden: the detached supervisor entry point for `flow do --auto`.
 		// Not listed in usage; invoked only by autoLauncher.
 		return cmdAutoExec(rest)
+	case "__owner-tick":
+		// Hidden: the detached owner-tick supervisor. Invoked only by
+		// ownerTickLauncher (via `flow owner tick-due`).
+		return cmdOwnerTick(rest)
 	case "run":
 		return cmdRun(rest)
 	case "done":
@@ -57,6 +61,8 @@ func Run(args []string) int {
 		return cmdEdit(rest)
 	case "update":
 		return cmdUpdate(rest)
+	case "owner":
+		return cmdOwner(rest)
 	case "archive":
 		return cmdArchive(rest)
 	case "unarchive":

--- a/internal/app/list.go
+++ b/internal/app/list.go
@@ -44,6 +44,17 @@ func (o listOpts) waitMax() int {
 	return waitingMaxRunes
 }
 
+// normalizeTags canonicalizes each tag and drops empties, preserving order.
+func normalizeTags(in stringSliceFlag) []string {
+	var out []string
+	for _, t := range in {
+		if n := flowdb.NormalizeTag(t); n != "" {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
 // cmdList dispatches `flow list tasks|projects|playbooks|runs|tags|owners`.
 func cmdList(args []string) int {
 	if len(args) == 0 {
@@ -191,7 +202,8 @@ func listTasksCmd(args []string) int {
 	status := fs.String("status", "", "backlog|in-progress|done")
 	project := fs.String("project", "", "project slug")
 	priority := fs.String("priority", "", "high|medium|low")
-	tag := fs.String("tag", "", "only tasks carrying this tag (case-insensitive)")
+	var tags stringSliceFlag
+	fs.Var(&tags, "tag", "only tasks carrying this tag (case-insensitive; repeatable — tasks must carry ALL given tags)")
 	since := fs.String("since", "", "today|monday|7d|YYYY-MM-DD")
 	includeArchived := fs.Bool("include-archived", false, "include archived tasks")
 	includeDone := fs.Bool("include-done", false, "include done tasks (hidden by default)")
@@ -211,7 +223,7 @@ func listTasksCmd(args []string) int {
 		Status:          *status,
 		Project:         *project,
 		Priority:        *priority,
-		Tag:             flowdb.NormalizeTag(*tag),
+		Tags:            normalizeTags(tags),
 		IncludeArchived: *includeArchived,
 	}
 	// Default kind is "regular"; "all" disables the kind filter.

--- a/internal/app/list.go
+++ b/internal/app/list.go
@@ -44,10 +44,10 @@ func (o listOpts) waitMax() int {
 	return waitingMaxRunes
 }
 
-// cmdList dispatches `flow list tasks|projects|playbooks|runs|tags`.
+// cmdList dispatches `flow list tasks|projects|playbooks|runs|tags|owners`.
 func cmdList(args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "error: list requires 'tasks', 'projects', 'playbooks', 'runs', or 'tags'")
+		fmt.Fprintln(os.Stderr, "error: list requires 'tasks', 'projects', 'playbooks', 'runs', 'tags', or 'owners'")
 		return 2
 	}
 	switch args[0] {
@@ -61,6 +61,12 @@ func cmdList(args []string) int {
 		return listRunsCmd(args[1:])
 	case "tags":
 		return listTagsCmd(args[1:])
+	case "owners":
+		// Verb-first alias for `flow owner list` — owners share the
+		// list/show surface with the other top-level objects. Lifecycle
+		// verbs (start/pause/tick/next/retire) stay grouped under
+		// `flow owner`.
+		return ownerList(args[1:])
 	}
 	fmt.Fprintf(os.Stderr, "error: unknown list subcommand %q\n", args[0])
 	return 2

--- a/internal/app/owner.go
+++ b/internal/app/owner.go
@@ -169,6 +169,9 @@ func ownerShow(args []string) int {
 			questions = append(questions, tk)
 		case tk.Kind == "playbook_run":
 			runs = append(runs, tk)
+		case tk.Status == "done":
+			// A completed owned task is not "in flight" — drop it from the
+			// active list so the section reflects only outstanding work.
 		default:
 			inflight = append(inflight, tk)
 		}
@@ -313,8 +316,7 @@ func ownerNext(args []string) int {
 		return 1
 	}
 	defer db.Close()
-	o, err := flowdb.GetOwner(db, slug)
-	if err != nil {
+	if _, err := flowdb.GetOwner(db, slug); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			fmt.Fprintf(os.Stderr, "error: no owner %q\n", slug)
 			return 1
@@ -322,8 +324,9 @@ func ownerNext(args []string) int {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
 	}
-	o.NextWakeAt = sql.NullString{String: next.Format(time.RFC3339), Valid: true}
-	if err := flowdb.UpdateOwner(db, o); err != nil {
+	// Targeted write (only next_wake_at) so a self-pacing tick or a manual
+	// `owner next` can't clobber the tick bookkeeping written concurrently.
+	if err := flowdb.SetOwnerNextWake(db, slug, next.Format(time.RFC3339)); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
 	}
@@ -352,9 +355,10 @@ func ownerStart(args []string) int {
 		return rc
 	}
 	defer db.Close()
-	o.Status = "active"
-	o.NextWakeAt = sql.NullString{String: flowdb.NowISO(), Valid: true}
-	if err := flowdb.UpdateOwner(db, o); err != nil {
+	// Targeted write that also clears archived_at — so `start` un-retires a
+	// retired owner (else DueOwners' archived_at filter would leave it
+	// active-but-never-ticking and hidden from the list).
+	if err := flowdb.ActivateOwner(db, o.Slug, flowdb.NowISO()); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
 	}
@@ -369,8 +373,7 @@ func ownerPause(args []string) int {
 		return rc
 	}
 	defer db.Close()
-	o.Status = "paused"
-	if err := flowdb.UpdateOwner(db, o); err != nil {
+	if err := flowdb.PauseOwner(db, o.Slug); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
 	}

--- a/internal/app/owner.go
+++ b/internal/app/owner.go
@@ -294,6 +294,14 @@ func ownerNext(args []string) int {
 		next = t
 	}
 
+	// Reject a wake time in the past: it would leave the owner perpetually
+	// due (ticking every scheduler pass). A tick self-paces FORWARD, so a
+	// past time is always a mistake (stale --at or negative --in).
+	if next.Before(time.Now()) {
+		fmt.Fprintf(os.Stderr, "error: next tick %s is in the past — pick a future time (ticks self-pace forward)\n", next.Format(time.RFC3339))
+		return 2
+	}
+
 	dbPath, err := flowDBPath()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -506,6 +514,16 @@ func addOwner(args []string) int {
 	var slug string
 	if *slugFlag != "" {
 		slug = *slugFlag
+		// An explicit slug is taken as-is (not auto-mangled like the
+		// generated path). Pre-check for a collision so the user gets a
+		// friendly message instead of a raw UNIQUE-constraint error.
+		if _, err := flowdb.GetOwner(db, slug); err == nil {
+			fmt.Fprintf(os.Stderr, "error: owner slug %q already exists — pick another --slug\n", slug)
+			return 1
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 1
+		}
 	} else {
 		baseSlug, err := Slugify(name)
 		if err != nil {

--- a/internal/app/owner.go
+++ b/internal/app/owner.go
@@ -29,7 +29,7 @@ This owner's operating manual. Edit freely or via a flow skill session.
 // cmdOwner dispatches `flow owner list|show|start|pause`.
 func cmdOwner(args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "error: owner requires a subcommand (list, show, start, pause)")
+		fmt.Fprintln(os.Stderr, "error: owner requires a subcommand (list, show, start, pause, tick)")
 		return 2
 	}
 	switch args[0] {
@@ -41,6 +41,8 @@ func cmdOwner(args []string) int {
 		return ownerStart(args[1:])
 	case "pause":
 		return ownerPause(args[1:])
+	case "tick":
+		return ownerTickManual(args[1:])
 	case "tick-due":
 		return ownerTickDue(args[1:])
 	}

--- a/internal/app/owner.go
+++ b/internal/app/owner.go
@@ -29,7 +29,7 @@ This owner's operating manual. Edit freely or via a flow skill session.
 // cmdOwner dispatches `flow owner list|show|start|pause`.
 func cmdOwner(args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "error: owner requires a subcommand (list, show, start, pause, tick, next)")
+		fmt.Fprintln(os.Stderr, "error: owner requires a subcommand (list, show, start, pause, tick, next, retire)")
 		return 2
 	}
 	switch args[0] {
@@ -43,6 +43,8 @@ func cmdOwner(args []string) int {
 		return ownerPause(args[1:])
 	case "next":
 		return ownerNext(args[1:])
+	case "retire":
+		return ownerRetire(args[1:])
 	case "tick":
 		return ownerTickManual(args[1:])
 	case "tick-due":
@@ -186,6 +188,72 @@ func printOwnerTaskSection(label string, tasks []*flowdb.Task) {
 	for _, tk := range tasks {
 		fmt.Printf("  - %-30s [%s]\n", tk.Slug, tk.Status)
 	}
+}
+
+// ownerRetire implements `flow owner retire <slug> [--delete]`. Graceful
+// retire (default) marks the owner status='retired' + archived: it stops
+// ticking and disappears from the default list, but its charter, journal,
+// tick logs, and owned tasks are preserved. `--delete` instead hard-removes
+// the row and the owners/<slug>/ directory (the supported replacement for
+// hand-deleting). Either way, owned tasks (tagged owner:<slug>) are left
+// intact — the work the owner spawned outlives it.
+func ownerRetire(args []string) int {
+	if len(args) == 0 || args[0] == "" {
+		fmt.Fprintln(os.Stderr, "error: owner retire requires an owner slug")
+		return 2
+	}
+	slug := args[0]
+	fs := flagSet("owner retire")
+	del := fs.Bool("delete", false, "permanently delete the owner row + its directory (instead of archiving)")
+	if err := fs.Parse(args[1:]); err != nil {
+		return 2
+	}
+
+	dbPath, err := flowDBPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	db, err := flowdb.OpenDB(dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	defer db.Close()
+	if _, err := flowdb.GetOwner(db, slug); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			fmt.Fprintf(os.Stderr, "error: no owner %q\n", slug)
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	root, err := flowRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	if *del {
+		if err := flowdb.DeleteOwner(db, slug); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 1
+		}
+		dir := filepath.Join(root, "owners", slug)
+		if err := os.RemoveAll(dir); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: remove %s: %v\n", dir, err)
+		}
+		fmt.Printf("deleted owner %q (row + %s). Owned tasks (tag owner:%s) are untouched.\n", slug, dir, slug)
+		return 0
+	}
+
+	if err := flowdb.RetireOwner(db, slug); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	fmt.Printf("retired owner %q — it will no longer tick. Files preserved under owners/%s/. (Use --delete to remove entirely.)\n", slug, slug)
+	return 0
 }
 
 // ownerNext implements `flow owner next <slug> --in <dur> | --at <when>`:

--- a/internal/app/owner.go
+++ b/internal/app/owner.go
@@ -1,0 +1,420 @@
+package app
+
+import (
+	"database/sql"
+	"errors"
+	"flow/internal/flowdb"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const ownerCharterStub = `# %s — charter
+
+This owner's operating manual. Edit freely or via a flow skill session.
+
+## Owns
+<the outcome this owner is responsible for>
+
+## Each tick
+- observe: <what to look at, e.g. open PRs / CI / prod health>
+- act: <what to do when something is off-target>
+- ask: <when to create a question-task for the human instead of guessing>
+
+## Done / escalate
+- <when an outcome counts as met, and when to escalate to the human>
+`
+
+// cmdOwner dispatches `flow owner list|show|start|pause`.
+func cmdOwner(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "error: owner requires a subcommand (list, show, start, pause)")
+		return 2
+	}
+	switch args[0] {
+	case "list":
+		return ownerList(args[1:])
+	case "show":
+		return ownerShow(args[1:])
+	case "start":
+		return ownerStart(args[1:])
+	case "pause":
+		return ownerPause(args[1:])
+	case "tick-due":
+		return ownerTickDue(args[1:])
+	}
+	fmt.Fprintf(os.Stderr, "error: unknown owner subcommand %q\n", args[0])
+	return 2
+}
+
+// loadOwnerArg parses a single owner-slug argument, opens the DB, and
+// loads the owner. On any error it reports to stderr, closes the DB,
+// and returns a non-zero rc with a nil owner/db. On success the caller
+// owns the returned *sql.DB and must Close it.
+func loadOwnerArg(args []string, name string) (*flowdb.Owner, *sql.DB, int) {
+	fs := flagSet(name)
+	if err := fs.Parse(args); err != nil {
+		return nil, nil, 2
+	}
+	if fs.NArg() < 1 {
+		fmt.Fprintf(os.Stderr, "error: %s requires an owner slug\n", name)
+		return nil, nil, 2
+	}
+	slug := fs.Arg(0)
+
+	dbPath, err := flowDBPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return nil, nil, 1
+	}
+	db, err := flowdb.OpenDB(dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return nil, nil, 1
+	}
+	o, err := flowdb.GetOwner(db, slug)
+	if err != nil {
+		db.Close()
+		if errors.Is(err, sql.ErrNoRows) {
+			fmt.Fprintf(os.Stderr, "error: no owner %q\n", slug)
+			return nil, nil, 1
+		}
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return nil, nil, 1
+	}
+	return o, db, 0
+}
+
+// ownerShow renders the owner's accountability surface: metadata, next
+// tick, and a live list of what it owns (tasks tagged owner:<slug>),
+// split into in-flight work units and questions parked for the human.
+func ownerShow(args []string) int {
+	o, db, rc := loadOwnerArg(args, "owner show")
+	if rc != 0 {
+		return rc
+	}
+	defer db.Close()
+
+	root, err := flowRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	// Reconcile a stale running tick (pid died before finalizing) so the
+	// display reflects reality.
+	reconcileOwnerTick(db, o)
+
+	now := time.Now()
+	fmt.Printf("owner:        %s\n", o.Slug)
+	fmt.Printf("name:         %s\n", o.Name)
+	fmt.Printf("status:       %s\n", o.Status)
+	fmt.Printf("every:        %s\n", o.Every)
+	if o.ProjectSlug.Valid && o.ProjectSlug.String != "" {
+		fmt.Printf("project:      %s\n", o.ProjectSlug.String)
+	}
+	fmt.Printf("work_dir:     %s\n", o.WorkDir)
+	if o.TickPID.Valid {
+		since := ""
+		if o.TickStarted.Valid && o.TickStarted.String != "" {
+			since = ", since " + o.TickStarted.String
+		}
+		fmt.Printf("tick:         running (pid %d%s)\n", o.TickPID.Int64, since)
+	}
+	fmt.Printf("next tick:    %s\n", ownerNextTickLabel(o, now))
+	lastTick := "(never)"
+	if o.LastTickAt.Valid && o.LastTickAt.String != "" {
+		lastTick = o.LastTickAt.String
+		if o.LastTickStatus.Valid && o.LastTickStatus.String != "" {
+			lastTick += "  [" + o.LastTickStatus.String + "]"
+		}
+	}
+	fmt.Printf("last tick:    %s\n", lastTick)
+	fmt.Printf("charter:      %s\n", filepath.Join(root, "owners", o.Slug, "charter.md"))
+
+	// The ledger: tasks tagged owner:<slug>, split into work units and
+	// questions (those also tagged 'question').
+	owned, err := flowdb.ListTasks(db, flowdb.TaskFilter{Tag: flowdb.NormalizeTag("owner:" + o.Slug)})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	slugs := make([]string, len(owned))
+	for i, tk := range owned {
+		slugs[i] = tk.Slug
+	}
+	tagsBySlug, err := flowdb.GetTaskTagsBatch(db, slugs)
+	if err != nil {
+		tagsBySlug = map[string][]string{}
+	}
+	isQuestion := func(s string) bool {
+		for _, tg := range tagsBySlug[s] {
+			if tg == "question" {
+				return true
+			}
+		}
+		return false
+	}
+	var inflight, runs, questions []*flowdb.Task
+	for _, tk := range owned {
+		switch {
+		case isQuestion(tk.Slug):
+			questions = append(questions, tk)
+		case tk.Kind == "playbook_run":
+			runs = append(runs, tk)
+		default:
+			inflight = append(inflight, tk)
+		}
+	}
+	printOwnerTaskSection("in flight", inflight)
+	printOwnerTaskSection("playbook runs", runs)
+	printOwnerTaskSection("questions for you", questions)
+	return 0
+}
+
+func printOwnerTaskSection(label string, tasks []*flowdb.Task) {
+	if len(tasks) == 0 {
+		fmt.Printf("%s: (none)\n", label)
+		return
+	}
+	fmt.Printf("%s:\n", label)
+	for _, tk := range tasks {
+		fmt.Printf("  - %-30s [%s]\n", tk.Slug, tk.Status)
+	}
+}
+
+// ownerStart marks an owner active and schedules its first tick now, so
+// the next scheduler pass picks it up. Then it ticks every Every.
+func ownerStart(args []string) int {
+	o, db, rc := loadOwnerArg(args, "owner start")
+	if rc != 0 {
+		return rc
+	}
+	defer db.Close()
+	o.Status = "active"
+	o.NextWakeAt = sql.NullString{String: flowdb.NowISO(), Valid: true}
+	if err := flowdb.UpdateOwner(db, o); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	fmt.Printf("Started owner %q — first tick due now, then every %s\n", o.Slug, o.Every)
+	return 0
+}
+
+// ownerPause stops an owner from ticking while preserving all its state.
+func ownerPause(args []string) int {
+	o, db, rc := loadOwnerArg(args, "owner pause")
+	if rc != 0 {
+		return rc
+	}
+	defer db.Close()
+	o.Status = "paused"
+	if err := flowdb.UpdateOwner(db, o); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	fmt.Printf("Paused owner %q\n", o.Slug)
+	return 0
+}
+
+// ownerList implements `flow owner list` — one row per owner with its
+// status, interval, and next scheduled tick.
+func ownerList(args []string) int {
+	fs := flagSet("owner list")
+	includeArchived := fs.Bool("include-archived", false, "include archived owners")
+	statusFilter := fs.String("status", "", "active|paused|retired")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	dbPath, err := flowDBPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	db, err := flowdb.OpenDB(dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	defer db.Close()
+
+	owners, err := flowdb.ListOwners(db, flowdb.OwnerFilter{
+		Status:          *statusFilter,
+		IncludeArchived: *includeArchived,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	if len(owners) == 0 {
+		fmt.Println(`No owners. Create one with: flow add owner "<name>" --work-dir <path> --every <dur>`)
+		return 0
+	}
+
+	now := time.Now()
+	fmt.Printf("%-20s %-8s %-6s %s\n", "SLUG", "STATUS", "EVERY", "NEXT TICK")
+	for _, o := range owners {
+		fmt.Printf("%-20s %-8s %-6s %s\n", o.Slug, o.Status, o.Every, ownerNextTickLabel(o, now))
+	}
+	return 0
+}
+
+// ownerNextTickLabel renders the "next tick" column: the scheduled
+// next_wake_at with a relative hint, or a parenthetical status when the
+// owner isn't actively scheduled.
+func ownerNextTickLabel(o *flowdb.Owner, now time.Time) string {
+	switch o.Status {
+	case "paused":
+		return "(paused)"
+	case "retired":
+		return "(retired)"
+	}
+	if !o.NextWakeAt.Valid || o.NextWakeAt.String == "" {
+		return "(not started)"
+	}
+	label := o.NextWakeAt.String
+	if rel := relativeWake(o.NextWakeAt.String, now); rel != "" {
+		label += "  " + rel
+	}
+	return label
+}
+
+// relativeWake formats an RFC3339 wake time relative to now, e.g.
+// "(in 22m)" or "(overdue 5m)". Returns "" if ts can't be parsed.
+func relativeWake(ts string, now time.Time) string {
+	w, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return ""
+	}
+	d := w.Sub(now)
+	if d <= 0 {
+		return fmt.Sprintf("(overdue %s)", roundDur(-d))
+	}
+	return fmt.Sprintf("(in %s)", roundDur(d))
+}
+
+func roundDur(d time.Duration) string {
+	if d < time.Minute {
+		return d.Round(time.Second).String()
+	}
+	return d.Round(time.Minute).String()
+}
+
+// addOwner implements `flow add owner "<name>" --work-dir <p> --every <dur>`.
+func addOwner(args []string) int {
+	if len(args) == 0 || args[0] == "" {
+		fmt.Fprintln(os.Stderr, "error: add owner requires a name")
+		return 2
+	}
+	name := args[0]
+	fs := flagSet("add owner")
+	slugFlag := fs.String("slug", "", "short user-chosen slug (default: auto-generated from name)")
+	workDir := fs.String("work-dir", "", "absolute path to the owner's work directory (required)")
+	project := fs.String("project", "", "parent project slug (optional)")
+	every := fs.String("every", "", "tick interval, e.g. 30m, 1h (required)")
+	mkdir := fs.Bool("mkdir", false, "create --work-dir if it does not exist")
+	if err := fs.Parse(args[1:]); err != nil {
+		return 2
+	}
+
+	if *workDir == "" {
+		fmt.Fprintln(os.Stderr, "error: --work-dir is required for owners")
+		return 2
+	}
+	if *every == "" {
+		fmt.Fprintln(os.Stderr, "error: --every is required (tick interval, e.g. 30m)")
+		return 2
+	}
+	if _, err := time.ParseDuration(*every); err != nil {
+		fmt.Fprintf(os.Stderr, "error: --every %q is not a valid duration (try 30m, 1h): %v\n", *every, err)
+		return 2
+	}
+	abs, err := resolveWorkDir(*workDir, *mkdir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	dbPath, err := flowDBPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	db, err := flowdb.OpenDB(dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	defer db.Close()
+
+	var slug string
+	if *slugFlag != "" {
+		slug = *slugFlag
+	} else {
+		baseSlug, err := Slugify(name)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 2
+		}
+		slug, err = uniqueSlug(db, "owners", baseSlug)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 1
+		}
+	}
+
+	var projectSlug sql.NullString
+	if *project != "" {
+		p, err := flowdb.GetProject(db, *project)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				fmt.Fprintf(os.Stderr, "error: project %q not found\n", *project)
+				return 1
+			}
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 1
+		}
+		projectSlug = sql.NullString{String: p.Slug, Valid: true}
+	}
+
+	o := &flowdb.Owner{
+		Slug:        slug,
+		Name:        name,
+		WorkDir:     abs,
+		ProjectSlug: projectSlug,
+		Every:       *every,
+	}
+	if err := flowdb.CreateOwner(db, o); err != nil {
+		fmt.Fprintf(os.Stderr, "error: create owner: %v\n", err)
+		return 1
+	}
+
+	root, err := flowRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	ownerDir := filepath.Join(root, "owners", slug)
+	if err := os.MkdirAll(filepath.Join(ownerDir, "updates"), 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	charterPath := filepath.Join(ownerDir, "charter.md")
+	if _, err := os.Stat(charterPath); os.IsNotExist(err) {
+		if err := os.WriteFile(charterPath, []byte(fmt.Sprintf(ownerCharterStub, name)), 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 1
+		}
+	}
+
+	if err := flowdb.UpsertWorkdir(db, abs, "", "", ""); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	fmt.Printf("Created owner %q at %s\n", slug, ownerDir)
+	fmt.Printf("Next: edit the charter, then start the owner so it begins ticking every %s\n", *every)
+	return 0
+}

--- a/internal/app/owner.go
+++ b/internal/app/owner.go
@@ -29,7 +29,7 @@ This owner's operating manual. Edit freely or via a flow skill session.
 // cmdOwner dispatches `flow owner list|show|start|pause`.
 func cmdOwner(args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "error: owner requires a subcommand (list, show, start, pause, tick)")
+		fmt.Fprintln(os.Stderr, "error: owner requires a subcommand (list, show, start, pause, tick, next)")
 		return 2
 	}
 	switch args[0] {
@@ -41,6 +41,8 @@ func cmdOwner(args []string) int {
 		return ownerStart(args[1:])
 	case "pause":
 		return ownerPause(args[1:])
+	case "next":
+		return ownerNext(args[1:])
 	case "tick":
 		return ownerTickManual(args[1:])
 	case "tick-due":
@@ -186,6 +188,86 @@ func printOwnerTaskSection(label string, tasks []*flowdb.Task) {
 	}
 }
 
+// ownerNext implements `flow owner next <slug> --in <dur> | --at <when>`:
+// set the owner's next tick time. This is how a tick SELF-PACES — at the
+// end of each run it decides when it next needs to act and sets it here,
+// overriding the `--every` fallback. Exactly one of --in/--at is required.
+func ownerNext(args []string) int {
+	if len(args) == 0 || args[0] == "" {
+		fmt.Fprintln(os.Stderr, "error: owner next requires an owner slug")
+		return 2
+	}
+	slug := args[0]
+	fs := flagSet("owner next")
+	in := fs.String("in", "", "set next tick this far from now (e.g. 15m, 2h)")
+	at := fs.String("at", "", "set next tick at an absolute time (RFC3339, or YYYY-MM-DD/today/tomorrow)")
+	if err := fs.Parse(args[1:]); err != nil {
+		return 2
+	}
+	if (*in == "") == (*at == "") {
+		fmt.Fprintln(os.Stderr, "error: give exactly one of --in or --at")
+		return 2
+	}
+
+	var next time.Time
+	if *in != "" {
+		d, err := time.ParseDuration(*in)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: --in %q is not a valid duration (try 15m, 2h): %v\n", *in, err)
+			return 2
+		}
+		next = time.Now().Add(d)
+	} else {
+		t, err := parseOwnerWhen(*at)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: --at %q: %v\n", *at, err)
+			return 2
+		}
+		next = t
+	}
+
+	dbPath, err := flowDBPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	db, err := flowdb.OpenDB(dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	defer db.Close()
+	o, err := flowdb.GetOwner(db, slug)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			fmt.Fprintf(os.Stderr, "error: no owner %q\n", slug)
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	o.NextWakeAt = sql.NullString{String: next.Format(time.RFC3339), Valid: true}
+	if err := flowdb.UpdateOwner(db, o); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	fmt.Printf("owner %q next tick set to %s\n", slug, next.Format(time.RFC3339))
+	return 0
+}
+
+// parseOwnerWhen accepts an RFC3339 timestamp or a date expression
+// (YYYY-MM-DD, today, tomorrow, weekday, Nd) for `flow owner next --at`.
+func parseOwnerWhen(s string) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
+	}
+	d, err := parseDueDate(s, time.Now())
+	if err != nil {
+		return time.Time{}, fmt.Errorf("not an RFC3339 time or a recognizable date: %w", err)
+	}
+	return d, nil
+}
+
 // ownerStart marks an owner active and schedules its first tick now, so
 // the next scheduler pass picks it up. Then it ticks every Every.
 func ownerStart(args []string) int {
@@ -315,7 +397,7 @@ func addOwner(args []string) int {
 	slugFlag := fs.String("slug", "", "short user-chosen slug (default: auto-generated from name)")
 	workDir := fs.String("work-dir", "", "absolute path to the owner's work directory (required)")
 	project := fs.String("project", "", "parent project slug (optional)")
-	every := fs.String("every", "", "tick interval, e.g. 30m, 1h (required)")
+	every := fs.String("every", "", "fallback/max tick interval (heartbeat floor), e.g. 1h, 24h; default 24h — ticks self-pace via `flow owner next`")
 	mkdir := fs.Bool("mkdir", false, "create --work-dir if it does not exist")
 	if err := fs.Parse(args[1:]); err != nil {
 		return 2
@@ -325,12 +407,14 @@ func addOwner(args []string) int {
 		fmt.Fprintln(os.Stderr, "error: --work-dir is required for owners")
 		return 2
 	}
-	if *every == "" {
-		fmt.Fprintln(os.Stderr, "error: --every is required (tick interval, e.g. 30m)")
-		return 2
-	}
-	if _, err := time.ParseDuration(*every); err != nil {
-		fmt.Fprintf(os.Stderr, "error: --every %q is not a valid duration (try 30m, 1h): %v\n", *every, err)
+	// --every is optional: it's only the fallback heartbeat floor (so a tick
+	// that never sets its next wake still re-wakes). The tick decides the
+	// real cadence per-run via `flow owner next`.
+	everyVal := *every
+	if everyVal == "" {
+		everyVal = "24h"
+	} else if _, err := time.ParseDuration(everyVal); err != nil {
+		fmt.Fprintf(os.Stderr, "error: --every %q is not a valid duration (try 1h, 24h): %v\n", *every, err)
 		return 2
 	}
 	abs, err := resolveWorkDir(*workDir, *mkdir)
@@ -386,7 +470,7 @@ func addOwner(args []string) int {
 		Name:        name,
 		WorkDir:     abs,
 		ProjectSlug: projectSlug,
-		Every:       *every,
+		Every:       everyVal,
 	}
 	if err := flowdb.CreateOwner(db, o); err != nil {
 		fmt.Fprintf(os.Stderr, "error: create owner: %v\n", err)
@@ -417,6 +501,6 @@ func addOwner(args []string) int {
 	}
 
 	fmt.Printf("Created owner %q at %s\n", slug, ownerDir)
-	fmt.Printf("Next: edit the charter, then start the owner so it begins ticking every %s\n", *every)
+	fmt.Printf("Next: edit the charter, then start the owner (it self-paces; %s is the fallback interval)\n", everyVal)
 	return 0
 }

--- a/internal/app/owner_test.go
+++ b/internal/app/owner_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestCmdAddOwnerHappyPath(t *testing.T) {
@@ -48,6 +49,60 @@ func TestCmdAddOwnerHappyPath(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(root, "owners", "af-maint", "updates")); err != nil {
 		t.Errorf("updates/ dir missing: %v", err)
+	}
+}
+
+// `flow owner next` must reject a wake time already in the past — a stale
+// --at (or a negative --in) would leave the owner perpetually due, ticking
+// every scheduler pass.
+func TestCmdOwnerNextRejectsPastTime(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	future := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{
+		Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m",
+		NextWakeAt: sql.NullString{String: future, Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if rc := cmdOwner([]string{"next", "o1", "--at", "2020-01-01T00:00:00Z"}); rc == 0 {
+		t.Fatalf("expected non-zero rc for a past --at, got 0")
+	}
+	// A negative --in must be rejected the same way.
+	if rc := cmdOwner([]string{"next", "o1", "--in", "-5m"}); rc == 0 {
+		t.Fatalf("expected non-zero rc for a negative --in, got 0")
+	}
+
+	o, err := flowdb.GetOwner(db, "o1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if o.NextWakeAt.String != future {
+		t.Errorf("next_wake_at = %q, want unchanged %q (past time should not be written)", o.NextWakeAt.String, future)
+	}
+}
+
+// An explicit --slug that collides with an existing owner should fail with
+// a friendly message, not a raw SQL UNIQUE-constraint error.
+func TestCmdAddOwnerDuplicateSlugFriendlyError(t *testing.T) {
+	setupFlowRoot(t)
+	wd := t.TempDir()
+	if rc := cmdAdd([]string{"owner", "first", "--work-dir", wd, "--slug", "dup"}); rc != 0 {
+		t.Fatalf("seed owner rc=%d", rc)
+	}
+
+	read := captureStderr(t)
+	rc := cmdAdd([]string{"owner", "second", "--work-dir", wd, "--slug", "dup"})
+	stderr := read()
+	if rc == 0 {
+		t.Fatalf("expected non-zero rc for a duplicate --slug, got 0")
+	}
+	if strings.Contains(stderr, "UNIQUE") || strings.Contains(stderr, "constraint") {
+		t.Errorf("expected a friendly message, got raw SQL error:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "dup") || !strings.Contains(strings.ToLower(stderr), "exists") {
+		t.Errorf("expected message naming the slug and 'exists', got:\n%s", stderr)
 	}
 }
 

--- a/internal/app/owner_test.go
+++ b/internal/app/owner_test.go
@@ -107,6 +107,64 @@ func TestCmdOwnerListShowsNextTick(t *testing.T) {
 	}
 }
 
+// flow list owners is a verb-first alias for `flow owner list` — both
+// render the same listing (the surface owners share with task/project/
+// playbook). Only list and show are dual-formed; lifecycle verbs stay
+// grouped under `flow owner`.
+func TestCmdListOwnersAlias(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{
+		Slug: "started", Name: "S", WorkDir: "/x", Every: "30m",
+		NextWakeAt: sql.NullString{String: "2026-06-08T13:00:00Z", Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	grouped := captureStdout(t, func() {
+		if rc := cmdOwner([]string{"list"}); rc != 0 {
+			t.Fatalf("owner list rc=%d", rc)
+		}
+	})
+	alias := captureStdout(t, func() {
+		if rc := cmdList([]string{"owners"}); rc != 0 {
+			t.Fatalf("list owners rc=%d", rc)
+		}
+	})
+	if alias != grouped {
+		t.Errorf("`flow list owners` must match `flow owner list`\n--- owner list ---\n%s\n--- list owners ---\n%s", grouped, alias)
+	}
+	if !strings.Contains(alias, "started") {
+		t.Errorf("expected owner in `flow list owners` output, got:\n%s", alias)
+	}
+}
+
+// flow show owner <slug> is a verb-first alias for `flow owner show <slug>`.
+func TestCmdShowOwnerAlias(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m"}); err != nil {
+		t.Fatal(err)
+	}
+
+	grouped := captureStdout(t, func() {
+		if rc := cmdOwner([]string{"show", "o1"}); rc != 0 {
+			t.Fatalf("owner show rc=%d", rc)
+		}
+	})
+	alias := captureStdout(t, func() {
+		if rc := cmdShow([]string{"owner", "o1"}); rc != 0 {
+			t.Fatalf("show owner rc=%d", rc)
+		}
+	})
+	if alias != grouped {
+		t.Errorf("`flow show owner o1` must match `flow owner show o1`\n--- owner show ---\n%s\n--- show owner ---\n%s", grouped, alias)
+	}
+	if !strings.Contains(alias, "o1") {
+		t.Errorf("expected owner slug in `flow show owner` output, got:\n%s", alias)
+	}
+}
+
 func TestCmdOwnerStartSchedulesTick(t *testing.T) {
 	setupFlowRoot(t)
 	db := openFlowDB(t)

--- a/internal/app/owner_test.go
+++ b/internal/app/owner_test.go
@@ -1,0 +1,259 @@
+package app
+
+import (
+	"database/sql"
+	"flow/internal/flowdb"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCmdAddOwnerHappyPath(t *testing.T) {
+	root := setupFlowRoot(t)
+	wd := t.TempDir()
+
+	rc := cmdAdd([]string{"owner", "agent-factory maintenance",
+		"--work-dir", wd, "--every", "30m", "--slug", "af-maint"})
+	if rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+
+	db := openFlowDB(t)
+	o, err := flowdb.GetOwner(db, "af-maint")
+	if err != nil {
+		t.Fatalf("GetOwner: %v", err)
+	}
+	if o.Name != "agent-factory maintenance" {
+		t.Errorf("name = %q", o.Name)
+	}
+	if o.WorkDir != wd {
+		t.Errorf("work_dir = %q, want %q", o.WorkDir, wd)
+	}
+	if o.Every != "30m" {
+		t.Errorf("every = %q, want 30m", o.Every)
+	}
+	if o.Status != "active" {
+		t.Errorf("status = %q, want active", o.Status)
+	}
+	// A freshly added owner is not yet started → no next tick scheduled.
+	if o.NextWakeAt.Valid {
+		t.Errorf("NextWakeAt should be NULL until started, got %q", o.NextWakeAt.String)
+	}
+
+	// charter.md + updates/ should exist on disk.
+	if _, err := os.Stat(filepath.Join(root, "owners", "af-maint", "charter.md")); err != nil {
+		t.Errorf("charter.md missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "owners", "af-maint", "updates")); err != nil {
+		t.Errorf("updates/ dir missing: %v", err)
+	}
+}
+
+func TestCmdAddOwnerRequiresWorkDirAndEvery(t *testing.T) {
+	setupFlowRoot(t)
+	wd := t.TempDir()
+
+	if rc := cmdAdd([]string{"owner", "no every", "--work-dir", wd}); rc != 2 {
+		t.Errorf("missing --every: rc=%d, want 2", rc)
+	}
+	if rc := cmdAdd([]string{"owner", "no workdir", "--every", "30m"}); rc != 2 {
+		t.Errorf("missing --work-dir: rc=%d, want 2", rc)
+	}
+	if rc := cmdAdd([]string{"owner", "bad every", "--work-dir", wd, "--every", "soon"}); rc != 2 {
+		t.Errorf("invalid --every: rc=%d, want 2", rc)
+	}
+}
+
+func TestCmdOwnerListShowsNextTick(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{
+		Slug: "started", Name: "S", WorkDir: "/x", Every: "30m",
+		NextWakeAt: sql.NullString{String: "2026-06-08T13:00:00Z", Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{
+		Slug: "fresh", Name: "F", WorkDir: "/y", Every: "1h",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(t, func() {
+		if rc := cmdOwner([]string{"list"}); rc != 0 {
+			t.Fatalf("rc=%d", rc)
+		}
+	})
+
+	if !strings.Contains(out, "started") || !strings.Contains(out, "2026-06-08T13:00:00Z") {
+		t.Errorf("expected started owner with its next tick in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "fresh") || !strings.Contains(out, "not started") {
+		t.Errorf("expected fresh owner marked 'not started', got:\n%s", out)
+	}
+}
+
+func TestCmdOwnerStartSchedulesTick(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if rc := cmdOwner([]string{"start", "o1"}); rc != 0 {
+		t.Fatalf("start rc=%d", rc)
+	}
+
+	o, err := flowdb.GetOwner(db, "o1")
+	if err != nil {
+		t.Fatalf("GetOwner: %v", err)
+	}
+	if o.Status != "active" {
+		t.Errorf("status = %q, want active", o.Status)
+	}
+	if !o.NextWakeAt.Valid || o.NextWakeAt.String == "" {
+		t.Errorf("start should schedule a next tick, NextWakeAt = %+v", o.NextWakeAt)
+	}
+}
+
+func TestCmdOwnerPause(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if rc := cmdOwner([]string{"pause", "o1"}); rc != 0 {
+		t.Fatalf("pause rc=%d", rc)
+	}
+
+	o, err := flowdb.GetOwner(db, "o1")
+	if err != nil {
+		t.Fatalf("GetOwner: %v", err)
+	}
+	if o.Status != "paused" {
+		t.Errorf("status = %q, want paused", o.Status)
+	}
+}
+
+func TestCmdOwnerStartUnknownErrors(t *testing.T) {
+	setupFlowRoot(t)
+	if rc := cmdOwner([]string{"start", "nope"}); rc != 1 {
+		t.Errorf("start unknown owner: rc=%d, want 1", rc)
+	}
+}
+
+func TestCmdAddTaskWithTags(t *testing.T) {
+	setupFlowRoot(t)
+	wd := t.TempDir()
+
+	rc := cmdAdd([]string{"task", "fix flaky", "--work-dir", wd, "--slug", "fix-flaky",
+		"--tag", "question", "--tag", "owner:af-maint"})
+	if rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+
+	db := openFlowDB(t)
+	tags, err := flowdb.GetTaskTags(db, "fix-flaky")
+	if err != nil {
+		t.Fatalf("GetTaskTags: %v", err)
+	}
+	want := map[string]bool{"question": true, "owner:af-maint": true}
+	for _, tg := range tags {
+		delete(want, tg)
+	}
+	if len(want) != 0 {
+		t.Errorf("missing tags %v; got %v", want, tags)
+	}
+}
+
+func TestCmdOwnerShowSeparatesPlaybookRuns(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m"}); err != nil {
+		t.Fatal(err)
+	}
+
+	insertTask(t, db, "fix-1", "fix it", "backlog", "medium", "/x", nil)
+	if err := flowdb.AddTaskTag(db, "fix-1", "owner:o1"); err != nil {
+		t.Fatal(err)
+	}
+	// A playbook run owned by the owner.
+	now := flowdb.NowISO()
+	if _, err := db.Exec(
+		`INSERT INTO tasks (slug, name, status, kind, priority, work_dir, created_at, updated_at)
+		 VALUES ('run-1', 'a run', 'backlog', 'playbook_run', 'medium', '/x', ?, ?)`, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := flowdb.AddTaskTag(db, "run-1", "owner:o1"); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(t, func() {
+		if rc := cmdOwner([]string{"show", "o1"}); rc != 0 {
+			t.Fatalf("rc=%d", rc)
+		}
+	})
+
+	if !strings.Contains(out, "playbook runs") {
+		t.Errorf("expected a 'playbook runs' section; got:\n%s", out)
+	}
+	// The run goes under playbook runs; the regular task stays in flight.
+	if !strings.Contains(out, "run-1") || !strings.Contains(out, "fix-1") {
+		t.Errorf("expected both run-1 and fix-1 in output; got:\n%s", out)
+	}
+	// run-1 must NOT be rendered in the in-flight section (it precedes
+	// 'playbook runs:'), so the in-flight line for run-1 should not exist.
+	inflightIdx := strings.Index(out, "in flight:")
+	runIdx := strings.Index(out, "run-1")
+	pbIdx := strings.Index(out, "playbook runs:")
+	if !(runIdx > pbIdx && pbIdx > inflightIdx) {
+		t.Errorf("run-1 should appear under 'playbook runs:' (after it), layout wrong:\n%s", out)
+	}
+}
+
+func TestCmdOwnerShowListsOwnedTasksAndQuestions(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{
+		Slug: "af-maint", Name: "agent-factory maintenance", WorkDir: "/x", Every: "30m",
+		NextWakeAt: sql.NullString{String: "2026-06-08T13:00:00Z", Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// A work unit and a question, both tagged to the owner.
+	insertTask(t, db, "fix-485", "fix #485", "in-progress", "medium", "/x", nil)
+	if err := flowdb.AddTaskTag(db, "fix-485", "owner:af-maint"); err != nil {
+		t.Fatal(err)
+	}
+	insertTask(t, db, "q-flaky", "is the flaky test worth fixing?", "backlog", "medium", "/x", nil)
+	if err := flowdb.AddTaskTag(db, "q-flaky", "owner:af-maint"); err != nil {
+		t.Fatal(err)
+	}
+	if err := flowdb.AddTaskTag(db, "q-flaky", "question"); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(t, func() {
+		if rc := cmdOwner([]string{"show", "af-maint"}); rc != 0 {
+			t.Fatalf("rc=%d", rc)
+		}
+	})
+
+	for _, want := range []string{
+		"af-maint",                // slug
+		"agent-factory maintenance", // name
+		"30m",                     // every
+		"2026-06-08T13:00:00Z",    // next tick
+		"fix-485",                 // owned work unit
+		"q-flaky",                 // owned question
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("show output missing %q; got:\n%s", want, out)
+		}
+	}
+}

--- a/internal/app/owner_test.go
+++ b/internal/app/owner_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"database/sql"
+	"errors"
 	"flow/internal/flowdb"
 	"os"
 	"path/filepath"
@@ -177,6 +178,51 @@ func TestCmdAddTaskWithTags(t *testing.T) {
 	}
 	if len(want) != 0 {
 		t.Errorf("missing tags %v; got %v", want, tags)
+	}
+}
+
+func TestCmdOwnerRetireGraceful(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{Slug: "o1", Name: "O", WorkDir: "/x", Every: "1h"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if rc := cmdOwner([]string{"retire", "o1"}); rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+	o, err := flowdb.GetOwner(db, "o1")
+	if err != nil {
+		t.Fatalf("owner row should still exist after graceful retire: %v", err)
+	}
+	if o.Status != "retired" || !o.ArchivedAt.Valid {
+		t.Errorf("expected retired+archived, got status=%q archived=%v", o.Status, o.ArchivedAt.Valid)
+	}
+
+	if rc := cmdOwner([]string{"retire", "nope"}); rc != 1 {
+		t.Errorf("retiring unknown owner: rc=%d, want 1", rc)
+	}
+}
+
+func TestCmdOwnerRetireDelete(t *testing.T) {
+	root := setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{Slug: "o1", Name: "O", WorkDir: "/x", Every: "1h"}); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(root, "owners", "o1")
+	if err := os.MkdirAll(filepath.Join(dir, "updates"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if rc := cmdOwner([]string{"retire", "o1", "--delete"}); rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+	if _, err := flowdb.GetOwner(db, "o1"); !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("owner row should be deleted, got err=%v", err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("owner directory should be removed")
 	}
 }
 

--- a/internal/app/owner_test.go
+++ b/internal/app/owner_test.go
@@ -83,6 +83,33 @@ func TestCmdOwnerNextRejectsPastTime(t *testing.T) {
 	}
 }
 
+// `flow owner next --at` accepts a date expression (today/tomorrow/
+// weekday), not just an RFC3339 timestamp — via parseOwnerWhen.
+func TestCmdOwnerNextAcceptsDateExpression(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m"}); err != nil {
+		t.Fatal(err)
+	}
+	if rc := cmdOwner([]string{"next", "o1", "--at", "tomorrow"}); rc != 0 {
+		t.Fatalf("--at tomorrow should be accepted, rc=%d", rc)
+	}
+	o, err := flowdb.GetOwner(db, "o1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !o.NextWakeAt.Valid {
+		t.Fatal("next_wake_at should be set")
+	}
+	nt, err := time.Parse(time.RFC3339, o.NextWakeAt.String)
+	if err != nil {
+		t.Fatalf("next_wake_at %q is not RFC3339: %v", o.NextWakeAt.String, err)
+	}
+	if !nt.After(time.Now()) {
+		t.Errorf("next_wake_at %q should be in the future", o.NextWakeAt.String)
+	}
+}
+
 // An explicit --slug that collides with an existing owner should fail with
 // a friendly message, not a raw SQL UNIQUE-constraint error.
 func TestCmdAddOwnerDuplicateSlugFriendlyError(t *testing.T) {

--- a/internal/app/owner_test.go
+++ b/internal/app/owner_test.go
@@ -50,13 +50,24 @@ func TestCmdAddOwnerHappyPath(t *testing.T) {
 	}
 }
 
-func TestCmdAddOwnerRequiresWorkDirAndEvery(t *testing.T) {
+func TestCmdAddOwnerEveryOptionalWithDefault(t *testing.T) {
 	setupFlowRoot(t)
 	wd := t.TempDir()
 
-	if rc := cmdAdd([]string{"owner", "no every", "--work-dir", wd}); rc != 2 {
-		t.Errorf("missing --every: rc=%d, want 2", rc)
+	// --every is now optional (just the fallback heartbeat floor) → defaults.
+	if rc := cmdAdd([]string{"owner", "no every", "--work-dir", wd, "--slug", "noev"}); rc != 0 {
+		t.Fatalf("missing --every should succeed now (defaults), rc=%d", rc)
 	}
+	db := openFlowDB(t)
+	o, err := flowdb.GetOwner(db, "noev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if o.Every != "24h" {
+		t.Errorf("default every = %q, want 24h", o.Every)
+	}
+
+	// --work-dir still required; bad --every still rejected.
 	if rc := cmdAdd([]string{"owner", "no workdir", "--every", "30m"}); rc != 2 {
 		t.Errorf("missing --work-dir: rc=%d, want 2", rc)
 	}

--- a/internal/app/owner_test.go
+++ b/internal/app/owner_test.go
@@ -52,6 +52,96 @@ func TestCmdAddOwnerHappyPath(t *testing.T) {
 	}
 }
 
+// A completed (done) owned task must not show under "in flight".
+func TestCmdOwnerShowExcludesDoneFromInFlight(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m"}); err != nil {
+		t.Fatal(err)
+	}
+	insertTask(t, db, "active-1", "a", "in-progress", "medium", "/x", nil)
+	insertTask(t, db, "done-1", "d", "done", "medium", "/x", nil)
+	for _, s := range []string{"active-1", "done-1"} {
+		if err := flowdb.AddTaskTag(db, s, "owner:o1"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	out := captureStdout(t, func() {
+		if rc := cmdOwner([]string{"show", "o1"}); rc != 0 {
+			t.Fatalf("rc=%d", rc)
+		}
+	})
+	inflight := out[strings.Index(out, "in flight"):]
+	if strings.Contains(inflight, "done-1") {
+		t.Errorf("done task should not appear under 'in flight'; got:\n%s", out)
+	}
+	if !strings.Contains(out, "active-1") {
+		t.Errorf("active task should appear; got:\n%s", out)
+	}
+}
+
+// retire → start must produce a ticking owner again (not an active-but-
+// archived zombie hidden from the list and never dispatched).
+func TestCmdOwnerStartUnretiresZombie(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m"}); err != nil {
+		t.Fatal(err)
+	}
+	if rc := cmdOwner([]string{"retire", "o1"}); rc != 0 {
+		t.Fatalf("retire rc=%d", rc)
+	}
+	if rc := cmdOwner([]string{"start", "o1"}); rc != 0 {
+		t.Fatalf("start rc=%d", rc)
+	}
+	o, _ := flowdb.GetOwner(db, "o1")
+	if o.Status != "active" || o.ArchivedAt.Valid {
+		t.Errorf("start should reactivate + unarchive: status=%q archived=%v", o.Status, o.ArchivedAt)
+	}
+	if lst, _ := flowdb.ListOwners(db, flowdb.OwnerFilter{}); len(lst) != 1 {
+		t.Errorf("reactivated owner should appear in `owner list`, got %d", len(lst))
+	}
+	if due, _ := flowdb.DueOwners(db, flowdb.NowISO()); len(due) != 1 {
+		t.Errorf("reactivated owner should be due, got %d", len(due))
+	}
+}
+
+// `flow list tasks --tag a --tag b` must intersect (AND) — the skill's
+// owner-ledger query (`--tag owner:<slug> --tag question`) depends on it.
+func TestCmdListTasksTagIntersection(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	insertTask(t, db, "q-a", "qa", "backlog", "medium", "/x", nil)
+	insertTask(t, db, "q-b", "qb", "backlog", "medium", "/x", nil)
+	insertTask(t, db, "plain-a", "pa", "backlog", "medium", "/x", nil)
+	tagging := map[string][]string{
+		"q-a":     {"owner:a", "question"},
+		"q-b":     {"owner:b", "question"},
+		"plain-a": {"owner:a"},
+	}
+	for slug, tags := range tagging {
+		for _, tg := range tags {
+			if err := flowdb.AddTaskTag(db, slug, tg); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	out := captureStdout(t, func() {
+		if rc := cmdList([]string{"tasks", "--tag", "owner:a", "--tag", "question", "--format", "tsv"}); rc != 0 {
+			t.Fatalf("rc=%d", rc)
+		}
+	})
+	if !strings.Contains(out, "q-a") {
+		t.Errorf("q-a has BOTH tags and must be listed; out:\n%s", out)
+	}
+	if strings.Contains(out, "q-b") {
+		t.Errorf("q-b has 'question' but not 'owner:a' — must be excluded (intersection); out:\n%s", out)
+	}
+	if strings.Contains(out, "plain-a") {
+		t.Errorf("plain-a has 'owner:a' but not 'question' — must be excluded; out:\n%s", out)
+	}
+}
+
 // `flow owner next` must reject a wake time already in the past — a stale
 // --at (or a negative --in) would leave the owner perpetually due, ticking
 // every scheduler pass.

--- a/internal/app/owner_tick.go
+++ b/internal/app/owner_tick.go
@@ -1,0 +1,244 @@
+package app
+
+import (
+	"database/sql"
+	"flow/internal/flowdb"
+	"flow/internal/harness"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+// The owner tick + scheduler (time-based, MVP).
+//
+//	flow owner tick-due          (scheduler entry — call on an interval, e.g. launchd)
+//	  ├─ DueOwners: active owners whose next_wake_at <= now
+//	  ├─ for each: advance next_wake_at = now + every (so the next scan
+//	  │  doesn't re-dispatch it) and launch a DETACHED tick
+//	  └─ returns
+//
+//	flow __owner-tick <slug>     (the detached tick; hidden subcommand)
+//	  ├─ builds the tick prompt, runs the owner's harness HEADLESSLY and
+//	  │  SESSIONLESS (a fresh session each tick — owners are not one long
+//	  │  Claude chat), blocking until it exits
+//	  └─ records last_tick_at + last_tick_status ('ok' | 'error')
+//
+// Each tick reads the owner's charter, reviews what it owns (tasks tagged
+// owner:<slug>), acts, and parks human decisions as question-tasks. MVP
+// limitation: a tick that runs longer than `every` may overlap the next
+// dispatch — there is no run-liveness guard yet.
+
+// ownerTickRunner executes one headless, sessionless tick for the owner
+// via its harness. SkipPermissionsRun starts a FRESH session each call
+// (no pinned session id) — the owner's memory is its durable charter +
+// ledger, not a resumed transcript. Overridable in tests.
+var ownerTickRunner = func(h harness.Harness, prompt string) error {
+	return h.SkipPermissionsRun(prompt)
+}
+
+// ownerTickLauncher starts the detached `flow __owner-tick <slug>`
+// process: own session (Setsid), cwd=workDir, stdout/stderr→logPath.
+// Overridable in tests.
+var ownerTickLauncher = func(slug, workDir, logPath string, env []string) (int, error) {
+	self, err := os.Executable()
+	if err != nil {
+		return 0, fmt.Errorf("locate flow binary: %w", err)
+	}
+	logF, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return 0, fmt.Errorf("open log %s: %w", logPath, err)
+	}
+	defer logF.Close()
+
+	cmd := exec.Command(self, "__owner-tick", slug)
+	cmd.Dir = workDir
+	cmd.Env = env
+	cmd.Stdin = nil
+	cmd.Stdout = logF
+	cmd.Stderr = logF
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		return 0, fmt.Errorf("start owner tick: %w", err)
+	}
+	pid := cmd.Process.Pid
+	_ = cmd.Process.Release()
+	return pid, nil
+}
+
+// ownerTickDue implements `flow owner tick-due`: the scheduler pass that
+// the OS timer (launchd) invokes on an interval.
+func ownerTickDue(args []string) int {
+	fs := flagSet("owner tick-due")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	dbPath, err := flowDBPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	db, err := openConcurrentDB(dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	defer db.Close()
+
+	root, err := flowRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	now := time.Now()
+	due, err := flowdb.DueOwners(db, now.Format(time.RFC3339))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	dispatched := 0
+	for _, o := range due {
+		dur, derr := time.ParseDuration(o.Every)
+		if derr != nil {
+			fmt.Fprintf(os.Stderr, "warning: owner %q has invalid every %q: %v; skipping\n", o.Slug, o.Every, derr)
+			continue
+		}
+		ticksDir := filepath.Join(root, "owners", o.Slug, "ticks")
+		if err := os.MkdirAll(ticksDir, 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: mkdir ticks for %q: %v\n", o.Slug, err)
+			continue
+		}
+		logPath := filepath.Join(ticksDir, now.UTC().Format("2006-01-02-150405")+".log")
+		pid, err := ownerTickLauncher(o.Slug, o.WorkDir, logPath, autoChildEnv())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: launch tick for %q: %v\n", o.Slug, err)
+			continue
+		}
+		// Advance the schedule (so the next scan doesn't re-dispatch) and
+		// record the running tick (pid + start) in one write.
+		o.NextWakeAt = sql.NullString{String: now.Add(dur).Format(time.RFC3339), Valid: true}
+		o.TickPID = sql.NullInt64{Int64: int64(pid), Valid: true}
+		o.TickStarted = sql.NullString{String: now.Format(time.RFC3339), Valid: true}
+		if err := flowdb.UpdateOwner(db, o); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: record tick for %q: %v\n", o.Slug, err)
+			continue
+		}
+		dispatched++
+	}
+	fmt.Printf("dispatched %d owner tick(s)\n", dispatched)
+	return 0
+}
+
+// cmdOwnerTick is the hidden `flow __owner-tick <slug>` supervisor that
+// runs inside the detached process: build the tick prompt, run the
+// owner's harness headlessly to completion, then record the tick.
+func cmdOwnerTick(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "error: __owner-tick requires an owner slug")
+		return 2
+	}
+	slug := args[0]
+
+	dbPath, err := flowDBPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	db, err := openConcurrentDB(dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	defer db.Close()
+
+	o, err := flowdb.GetOwner(db, slug)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: load owner %q: %v\n", slug, err)
+		return 1
+	}
+
+	var hname string
+	if o.Harness.Valid {
+		hname = o.Harness.String
+	}
+	h, herr := harnessByName(hname)
+	if herr != nil {
+		fmt.Fprintf(os.Stderr, "error: resolve harness for %q: %v\n", slug, herr)
+		_ = recordOwnerTick(db, o, "error")
+		return 1
+	}
+
+	prompt := buildOwnerTickPrompt(o.Slug)
+	runErr := ownerTickRunner(h, prompt)
+
+	status := "ok"
+	if runErr != nil {
+		status = "error"
+	}
+	if err := recordOwnerTick(db, o, status); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: record tick for %q: %v\n", slug, err)
+	}
+	if runErr != nil {
+		fmt.Fprintf(os.Stderr, "owner tick for %q failed: %v\n", slug, runErr)
+		return 1
+	}
+	fmt.Printf("owner tick for %q finished: %s\n", slug, status)
+	return 0
+}
+
+// recordOwnerTick stamps last_tick_at + last_tick_status on the owner and
+// clears the running-tick bookkeeping (the tick is over).
+func recordOwnerTick(db *sql.DB, o *flowdb.Owner, status string) error {
+	o.LastTickAt = sql.NullString{String: flowdb.NowISO(), Valid: true}
+	o.LastTickStatus = sql.NullString{String: status, Valid: true}
+	o.TickPID = sql.NullInt64{}
+	o.TickStarted = sql.NullString{}
+	return flowdb.UpdateOwner(db, o)
+}
+
+// reconcileOwnerTick promotes a stale running tick to 'dead' when its
+// supervisor pid is no longer alive (crash, kill, reboot — anything that
+// prevented recordOwnerTick from running). No-op when no tick is recorded
+// running or the pid is still alive. Mutates both the DB and the in-memory
+// owner so the caller renders the reconciled state. Best-effort.
+func reconcileOwnerTick(db *sql.DB, o *flowdb.Owner) {
+	if !o.TickPID.Valid {
+		return
+	}
+	if processAlive(int(o.TickPID.Int64)) {
+		return // genuinely running
+	}
+	o.LastTickStatus = sql.NullString{String: "dead", Valid: true}
+	if !o.LastTickAt.Valid {
+		o.LastTickAt = sql.NullString{String: flowdb.NowISO(), Valid: true}
+	}
+	o.TickPID = sql.NullInt64{}
+	o.TickStarted = sql.NullString{}
+	_ = flowdb.UpdateOwner(db, o)
+}
+
+// buildOwnerTickPrompt is the bootstrap prompt for one headless owner
+// tick. The owner reads its charter, reviews what it owns, acts, and
+// parks any human decision as a question-task rather than blocking.
+func buildOwnerTickPrompt(slug string) string {
+	return fmt.Sprintf(
+		"You are the autonomous OWNER %q running ONE tick. You are headless: NO human is watching and there is no terminal — do NOT use AskUserQuestion and do NOT wait for input.\n\n"+
+			"YOU ORCHESTRATE; YOU NEVER EXECUTE WORK INLINE. A tick is a sessionless run with NO `flow done` close-out, so any real work you do directly here is LOST to the knowledge base and leaves no transcript. So do NOT do substantive work yourself in this tick — instead route EVERY piece of work through a task or a playbook, which run as their own sessions and self-close with the `flow done` KB + project sweep:\n"+
+			"  - RECURRING work → a PLAYBOOK. If one doesn't exist, create it (flow add playbook ...); then trigger a run: `flow run playbook <slug> --auto`. Tag the run owner:%s.\n"+
+			"  - ONE-TIME work → a TASK. Create it: `flow add task \"<what to do>\" --tag owner:%s`, then run it headlessly: `flow do --auto <task>`. It self-`flow done`s, firing the close-out sweep that captures learnings.\n"+
+			"  - A decision only the HUMAN can make → a QUESTION task: `flow add task \"<the question>\" --tag question --tag owner:%s`, then move on.\n\n"+
+			"Do these in order:\n"+
+			"1. Invoke the flow skill via the Skill tool.\n"+
+			"2. Read your charter at owners/%s/charter.md — your operating manual (what you own, how to observe, when to ask, when to escalate).\n"+
+			"3. Review what you already own: `flow list tasks --tag owner:%s` — in-flight work units, runs, and open questions. Advance/check on them; never duplicate work already tracked.\n"+
+			"4. Observe the world per your charter, then DISPATCH what needs doing as playbook-runs / tasks / questions per the rule above. Keep the tick SHORT — spin work out, never perform it inline.\n"+
+			"5. Be conservative with irreversible or outward-facing actions (push, PR, deploy, messaging) unless your charter EXPLICITLY authorizes them.\n"+
+			"6. When you've dispatched this tick's work, exit. Your next tick is scheduled automatically. Do not loop or wait.\n",
+		slug, slug, slug, slug, slug, slug,
+	)
+}

--- a/internal/app/owner_tick.go
+++ b/internal/app/owner_tick.go
@@ -168,7 +168,12 @@ func ownerTickManual(args []string) int {
 		return 0
 	}
 
-	if err := ownerInteractiveLauncher(o, buildOwnerTickPromptInteractive(slug)); err != nil {
+	ownerDir, derr := ownerDirFor(slug)
+	if derr != nil {
+		fmt.Fprintf(os.Stderr, "error: resolve owner dir for %q: %v\n", slug, derr)
+		return 1
+	}
+	if err := ownerInteractiveLauncher(o, buildOwnerTickPromptInteractive(slug, ownerDir)); err != nil {
 		fmt.Fprintf(os.Stderr, "error: spawn interactive tick: %v\n", err)
 		return 1
 	}
@@ -225,7 +230,7 @@ func ownerTickDue(args []string) int {
 		// tick_pid), don't stack another on top of it. A dead pid (crashed
 		// tick) is not alive, so we fall through and dispatch a fresh one
 		// (which overwrites the stale pid below).
-		if o.TickPID.Valid && processAlive(int(o.TickPID.Int64)) {
+		if o.TickPID.Valid && processAlive(int(o.TickPID.Int64)) && !ownerTickStale(o) {
 			continue
 		}
 		dur, derr := time.ParseDuration(o.Every)
@@ -294,6 +299,12 @@ func cmdOwnerTick(args []string) int {
 	// paused owner). Skip cleanly without running the harness or recording
 	// a tick.
 	if o.Status != "active" {
+		// A pending dispatch may have stamped tick_pid before this owner was
+		// paused/retired. Clear it so the owner isn't shown as "tick running"
+		// and the reconciler doesn't later mislabel this clean skip as 'dead'.
+		if o.TickPID.Valid {
+			_ = clearOwnerTickBookkeeping(db, slug)
+		}
 		fmt.Printf("owner %q is %s (not active) — skipping tick\n", slug, o.Status)
 		return 0
 	}
@@ -309,7 +320,13 @@ func cmdOwnerTick(args []string) int {
 		return 1
 	}
 
-	prompt := buildOwnerTickPrompt(o.Slug)
+	ownerDir, derr := ownerDirFor(o.Slug)
+	if derr != nil {
+		fmt.Fprintf(os.Stderr, "error: resolve owner dir for %q: %v\n", slug, derr)
+		_ = recordOwnerTick(db, slug, "error")
+		return 1
+	}
+	prompt := buildOwnerTickPrompt(o.Slug, ownerDir)
 	runErr := ownerTickRunner(h, prompt)
 
 	status := "ok"
@@ -342,6 +359,51 @@ func cmdOwnerTick(args []string) int {
 // scheduler records the pid leaves a stale (dead) pid set, which the
 // dead-pid reconcile (reconcileOwnerTick / DueOwners overlap guard) heals
 // on the next read or scan. No durable result is lost.
+
+// ownerTickStaleAfter caps how long a recorded tick_pid is trusted. A tick
+// orchestrates and exits in minutes; a pid still "alive" long after
+// tick_started is almost certainly pid-reuse (the original supervisor died
+// — e.g. reboot — and an unrelated process now holds that pid, which
+// processAlive reports as alive, incl. EPERM=alive for another user's
+// process). Without this cap such an owner would be skipped by the overlap
+// guard forever. One hour is far beyond any real tick.
+const ownerTickStaleAfter = time.Hour
+
+// ownerTickStale reports whether a recorded tick has been "running" longer
+// than ownerTickStaleAfter (so its pid should not be trusted).
+func ownerTickStale(o *flowdb.Owner) bool {
+	if !o.TickStarted.Valid {
+		return false
+	}
+	started, err := time.Parse(time.RFC3339, o.TickStarted.String)
+	if err != nil {
+		return false
+	}
+	return time.Since(started) > ownerTickStaleAfter
+}
+
+// ownerDirFor returns the absolute on-disk directory for an owner
+// ($FLOW_ROOT/owners/<slug>) — where its charter and journal live. Tick
+// prompts use this so a headless run (cwd=work_dir) reads/writes the real
+// files instead of creating an owners/ dir inside the user's repo.
+func ownerDirFor(slug string) (string, error) {
+	root, err := flowRoot()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "owners", slug), nil
+}
+
+// clearOwnerTickBookkeeping clears tick_pid/tick_started without recording a
+// tick result — used when a dispatched tick is skipped (e.g. owner no longer
+// active) so a stale pid isn't left behind.
+func clearOwnerTickBookkeeping(db *sql.DB, slug string) error {
+	_, err := db.Exec(
+		`UPDATE owners SET tick_pid=NULL, tick_started=NULL, updated_at=? WHERE slug=?`,
+		flowdb.NowISO(), slug,
+	)
+	return err
+}
 
 // recordOwnerTickStarted stamps the running-tick bookkeeping (pid + start)
 // for a hand-triggered headless tick. It does not advance the schedule.
@@ -397,7 +459,7 @@ func reconcileOwnerTick(db *sql.DB, o *flowdb.Owner) {
 	if !o.TickPID.Valid {
 		return
 	}
-	if processAlive(int(o.TickPID.Int64)) {
+	if processAlive(int(o.TickPID.Int64)) && !ownerTickStale(o) {
 		return // genuinely running
 	}
 	now := flowdb.NowISO()
@@ -426,29 +488,29 @@ func reconcileOwnerTick(db *sql.DB, o *flowdb.Owner) {
 // journal discipline as the headless tick, but the human can guide it: it
 // MAY use AskUserQuestion, and it folds anything learned back into the
 // charter so future headless ticks improve.
-func buildOwnerTickPromptInteractive(slug string) string {
+func buildOwnerTickPromptInteractive(slug, ownerDir string) string {
 	return fmt.Sprintf(
-		"You are running ONE tick of the flow OWNER %q — INTERACTIVELY, with the user present (often the FIRST tick, to help you navigate). You MAY use AskUserQuestion to clarify intent, confirm a plan, or resolve charter ambiguity, and the user can course-correct you. If the charter is unclear or wrong, work it out WITH the user and update owners/%s/charter.md so future HEADLESS ticks behave correctly.\n\n"+
+		"You are running ONE tick of the flow OWNER %q — INTERACTIVELY, with the user present (often the FIRST tick, to help you navigate). You MAY use AskUserQuestion to clarify intent, confirm a plan, or resolve charter ambiguity, and the user can course-correct you. If the charter is unclear or wrong, work it out WITH the user and update %s/charter.md so future HEADLESS ticks behave correctly.\n\n"+
 			"You still ORCHESTRATE; you NEVER execute work inline. A tick gets no `flow done` close-out sweep, so route real work through tasks/playbooks that self-close:\n"+
 			"  - RECURRING work → a PLAYBOOK: create if needed, then `flow run playbook <slug> --auto`. Tag the run owner:%s.\n"+
 			"  - ONE-TIME work → a TASK: `flow add task \"<what>\" --tag owner:%s`, then `flow do --auto <task>`.\n"+
 			"  - A decision for the user → just ASK them (you're interactive), or park a QUESTION task (`--tag question --tag owner:%s`) for later.\n\n"+
 			"Do these in order:\n"+
 			"1. Invoke the flow skill via the Skill tool.\n"+
-			"2. Read your charter at owners/%s/charter.md.\n"+
-			"3. Read recent notes under owners/%s/updates/ (your journal), then review what you own with `flow owner show %s` (tasks, playbook runs, and questions with status). Don't duplicate tracked work or re-spawn an in-progress run.\n"+
+			"2. Read your charter at %s/charter.md (absolute path — your charter and journal live under $FLOW_ROOT, NOT your work_dir).\n"+
+			"3. Read recent notes under %s/updates/ (your journal), then review what you own with `flow owner show %s` (tasks, playbook runs, and questions with status). Don't duplicate tracked work or re-spawn an in-progress run.\n"+
 			"4. Observe per the charter and, together with the user, DISPATCH the needed playbook-runs / tasks / questions.\n"+
 			"5. Be conservative with irreversible/outward actions unless the charter authorizes them (when unsure, ask the user).\n"+
-			"6. Before finishing, WRITE a short note to owners/%s/updates/<today>-tick.md (what you observed, what you dispatched with slugs, what the next tick should check), and fold any lessons into the charter so headless ticks improve.\n"+
+			"6. Before finishing, WRITE a short note to %s/updates/<today>-tick.md (what you observed, what you dispatched with slugs, what the next tick should check), and fold any lessons into the charter so headless ticks improve.\n"+
 			"7. SELF-PACE the next wake: decide when you next need to run and set it with `flow owner next %s --in <duration>` (or --at <time>). You pick the cadence yourself each run — no need to ask the user about timing; --every is only a fallback.\n",
-		slug, slug, slug, slug, slug, slug, slug, slug, slug, slug,
+		slug, ownerDir, slug, slug, slug, ownerDir, ownerDir, slug, ownerDir, slug,
 	)
 }
 
 // buildOwnerTickPrompt is the bootstrap prompt for one headless owner
 // tick. The owner reads its charter, reviews what it owns, acts, and
 // parks any human decision as a question-task rather than blocking.
-func buildOwnerTickPrompt(slug string) string {
+func buildOwnerTickPrompt(slug, ownerDir string) string {
 	return fmt.Sprintf(
 		"You are the autonomous OWNER %q running ONE tick. You are headless: NO human is watching and there is no terminal — do NOT use AskUserQuestion and do NOT wait for input.\n\n"+
 			"YOU ORCHESTRATE; YOU NEVER EXECUTE WORK INLINE. A tick is a sessionless run with NO `flow done` close-out, so any real work you do directly here is LOST to the knowledge base and leaves no transcript. So do NOT do substantive work yourself in this tick — instead route EVERY piece of work through a task or a playbook, which run as their own sessions and self-close with the `flow done` KB + project sweep:\n"+
@@ -457,13 +519,13 @@ func buildOwnerTickPrompt(slug string) string {
 			"  - A decision only the HUMAN can make → a QUESTION task: `flow add task \"<the question>\" --tag question --tag owner:%s`, then move on.\n\n"+
 			"Do these in order:\n"+
 			"1. Invoke the flow skill via the Skill tool.\n"+
-			"2. Read your charter at owners/%s/charter.md — your operating manual (what you own, how to observe, when to ask, when to escalate).\n"+
-			"3. Catch up on yourself: read the most recent note(s) under owners/%s/updates/ — that is your JOURNAL from prior ticks (what you dispatched, what you were waiting on, what to check now). Then review everything you own with `flow owner show %s` — it lists your in-flight tasks, playbook runs, AND open questions with their current status (do NOT use `flow list tasks`, which hides playbook runs). Advance or check on what's there; never duplicate work already tracked and never re-spawn a run that is still in progress.\n"+
+			"2. Read your charter at %s/charter.md — your operating manual (what you own, how to observe, when to ask, when to escalate). This is an ABSOLUTE path: your charter and journal live under $FLOW_ROOT, NOT your work_dir — do not create an `owners/` directory in the repo.\n"+
+			"3. Catch up on yourself: read the most recent note(s) under %s/updates/ — that is your JOURNAL from prior ticks (what you dispatched, what you were waiting on, what to check now). Then review everything you own with `flow owner show %s` — it lists your in-flight tasks, playbook runs, AND open questions with their current status (do NOT use `flow list tasks`, which hides playbook runs). Advance or check on what's there; never duplicate work already tracked and never re-spawn a run that is still in progress.\n"+
 			"4. Observe the world per your charter, then DISPATCH what needs doing as playbook-runs / tasks / questions per the rule above. Keep the tick SHORT — spin work out, never perform it inline.\n"+
 			"5. Be conservative with irreversible or outward-facing actions (push, PR, deploy, messaging) unless your charter EXPLICITLY authorizes them.\n"+
-			"6. WRITE a short note to owners/%s/updates/<today>-tick.md recording what you observed, what you dispatched (with the task/run slugs), and what your NEXT tick should check. This is your memory — the next tick starts from a blank session and knows only what you write here plus the task records.\n"+
+			"6. WRITE a short note to %s/updates/<today>-tick.md recording what you observed, what you dispatched (with the task/run slugs), and what your NEXT tick should check. This is your memory — the next tick starts from a blank session and knows only what you write here plus the task records.\n"+
 			"7. SELF-PACE: decide when you next need to run and set it with `flow owner next %s --in <duration>` (e.g. +15m if watching a deploy/CI, +1h if a review is pending; use --at <time> for longer/idle gaps). You choose the cadence per-run; if you skip this, the owner falls back to its --every interval.\n"+
 			"8. Then exit. Do not loop or wait.\n",
-		slug, slug, slug, slug, slug, slug, slug, slug, slug,
+		slug, slug, slug, slug, ownerDir, ownerDir, slug, ownerDir, slug,
 	)
 }

--- a/internal/app/owner_tick.go
+++ b/internal/app/owner_tick.go
@@ -133,6 +133,16 @@ func ownerTickManual(args []string) int {
 		return 1
 	}
 
+	// A paused/retired owner does not tick. Refuse the hand-triggered tick
+	// with guidance rather than silently spawning a session that
+	// contradicts the owner's state.
+	if o.Status != "active" {
+		fmt.Fprintf(os.Stderr,
+			"error: owner %q is %s — resume it first with `flow owner start %s` (a paused/retired owner does not tick)\n",
+			slug, o.Status, slug)
+		return 1
+	}
+
 	if *auto {
 		root, err := flowRoot()
 		if err != nil {
@@ -276,6 +286,16 @@ func cmdOwnerTick(args []string) int {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: load owner %q: %v\n", slug, err)
 		return 1
+	}
+
+	// Status guard: only active owners tick. The scheduler already filters
+	// via DueOwners, but an owner can be paused/retired in the window
+	// between dispatch and this detached run (or a manual --auto on a
+	// paused owner). Skip cleanly without running the harness or recording
+	// a tick.
+	if o.Status != "active" {
+		fmt.Printf("owner %q is %s (not active) — skipping tick\n", slug, o.Status)
+		return 0
 	}
 
 	var hname string

--- a/internal/app/owner_tick.go
+++ b/internal/app/owner_tick.go
@@ -235,10 +235,11 @@ func buildOwnerTickPrompt(slug string) string {
 			"Do these in order:\n"+
 			"1. Invoke the flow skill via the Skill tool.\n"+
 			"2. Read your charter at owners/%s/charter.md — your operating manual (what you own, how to observe, when to ask, when to escalate).\n"+
-			"3. Review what you already own: `flow list tasks --tag owner:%s` — in-flight work units, runs, and open questions. Advance/check on them; never duplicate work already tracked.\n"+
+			"3. Catch up on yourself: read the most recent note(s) under owners/%s/updates/ — that is your JOURNAL from prior ticks (what you dispatched, what you were waiting on, what to check now). Then review everything you own with `flow owner show %s` — it lists your in-flight tasks, playbook runs, AND open questions with their current status (do NOT use `flow list tasks`, which hides playbook runs). Advance or check on what's there; never duplicate work already tracked and never re-spawn a run that is still in progress.\n"+
 			"4. Observe the world per your charter, then DISPATCH what needs doing as playbook-runs / tasks / questions per the rule above. Keep the tick SHORT — spin work out, never perform it inline.\n"+
 			"5. Be conservative with irreversible or outward-facing actions (push, PR, deploy, messaging) unless your charter EXPLICITLY authorizes them.\n"+
-			"6. When you've dispatched this tick's work, exit. Your next tick is scheduled automatically. Do not loop or wait.\n",
-		slug, slug, slug, slug, slug, slug,
+			"6. Before you exit, WRITE a short note to owners/%s/updates/<today>-tick.md recording what you observed, what you dispatched (with the task/run slugs), and what your NEXT tick should check. This is your memory — the next tick starts from a blank session and knows only what you write here plus the task records.\n"+
+			"7. Then exit. Your next tick is scheduled automatically. Do not loop or wait.\n",
+		slug, slug, slug, slug, slug, slug, slug, slug,
 	)
 }

--- a/internal/app/owner_tick.go
+++ b/internal/app/owner_tick.go
@@ -151,9 +151,7 @@ func ownerTickManual(args []string) int {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			return 1
 		}
-		o.TickPID = sql.NullInt64{Int64: int64(pid), Valid: true}
-		o.TickStarted = sql.NullString{String: now.Format(time.RFC3339), Valid: true}
-		if err := flowdb.UpdateOwner(db, o); err != nil {
+		if err := recordOwnerTickStarted(db, slug, pid, now.Format(time.RFC3339)); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: record tick for %q: %v\n", slug, err)
 		}
 		fmt.Printf("dispatched a headless tick for owner %q (pid %d)\n", slug, pid)
@@ -167,11 +165,11 @@ func ownerTickManual(args []string) int {
 	// Record that an interactive tick was launched. We can't track its
 	// completion (the user drives the tab, there's no process we wait on),
 	// so we mark last_tick now with status 'interactive' — enough that
-	// `flow owner show` reflects a tick ran instead of "(never)". The
-	// session itself self-paces (`flow owner next`) and journals.
-	o.LastTickAt = sql.NullString{String: flowdb.NowISO(), Valid: true}
-	o.LastTickStatus = sql.NullString{String: "interactive", Valid: true}
-	if err := flowdb.UpdateOwner(db, o); err != nil {
+	// `flow owner show` reflects a tick ran instead of "(never)". Targeted
+	// update (last_tick_* only) so it never overwrites next_wake_at — the
+	// interactive session self-paces via `flow owner next` and that write
+	// must win regardless of ordering.
+	if err := recordOwnerInteractiveTick(db, slug); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: record interactive tick for %q: %v\n", slug, err)
 	}
 	fmt.Printf("opened an interactive tick for owner %q — drive it in the new tab\n", slug)
@@ -237,11 +235,12 @@ func ownerTickDue(args []string) int {
 			continue
 		}
 		// Advance the schedule (so the next scan doesn't re-dispatch) and
-		// record the running tick (pid + start) in one write.
-		o.NextWakeAt = sql.NullString{String: now.Add(dur).Format(time.RFC3339), Valid: true}
-		o.TickPID = sql.NullInt64{Int64: int64(pid), Valid: true}
-		o.TickStarted = sql.NullString{String: now.Format(time.RFC3339), Valid: true}
-		if err := flowdb.UpdateOwner(db, o); err != nil {
+		// record the running tick (pid + start). Targeted column update —
+		// NOT a full-row write — so it can't clobber last_tick_* if the
+		// detached tick has already finished and recorded its result (the
+		// dispatch-vs-finish race).
+		if err := recordOwnerTickDispatched(db, o.Slug, pid,
+			now.Format(time.RFC3339), now.Add(dur).Format(time.RFC3339)); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: record tick for %q: %v\n", o.Slug, err)
 			continue
 		}
@@ -286,7 +285,7 @@ func cmdOwnerTick(args []string) int {
 	h, herr := harnessByName(hname)
 	if herr != nil {
 		fmt.Fprintf(os.Stderr, "error: resolve harness for %q: %v\n", slug, herr)
-		_ = recordOwnerTick(db, o, "error")
+		_ = recordOwnerTick(db, slug, "error")
 		return 1
 	}
 
@@ -297,7 +296,7 @@ func cmdOwnerTick(args []string) int {
 	if runErr != nil {
 		status = "error"
 	}
-	if err := recordOwnerTick(db, o, status); err != nil {
+	if err := recordOwnerTick(db, slug, status); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: record tick for %q: %v\n", slug, err)
 	}
 	if runErr != nil {
@@ -308,14 +307,65 @@ func cmdOwnerTick(args []string) int {
 	return 0
 }
 
-// recordOwnerTick stamps last_tick_at + last_tick_status on the owner and
-// clears the running-tick bookkeeping (the tick is over).
-func recordOwnerTick(db *sql.DB, o *flowdb.Owner, status string) error {
-	o.LastTickAt = sql.NullString{String: flowdb.NowISO(), Valid: true}
-	o.LastTickStatus = sql.NullString{String: status, Valid: true}
-	o.TickPID = sql.NullInt64{}
-	o.TickStarted = sql.NullString{}
-	return flowdb.UpdateOwner(db, o)
+// The tick-bookkeeping writes below are deliberately TARGETED column
+// updates rather than the full-row flowdb.UpdateOwner. The scheduler
+// (parent) and the detached tick (child) write the owner row
+// concurrently — a full-row write of either's stale in-memory struct
+// clobbers the other's columns. By having each writer touch only the
+// columns it owns, the writes commute:
+//
+//	dispatch/start → tick_pid, tick_started (+ next_wake_at for the scheduler)
+//	finish         → last_tick_at, last_tick_status, clear tick_pid/tick_started
+//	self-pace      → next_wake_at (written by the tick via `flow owner next`)
+//
+// The one remaining overlap is tick_pid: a tick that finishes before the
+// scheduler records the pid leaves a stale (dead) pid set, which the
+// dead-pid reconcile (reconcileOwnerTick / DueOwners overlap guard) heals
+// on the next read or scan. No durable result is lost.
+
+// recordOwnerTickStarted stamps the running-tick bookkeeping (pid + start)
+// for a hand-triggered headless tick. It does not advance the schedule.
+func recordOwnerTickStarted(db *sql.DB, slug string, pid int, started string) error {
+	_, err := db.Exec(
+		`UPDATE owners SET tick_pid=?, tick_started=?, updated_at=? WHERE slug=?`,
+		pid, started, flowdb.NowISO(), slug,
+	)
+	return err
+}
+
+// recordOwnerTickDispatched is recordOwnerTickStarted plus advancing the
+// schedule floor (next_wake_at) — the scheduler dispatch path.
+func recordOwnerTickDispatched(db *sql.DB, slug string, pid int, started, nextWakeAt string) error {
+	_, err := db.Exec(
+		`UPDATE owners SET tick_pid=?, tick_started=?, next_wake_at=?, updated_at=? WHERE slug=?`,
+		pid, started, nextWakeAt, flowdb.NowISO(), slug,
+	)
+	return err
+}
+
+// recordOwnerInteractiveTick marks a hand-triggered interactive tick as
+// having run (last_tick_* only). It leaves next_wake_at untouched so the
+// interactive session's own `flow owner next` self-pacing wins.
+func recordOwnerInteractiveTick(db *sql.DB, slug string) error {
+	now := flowdb.NowISO()
+	_, err := db.Exec(
+		`UPDATE owners SET last_tick_at=?, last_tick_status='interactive', updated_at=? WHERE slug=?`,
+		now, now, slug,
+	)
+	return err
+}
+
+// recordOwnerTick stamps last_tick_at + last_tick_status and clears the
+// running-tick bookkeeping (the tick is over). Targeted update — it never
+// touches next_wake_at, so a next-wake the tick set mid-run via
+// `flow owner next` survives.
+func recordOwnerTick(db *sql.DB, slug, status string) error {
+	now := flowdb.NowISO()
+	_, err := db.Exec(
+		`UPDATE owners SET last_tick_at=?, last_tick_status=?, tick_pid=NULL, tick_started=NULL, updated_at=? WHERE slug=?`,
+		now, status, now, slug,
+	)
+	return err
 }
 
 // reconcileOwnerTick promotes a stale running tick to 'dead' when its
@@ -330,13 +380,25 @@ func reconcileOwnerTick(db *sql.DB, o *flowdb.Owner) {
 	if processAlive(int(o.TickPID.Int64)) {
 		return // genuinely running
 	}
+	now := flowdb.NowISO()
+	// Targeted + guarded: only promote to 'dead' while a tick_pid is still
+	// recorded. If a real finish (recordOwnerTick) lands between the
+	// processAlive check and this write, it clears tick_pid first and the
+	// WHERE no longer matches — so we never overwrite a genuine 'ok'/'error'
+	// result with 'dead'.
+	if _, err := db.Exec(
+		`UPDATE owners SET last_tick_status='dead', last_tick_at=COALESCE(last_tick_at, ?),
+		 tick_pid=NULL, tick_started=NULL, updated_at=? WHERE slug=? AND tick_pid IS NOT NULL`,
+		now, now, o.Slug,
+	); err != nil {
+		return
+	}
 	o.LastTickStatus = sql.NullString{String: "dead", Valid: true}
 	if !o.LastTickAt.Valid {
-		o.LastTickAt = sql.NullString{String: flowdb.NowISO(), Valid: true}
+		o.LastTickAt = sql.NullString{String: now, Valid: true}
 	}
 	o.TickPID = sql.NullInt64{}
 	o.TickStarted = sql.NullString{}
-	_ = flowdb.UpdateOwner(db, o)
 }
 
 // buildOwnerTickPromptInteractive is the prompt for a hand-triggered tick

--- a/internal/app/owner_tick.go
+++ b/internal/app/owner_tick.go
@@ -164,6 +164,16 @@ func ownerTickManual(args []string) int {
 		fmt.Fprintf(os.Stderr, "error: spawn interactive tick: %v\n", err)
 		return 1
 	}
+	// Record that an interactive tick was launched. We can't track its
+	// completion (the user drives the tab, there's no process we wait on),
+	// so we mark last_tick now with status 'interactive' — enough that
+	// `flow owner show` reflects a tick ran instead of "(never)". The
+	// session itself self-paces (`flow owner next`) and journals.
+	o.LastTickAt = sql.NullString{String: flowdb.NowISO(), Valid: true}
+	o.LastTickStatus = sql.NullString{String: "interactive", Valid: true}
+	if err := flowdb.UpdateOwner(db, o); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: record interactive tick for %q: %v\n", slug, err)
+	}
 	fmt.Printf("opened an interactive tick for owner %q — drive it in the new tab\n", slug)
 	return 0
 }

--- a/internal/app/owner_tick.go
+++ b/internal/app/owner_tick.go
@@ -144,6 +144,16 @@ func ownerTickManual(args []string) int {
 	}
 
 	if *auto {
+		// Overlap guard (same as the scheduler's): don't stack a headless
+		// tick on top of one already running — important now that event
+		// triggers (`flow owner tick --auto` from a watcher) can race a
+		// scheduled tick. A dead or stale pid falls through and is replaced.
+		if o.TickPID.Valid && processAlive(int(o.TickPID.Int64)) && !ownerTickStale(o) {
+			fmt.Fprintf(os.Stderr,
+				"error: owner %q already has a tick running (pid %d) — wait for it to finish\n",
+				slug, o.TickPID.Int64)
+			return 1
+		}
 		root, err := flowRoot()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/internal/app/owner_tick.go
+++ b/internal/app/owner_tick.go
@@ -203,6 +203,13 @@ func ownerTickDue(args []string) int {
 
 	dispatched := 0
 	for _, o := range due {
+		// Overlap guard: if a tick is already running for this owner (a live
+		// tick_pid), don't stack another on top of it. A dead pid (crashed
+		// tick) is not alive, so we fall through and dispatch a fresh one
+		// (which overwrites the stale pid below).
+		if o.TickPID.Valid && processAlive(int(o.TickPID.Int64)) {
+			continue
+		}
 		dur, derr := time.ParseDuration(o.Every)
 		if derr != nil {
 			fmt.Fprintf(os.Stderr, "warning: owner %q has invalid every %q: %v; skipping\n", o.Slug, o.Every, derr)

--- a/internal/app/owner_tick.go
+++ b/internal/app/owner_tick.go
@@ -2,8 +2,10 @@ package app
 
 import (
 	"database/sql"
+	"errors"
 	"flow/internal/flowdb"
 	"flow/internal/harness"
+	"flow/internal/spawner"
 	"fmt"
 	"os"
 	"os/exec"
@@ -66,6 +68,104 @@ var ownerTickLauncher = func(slug, workDir, logPath string, env []string) (int, 
 	pid := cmd.Process.Pid
 	_ = cmd.Process.Release()
 	return pid, nil
+}
+
+// ownerInteractiveLauncher spawns an interactive terminal tab running one
+// owner tick with the human present (the hand-triggered / first-run path).
+// It mints a throwaway session (not bound to the owner) and reuses the same
+// spawn machinery as `flow do`. Overridable in tests.
+var ownerInteractiveLauncher = func(o *flowdb.Owner, prompt string) error {
+	var hname string
+	if o.Harness.Valid {
+		hname = o.Harness.String
+	}
+	h, err := harnessByName(hname)
+	if err != nil {
+		return err
+	}
+	sid, err := h.NewSessionID()
+	if err != nil {
+		return fmt.Errorf("new session id: %w", err)
+	}
+	command := h.LaunchCmd(sid, prompt, harness.LaunchOpts{})
+	var spawnEnv map[string]string
+	if root := os.Getenv("FLOW_ROOT"); root != "" {
+		spawnEnv = map[string]string{"FLOW_ROOT": root}
+	}
+	return spawner.SpawnTab("owner: "+o.Slug, o.WorkDir, command, spawnEnv)
+}
+
+// ownerTickManual implements `flow owner tick <slug>`: a hand-triggered,
+// on-demand tick (wake the owner now, regardless of schedule). Interactive
+// by default — spawns a tab the user drives, ideal for the first tick or
+// to check something early. `--auto` runs it headlessly instead. Neither
+// path advances the owner's schedule; this is an extra tick on top of it.
+func ownerTickManual(args []string) int {
+	if len(args) == 0 || args[0] == "" {
+		fmt.Fprintln(os.Stderr, "error: owner tick requires an owner slug")
+		return 2
+	}
+	slug := args[0]
+	fs := flagSet("owner tick")
+	auto := fs.Bool("auto", false, "run the tick headlessly in the background (no tab, no human)")
+	if err := fs.Parse(args[1:]); err != nil {
+		return 2
+	}
+
+	dbPath, err := flowDBPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	db, err := flowdb.OpenDB(dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	defer db.Close()
+	o, err := flowdb.GetOwner(db, slug)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			fmt.Fprintf(os.Stderr, "error: no owner %q\n", slug)
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	if *auto {
+		root, err := flowRoot()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 1
+		}
+		now := time.Now()
+		ticksDir := filepath.Join(root, "owners", slug, "ticks")
+		if err := os.MkdirAll(ticksDir, 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 1
+		}
+		logPath := filepath.Join(ticksDir, now.UTC().Format("2006-01-02-150405")+".log")
+		pid, err := ownerTickLauncher(slug, o.WorkDir, logPath, autoChildEnv())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 1
+		}
+		o.TickPID = sql.NullInt64{Int64: int64(pid), Valid: true}
+		o.TickStarted = sql.NullString{String: now.Format(time.RFC3339), Valid: true}
+		if err := flowdb.UpdateOwner(db, o); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: record tick for %q: %v\n", slug, err)
+		}
+		fmt.Printf("dispatched a headless tick for owner %q (pid %d)\n", slug, pid)
+		return 0
+	}
+
+	if err := ownerInteractiveLauncher(o, buildOwnerTickPromptInteractive(slug)); err != nil {
+		fmt.Fprintf(os.Stderr, "error: spawn interactive tick: %v\n", err)
+		return 1
+	}
+	fmt.Printf("opened an interactive tick for owner %q — drive it in the new tab\n", slug)
+	return 0
 }
 
 // ownerTickDue implements `flow owner tick-due`: the scheduler pass that
@@ -220,6 +320,29 @@ func reconcileOwnerTick(db *sql.DB, o *flowdb.Owner) {
 	o.TickPID = sql.NullInt64{}
 	o.TickStarted = sql.NullString{}
 	_ = flowdb.UpdateOwner(db, o)
+}
+
+// buildOwnerTickPromptInteractive is the prompt for a hand-triggered tick
+// run WITH the user present (often the first tick). Same orchestrate +
+// journal discipline as the headless tick, but the human can guide it: it
+// MAY use AskUserQuestion, and it folds anything learned back into the
+// charter so future headless ticks improve.
+func buildOwnerTickPromptInteractive(slug string) string {
+	return fmt.Sprintf(
+		"You are running ONE tick of the flow OWNER %q — INTERACTIVELY, with the user present (often the FIRST tick, to help you navigate). You MAY use AskUserQuestion to clarify intent, confirm a plan, or resolve charter ambiguity, and the user can course-correct you. If the charter is unclear or wrong, work it out WITH the user and update owners/%s/charter.md so future HEADLESS ticks behave correctly.\n\n"+
+			"You still ORCHESTRATE; you NEVER execute work inline. A tick gets no `flow done` close-out sweep, so route real work through tasks/playbooks that self-close:\n"+
+			"  - RECURRING work → a PLAYBOOK: create if needed, then `flow run playbook <slug> --auto`. Tag the run owner:%s.\n"+
+			"  - ONE-TIME work → a TASK: `flow add task \"<what>\" --tag owner:%s`, then `flow do --auto <task>`.\n"+
+			"  - A decision for the user → just ASK them (you're interactive), or park a QUESTION task (`--tag question --tag owner:%s`) for later.\n\n"+
+			"Do these in order:\n"+
+			"1. Invoke the flow skill via the Skill tool.\n"+
+			"2. Read your charter at owners/%s/charter.md.\n"+
+			"3. Read recent notes under owners/%s/updates/ (your journal), then review what you own with `flow owner show %s` (tasks, playbook runs, and questions with status). Don't duplicate tracked work or re-spawn an in-progress run.\n"+
+			"4. Observe per the charter and, together with the user, DISPATCH the needed playbook-runs / tasks / questions.\n"+
+			"5. Be conservative with irreversible/outward actions unless the charter authorizes them (when unsure, ask the user).\n"+
+			"6. Before finishing, WRITE a short note to owners/%s/updates/<today>-tick.md (what you observed, what you dispatched with slugs, what the next tick should check), and fold any lessons into the charter so headless ticks improve.\n",
+		slug, slug, slug, slug, slug, slug, slug, slug, slug,
+	)
 }
 
 // buildOwnerTickPrompt is the bootstrap prompt for one headless owner

--- a/internal/app/owner_tick.go
+++ b/internal/app/owner_tick.go
@@ -340,8 +340,9 @@ func buildOwnerTickPromptInteractive(slug string) string {
 			"3. Read recent notes under owners/%s/updates/ (your journal), then review what you own with `flow owner show %s` (tasks, playbook runs, and questions with status). Don't duplicate tracked work or re-spawn an in-progress run.\n"+
 			"4. Observe per the charter and, together with the user, DISPATCH the needed playbook-runs / tasks / questions.\n"+
 			"5. Be conservative with irreversible/outward actions unless the charter authorizes them (when unsure, ask the user).\n"+
-			"6. Before finishing, WRITE a short note to owners/%s/updates/<today>-tick.md (what you observed, what you dispatched with slugs, what the next tick should check), and fold any lessons into the charter so headless ticks improve.\n",
-		slug, slug, slug, slug, slug, slug, slug, slug, slug,
+			"6. Before finishing, WRITE a short note to owners/%s/updates/<today>-tick.md (what you observed, what you dispatched with slugs, what the next tick should check), and fold any lessons into the charter so headless ticks improve.\n"+
+			"7. SELF-PACE the next wake: decide when you next need to run and set it with `flow owner next %s --in <duration>` (or --at <time>). You pick the cadence yourself each run — no need to ask the user about timing; --every is only a fallback.\n",
+		slug, slug, slug, slug, slug, slug, slug, slug, slug, slug,
 	)
 }
 
@@ -361,8 +362,9 @@ func buildOwnerTickPrompt(slug string) string {
 			"3. Catch up on yourself: read the most recent note(s) under owners/%s/updates/ — that is your JOURNAL from prior ticks (what you dispatched, what you were waiting on, what to check now). Then review everything you own with `flow owner show %s` — it lists your in-flight tasks, playbook runs, AND open questions with their current status (do NOT use `flow list tasks`, which hides playbook runs). Advance or check on what's there; never duplicate work already tracked and never re-spawn a run that is still in progress.\n"+
 			"4. Observe the world per your charter, then DISPATCH what needs doing as playbook-runs / tasks / questions per the rule above. Keep the tick SHORT — spin work out, never perform it inline.\n"+
 			"5. Be conservative with irreversible or outward-facing actions (push, PR, deploy, messaging) unless your charter EXPLICITLY authorizes them.\n"+
-			"6. Before you exit, WRITE a short note to owners/%s/updates/<today>-tick.md recording what you observed, what you dispatched (with the task/run slugs), and what your NEXT tick should check. This is your memory — the next tick starts from a blank session and knows only what you write here plus the task records.\n"+
-			"7. Then exit. Your next tick is scheduled automatically. Do not loop or wait.\n",
-		slug, slug, slug, slug, slug, slug, slug, slug,
+			"6. WRITE a short note to owners/%s/updates/<today>-tick.md recording what you observed, what you dispatched (with the task/run slugs), and what your NEXT tick should check. This is your memory — the next tick starts from a blank session and knows only what you write here plus the task records.\n"+
+			"7. SELF-PACE: decide when you next need to run and set it with `flow owner next %s --in <duration>` (e.g. +15m if watching a deploy/CI, +1h if a review is pending; use --at <time> for longer/idle gaps). You choose the cadence per-run; if you skip this, the owner falls back to its --every interval.\n"+
+			"8. Then exit. Do not loop or wait.\n",
+		slug, slug, slug, slug, slug, slug, slug, slug, slug,
 	)
 }

--- a/internal/app/owner_tick_test.go
+++ b/internal/app/owner_tick_test.go
@@ -82,6 +82,106 @@ func TestOwnerTickDueRecordsRunningPID(t *testing.T) {
 	}
 }
 
+// After dispatch advances next_wake_at into the future, an immediate
+// second scheduler pass must not re-dispatch the same owner.
+func TestOwnerTickDueSecondPassDoesNotRedispatch(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	past := sql.NullString{String: time.Now().Add(-time.Hour).Format(time.RFC3339), Valid: true}
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{
+		Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m", Status: "active", NextWakeAt: past,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var dispatched []string
+	old := ownerTickLauncher
+	ownerTickLauncher = func(slug, workDir, logPath string, env []string) (int, error) {
+		dispatched = append(dispatched, slug)
+		return 0, nil
+	}
+	t.Cleanup(func() { ownerTickLauncher = old })
+	// Force the recorded pid to look dead so the overlap guard isn't what
+	// prevents re-dispatch — we want to prove the next_wake_at advance does.
+	oldAlive := processAlive
+	processAlive = func(pid int) bool { return false }
+	t.Cleanup(func() { processAlive = oldAlive })
+
+	if rc := cmdOwner([]string{"tick-due"}); rc != 0 {
+		t.Fatalf("first pass rc=%d", rc)
+	}
+	if len(dispatched) != 1 {
+		t.Fatalf("first pass dispatched %v, want [o1]", dispatched)
+	}
+	dispatched = nil
+	if rc := cmdOwner([]string{"tick-due"}); rc != 0 {
+		t.Fatalf("second pass rc=%d", rc)
+	}
+	if len(dispatched) != 0 {
+		t.Errorf("second pass re-dispatched %v; the next_wake advance should prevent it", dispatched)
+	}
+}
+
+// tick-due must skip (not crash, not launch) an owner with an unparseable
+// --every — a defensive path since CreateOwner / direct writes don't
+// validate the interval the way `flow add owner` does.
+func TestOwnerTickDueSkipsInvalidEvery(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	past := sql.NullString{String: time.Now().Add(-time.Hour).Format(time.RFC3339), Valid: true}
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{
+		Slug: "bad", Name: "B", WorkDir: "/x", Every: "notaduration", Status: "active", NextWakeAt: past,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	called := false
+	old := ownerTickLauncher
+	ownerTickLauncher = func(slug, workDir, logPath string, env []string) (int, error) { called = true; return 0, nil }
+	t.Cleanup(func() { ownerTickLauncher = old })
+
+	if rc := cmdOwner([]string{"tick-due"}); rc != 0 {
+		t.Fatalf("tick-due rc=%d (a bad-every row must not crash the pass)", rc)
+	}
+	if called {
+		t.Errorf("owner with invalid --every should be skipped, not launched")
+	}
+}
+
+// Each tick is a FRESH, sessionless run: the detached child's env must not
+// carry CLAUDE_CODE_SESSION_ID from the parent, or the tick would resume
+// the parent's transcript instead of starting clean.
+func TestOwnerTickDispatchEnvIsSessionless(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "11111111-2222-3333-4444-555555555555")
+	past := sql.NullString{String: time.Now().Add(-time.Hour).Format(time.RFC3339), Valid: true}
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{
+		Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m", Status: "active", NextWakeAt: past,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var gotEnv []string
+	called := false
+	old := ownerTickLauncher
+	ownerTickLauncher = func(slug, workDir, logPath string, env []string) (int, error) {
+		gotEnv = env
+		called = true
+		return 0, nil
+	}
+	t.Cleanup(func() { ownerTickLauncher = old })
+
+	if rc := cmdOwner([]string{"tick-due"}); rc != 0 {
+		t.Fatalf("tick-due rc=%d", rc)
+	}
+	if !called {
+		t.Fatal("launcher was not called")
+	}
+	for _, kv := range gotEnv {
+		if strings.HasPrefix(kv, "CLAUDE_CODE_SESSION_ID=") {
+			t.Errorf("tick child env leaked %q — each tick must be a fresh, sessionless run", kv)
+		}
+	}
+}
+
 // A tick that finishes BEFORE the scheduler records its pid must not have
 // its result clobbered. The scheduler dispatch write must touch only the
 // running-tick + schedule columns, never last_tick_*. Regression for the

--- a/internal/app/owner_tick_test.go
+++ b/internal/app/owner_tick_test.go
@@ -324,6 +324,59 @@ func TestBuildOwnerTickPromptInteractiveAllowsHuman(t *testing.T) {
 	}
 }
 
+func TestCmdOwnerNextSetsNextWake(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{Slug: "o1", Name: "O", WorkDir: "/x", Every: "24h"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// --in <dur>: wake this far from now.
+	if rc := cmdOwner([]string{"next", "o1", "--in", "15m"}); rc != 0 {
+		t.Fatalf("--in rc=%d", rc)
+	}
+	o, _ := flowdb.GetOwner(db, "o1")
+	if !o.NextWakeAt.Valid {
+		t.Fatal("next_wake not set by --in")
+	}
+	w, err := time.Parse(time.RFC3339, o.NextWakeAt.String)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d := time.Until(w); d < 14*time.Minute || d > 16*time.Minute {
+		t.Errorf("next wake should be ~15m from now, got %v", d)
+	}
+
+	// --at <ts>: wake at an absolute time.
+	at := time.Now().Add(3 * time.Hour).Format(time.RFC3339)
+	if rc := cmdOwner([]string{"next", "o1", "--at", at}); rc != 0 {
+		t.Fatalf("--at rc=%d", rc)
+	}
+	o, _ = flowdb.GetOwner(db, "o1")
+	if o.NextWakeAt.String != at {
+		t.Errorf("next_wake = %q, want %q", o.NextWakeAt.String, at)
+	}
+
+	// exactly one of --in / --at.
+	if rc := cmdOwner([]string{"next", "o1"}); rc != 2 {
+		t.Errorf("no flag: rc=%d, want 2", rc)
+	}
+	if rc := cmdOwner([]string{"next", "o1", "--in", "1h", "--at", at}); rc != 2 {
+		t.Errorf("both flags: rc=%d, want 2", rc)
+	}
+}
+
+func TestTickPromptsSelfPaceNextWake(t *testing.T) {
+	for label, p := range map[string]string{
+		"headless":    buildOwnerTickPrompt("desk"),
+		"interactive": buildOwnerTickPromptInteractive("desk"),
+	} {
+		if !strings.Contains(strings.ToLower(p), "flow owner next desk") {
+			t.Errorf("%s tick prompt must instruct self-paced scheduling via `flow owner next`; got:\n%s", label, p)
+		}
+	}
+}
+
 func TestBuildOwnerTickPromptReadsAndWritesJournal(t *testing.T) {
 	p := strings.ToLower(buildOwnerTickPrompt("desk"))
 	for _, want := range []string{

--- a/internal/app/owner_tick_test.go
+++ b/internal/app/owner_tick_test.go
@@ -243,6 +243,25 @@ func TestBuildOwnerTickPromptRoutesWorkThroughTasksAndPlaybooks(t *testing.T) {
 	}
 }
 
+func TestBuildOwnerTickPromptReadsAndWritesJournal(t *testing.T) {
+	p := strings.ToLower(buildOwnerTickPrompt("desk"))
+	for _, want := range []string{
+		"flow owner show desk", // review via owner show (includes runs), not list-tasks
+		"owners/desk/updates",  // journal location (like playbook/task updates)
+		"write a short note",   // record what it did for the next tick
+		"this is your memory",  // rationale
+	} {
+		if !strings.Contains(p, want) {
+			t.Errorf("tick prompt must mention %q (read/write journal + owner show); prompt:\n%s", want, p)
+		}
+	}
+	// The review step must NOT use the runs-blind `flow list tasks --tag`
+	// (it excludes playbook_run, so the owner would miss its own runs).
+	if strings.Contains(p, "flow list tasks --tag owner:desk") {
+		t.Errorf("review step should use `flow owner show` (includes playbook runs), not `flow list tasks --tag`")
+	}
+}
+
 var errTickBoom = &tickTestErr{}
 
 type tickTestErr struct{}

--- a/internal/app/owner_tick_test.go
+++ b/internal/app/owner_tick_test.go
@@ -82,6 +82,39 @@ func TestOwnerTickDueRecordsRunningPID(t *testing.T) {
 	}
 }
 
+// A hand-triggered `flow owner tick --auto` must not stack a second tick on
+// top of one already running (e.g. a scheduled tick, or an event-triggered
+// tick racing the scheduler) — it refuses and preserves the live pid.
+func TestOwnerTickManualAutoRefusesWhileTickRunning(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{
+		Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m", Status: "active",
+		TickPID:     sql.NullInt64{Int64: 4242, Valid: true},
+		TickStarted: sql.NullString{String: time.Now().Format(time.RFC3339), Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	oldAlive := processAlive
+	processAlive = func(pid int) bool { return pid == 4242 } // the tick is live
+	t.Cleanup(func() { processAlive = oldAlive })
+	launched := false
+	old := ownerTickLauncher
+	ownerTickLauncher = func(slug, workDir, logPath string, env []string) (int, error) { launched = true; return 9, nil }
+	t.Cleanup(func() { ownerTickLauncher = old })
+
+	if rc := ownerTickManual([]string{"o1", "--auto"}); rc == 0 {
+		t.Errorf("expected refusal while a tick is already running, got rc=0")
+	}
+	if launched {
+		t.Errorf("must not launch a second tick over a running one")
+	}
+	o, _ := flowdb.GetOwner(db, "o1")
+	if o.TickPID.Int64 != 4242 {
+		t.Errorf("the running tick's pid must be preserved, got %v", o.TickPID)
+	}
+}
+
 // Tick prompts must reference the ABSOLUTE owner dir, so a headless run
 // (cwd=work_dir) reads/writes the real charter+journal under $FLOW_ROOT
 // instead of creating a stray owners/ dir inside the user's repo.

--- a/internal/app/owner_tick_test.go
+++ b/internal/app/owner_tick_test.go
@@ -169,6 +169,59 @@ func TestCmdOwnerTickPreservesSelfPacedNextWake(t *testing.T) {
 	}
 }
 
+// The detached tick (`flow __owner-tick`) must not run the harness for a
+// non-active owner (paused/retired) — a guard for the window between
+// dispatch and execution, and for any manual --auto on a paused owner.
+func TestCmdOwnerTickDetachedSkipsNonActive(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{
+		Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m", Status: "paused",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	ran := false
+	old := ownerTickRunner
+	ownerTickRunner = func(h harness.Harness, prompt string) error { ran = true; return nil }
+	t.Cleanup(func() { ownerTickRunner = old })
+
+	cmdOwnerTick([]string{"o1"})
+
+	if ran {
+		t.Errorf("harness should NOT run for a paused owner")
+	}
+	o, err := flowdb.GetOwner(db, "o1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if o.LastTickStatus.Valid {
+		t.Errorf("no tick should be recorded for a skipped paused owner, got %q", o.LastTickStatus.String)
+	}
+}
+
+// The hand-triggered `flow owner tick` must refuse a non-active owner with
+// guidance rather than silently spawning a session.
+func TestCmdOwnerTickManualRefusesNonActive(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{
+		Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m", Status: "paused",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	spawned := false
+	old := ownerInteractiveLauncher
+	ownerInteractiveLauncher = func(o *flowdb.Owner, prompt string) error { spawned = true; return nil }
+	t.Cleanup(func() { ownerInteractiveLauncher = old })
+
+	if rc := ownerTickManual([]string{"o1"}); rc == 0 {
+		t.Errorf("expected non-zero rc for a paused owner, got 0")
+	}
+	if spawned {
+		t.Errorf("should NOT spawn an interactive tick for a paused owner")
+	}
+}
+
 func TestCmdOwnerTickClearsTickPID(t *testing.T) {
 	setupFlowRoot(t)
 	db := openFlowDB(t)

--- a/internal/app/owner_tick_test.go
+++ b/internal/app/owner_tick_test.go
@@ -166,6 +166,56 @@ func TestOwnerShowReconcilesDeadTick(t *testing.T) {
 	}
 }
 
+func TestOwnerTickDueSkipsOwnerWithRunningTick(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	past := sql.NullString{String: time.Now().Add(-time.Hour).Format(time.RFC3339), Valid: true}
+	// Due, but a tick is already running (live pid) → must be skipped.
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{
+		Slug: "busy", Name: "B", WorkDir: "/x", Every: "30m", Status: "active", NextWakeAt: past,
+		TickPID: sql.NullInt64{Int64: 5555, Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Due, with a DEAD tick pid → should still be dispatched.
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{
+		Slug: "free", Name: "F", WorkDir: "/y", Every: "30m", Status: "active", NextWakeAt: past,
+		TickPID: sql.NullInt64{Int64: 6666, Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	oldAlive := processAlive
+	processAlive = func(pid int) bool { return pid == 5555 } // 5555 alive, 6666 dead
+	t.Cleanup(func() { processAlive = oldAlive })
+
+	var dispatched []string
+	oldL := ownerTickLauncher
+	ownerTickLauncher = func(slug, workDir, logPath string, env []string) (int, error) {
+		dispatched = append(dispatched, slug)
+		return 1, nil
+	}
+	t.Cleanup(func() { ownerTickLauncher = oldL })
+
+	if rc := cmdOwner([]string{"tick-due"}); rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+	for _, s := range dispatched {
+		if s == "busy" {
+			t.Errorf("an owner with a LIVE tick must be skipped, got dispatched=%v", dispatched)
+		}
+	}
+	free := false
+	for _, s := range dispatched {
+		if s == "free" {
+			free = true
+		}
+	}
+	if !free {
+		t.Errorf("an owner with a DEAD tick pid should be dispatched, got %v", dispatched)
+	}
+}
+
 func TestCmdOwnerTickRecordsOkStatus(t *testing.T) {
 	setupFlowRoot(t)
 	db := openFlowDB(t)

--- a/internal/app/owner_tick_test.go
+++ b/internal/app/owner_tick_test.go
@@ -328,6 +328,19 @@ func TestOwnerTickManualInteractiveSpawnsTab(t *testing.T) {
 	if !strings.Contains(spawnedPrompt, "o1") {
 		t.Errorf("interactive prompt should name the owner")
 	}
+
+	// An interactive tick must be recorded on the owner (it ran), so
+	// `flow owner show` doesn't report "last tick: (never)".
+	o, err := flowdb.GetOwner(db, "o1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !o.LastTickAt.Valid || o.LastTickAt.String == "" {
+		t.Errorf("interactive tick should record last_tick_at")
+	}
+	if o.LastTickStatus.String != "interactive" {
+		t.Errorf("interactive tick status = %q, want interactive", o.LastTickStatus.String)
+	}
 }
 
 func TestOwnerTickManualAutoRunsHeadless(t *testing.T) {

--- a/internal/app/owner_tick_test.go
+++ b/internal/app/owner_tick_test.go
@@ -1,0 +1,250 @@
+package app
+
+import (
+	"database/sql"
+	"flow/internal/flowdb"
+	"flow/internal/harness"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOwnerTickDueDispatchesAndReschedules(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+
+	past := sql.NullString{String: time.Now().Add(-time.Hour).UTC().Format(time.RFC3339), Valid: true}
+	future := sql.NullString{String: time.Now().Add(time.Hour).UTC().Format(time.RFC3339), Valid: true}
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{Slug: "due", Name: "D", WorkDir: "/x", Every: "30m", NextWakeAt: past}); err != nil {
+		t.Fatal(err)
+	}
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{Slug: "later", Name: "L", WorkDir: "/y", Every: "30m", NextWakeAt: future}); err != nil {
+		t.Fatal(err)
+	}
+
+	var dispatched []string
+	old := ownerTickLauncher
+	ownerTickLauncher = func(slug, workDir, logPath string, env []string) (int, error) {
+		dispatched = append(dispatched, slug)
+		return 0, nil
+	}
+	t.Cleanup(func() { ownerTickLauncher = old })
+
+	if rc := cmdOwner([]string{"tick-due"}); rc != 0 {
+		t.Fatalf("tick-due rc=%d", rc)
+	}
+
+	if len(dispatched) != 1 || dispatched[0] != "due" {
+		t.Fatalf("dispatched = %v, want [due]", dispatched)
+	}
+
+	// The dispatched owner's next tick must be advanced into the future so
+	// the next scan doesn't re-fire it.
+	o, err := flowdb.GetOwner(db, "due")
+	if err != nil {
+		t.Fatal(err)
+	}
+	next, err := time.Parse(time.RFC3339, o.NextWakeAt.String)
+	if err != nil {
+		t.Fatalf("parse next_wake_at %q: %v", o.NextWakeAt.String, err)
+	}
+	if !next.After(time.Now()) {
+		t.Errorf("next_wake_at = %q not advanced into the future", o.NextWakeAt.String)
+	}
+}
+
+func TestOwnerTickDueRecordsRunningPID(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	past := sql.NullString{String: time.Now().Add(-time.Hour).Format(time.RFC3339), Valid: true}
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{
+		Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m", Status: "active", NextWakeAt: past,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	old := ownerTickLauncher
+	ownerTickLauncher = func(slug, workDir, logPath string, env []string) (int, error) { return 4242, nil }
+	t.Cleanup(func() { ownerTickLauncher = old })
+
+	if rc := cmdOwner([]string{"tick-due"}); rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+	o, err := flowdb.GetOwner(db, "o1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if o.TickPID.Int64 != 4242 {
+		t.Errorf("TickPID = %+v, want 4242 recorded on dispatch", o.TickPID)
+	}
+	if !o.TickStarted.Valid {
+		t.Errorf("TickStarted should be set on dispatch")
+	}
+}
+
+func TestCmdOwnerTickClearsTickPID(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{
+		Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m",
+		TickPID: sql.NullInt64{Int64: 999, Valid: true}, TickStarted: sql.NullString{String: "2026-06-09T00:00:00Z", Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	old := ownerTickRunner
+	ownerTickRunner = func(h harness.Harness, prompt string) error { return nil }
+	t.Cleanup(func() { ownerTickRunner = old })
+
+	if rc := cmdOwnerTick([]string{"o1"}); rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+	o, err := flowdb.GetOwner(db, "o1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if o.TickPID.Valid {
+		t.Errorf("TickPID should be cleared when the tick finishes, got %+v", o.TickPID)
+	}
+	if o.LastTickStatus.String != "ok" {
+		t.Errorf("LastTickStatus = %q, want ok", o.LastTickStatus.String)
+	}
+}
+
+func TestOwnerShowShowsRunningTick(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{
+		Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m",
+		TickPID: sql.NullInt64{Int64: 4242, Valid: true}, TickStarted: sql.NullString{String: "2026-06-09T00:00:00Z", Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	oldAlive := processAlive
+	processAlive = func(pid int) bool { return pid == 4242 }
+	t.Cleanup(func() { processAlive = oldAlive })
+
+	out := captureStdout(t, func() {
+		if rc := cmdOwner([]string{"show", "o1"}); rc != 0 {
+			t.Fatalf("rc=%d", rc)
+		}
+	})
+	if !strings.Contains(out, "running") || !strings.Contains(out, "4242") {
+		t.Errorf("expected a running tick line with pid 4242; got:\n%s", out)
+	}
+}
+
+func TestOwnerShowReconcilesDeadTick(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{
+		Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m",
+		TickPID: sql.NullInt64{Int64: 4242, Valid: true}, TickStarted: sql.NullString{String: "2026-06-09T00:00:00Z", Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	oldAlive := processAlive
+	processAlive = func(pid int) bool { return false } // the tick pid is dead
+	t.Cleanup(func() { processAlive = oldAlive })
+
+	out := captureStdout(t, func() {
+		if rc := cmdOwner([]string{"show", "o1"}); rc != 0 {
+			t.Fatalf("rc=%d", rc)
+		}
+	})
+	if strings.Contains(out, "running") {
+		t.Errorf("a dead tick pid must not display as running; got:\n%s", out)
+	}
+	o, err := flowdb.GetOwner(db, "o1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if o.TickPID.Valid {
+		t.Errorf("dead tick pid should be reconciled (cleared), got %+v", o.TickPID)
+	}
+	if o.LastTickStatus.String != "dead" {
+		t.Errorf("reconciled status = %q, want dead", o.LastTickStatus.String)
+	}
+}
+
+func TestCmdOwnerTickRecordsOkStatus(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var gotPrompt string
+	old := ownerTickRunner
+	ownerTickRunner = func(h harness.Harness, prompt string) error {
+		gotPrompt = prompt
+		return nil
+	}
+	t.Cleanup(func() { ownerTickRunner = old })
+
+	if rc := cmdOwnerTick([]string{"o1"}); rc != 0 {
+		t.Fatalf("tick rc=%d", rc)
+	}
+
+	if !strings.Contains(gotPrompt, "o1") {
+		t.Errorf("tick prompt should name the owner; got:\n%s", gotPrompt)
+	}
+	o, err := flowdb.GetOwner(db, "o1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !o.LastTickAt.Valid || o.LastTickAt.String == "" {
+		t.Errorf("LastTickAt not recorded")
+	}
+	if o.LastTickStatus.String != "ok" {
+		t.Errorf("LastTickStatus = %q, want ok", o.LastTickStatus.String)
+	}
+}
+
+func TestCmdOwnerTickRecordsErrorStatus(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m"}); err != nil {
+		t.Fatal(err)
+	}
+
+	old := ownerTickRunner
+	ownerTickRunner = func(h harness.Harness, prompt string) error {
+		return errTickBoom
+	}
+	t.Cleanup(func() { ownerTickRunner = old })
+
+	if rc := cmdOwnerTick([]string{"o1"}); rc != 1 {
+		t.Errorf("tick rc=%d, want 1 on runner error", rc)
+	}
+	o, err := flowdb.GetOwner(db, "o1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if o.LastTickStatus.String != "error" {
+		t.Errorf("LastTickStatus = %q, want error", o.LastTickStatus.String)
+	}
+}
+
+func TestBuildOwnerTickPromptRoutesWorkThroughTasksAndPlaybooks(t *testing.T) {
+	p := strings.ToLower(buildOwnerTickPrompt("desk"))
+	// A tick is sessionless and gets no `flow done` KB sweep, so it must
+	// route substantive work through tasks/playbooks (which self-close with
+	// the sweep) rather than doing the work inline.
+	for _, want := range []string{
+		"do not do substantive work", // the core rule
+		"flow run playbook",          // recurring → playbook
+		"flow do --auto",             // one-time → task run that self-flow-dones
+		"flow done",                  // the rationale: the sweep
+		"owner:desk",                 // tag work to the owner
+	} {
+		if !strings.Contains(p, want) {
+			t.Errorf("tick prompt must mention %q (orchestrate-don't-execute); prompt:\n%s", want, p)
+		}
+	}
+}
+
+var errTickBoom = &tickTestErr{}
+
+type tickTestErr struct{}
+
+func (*tickTestErr) Error() string { return "boom" }

--- a/internal/app/owner_tick_test.go
+++ b/internal/app/owner_tick_test.go
@@ -82,6 +82,93 @@ func TestOwnerTickDueRecordsRunningPID(t *testing.T) {
 	}
 }
 
+// A tick that finishes BEFORE the scheduler records its pid must not have
+// its result clobbered. The scheduler dispatch write must touch only the
+// running-tick + schedule columns, never last_tick_*. Regression for the
+// dispatch-vs-finish race (full-row UpdateOwner overwrote the child's
+// last_tick_status with the stale pre-tick value).
+func TestOwnerTickDueFastFinishingChildKeepsResult(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	past := sql.NullString{String: time.Now().Add(-time.Hour).Format(time.RFC3339), Valid: true}
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{
+		Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m", Status: "active", NextWakeAt: past,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	old := ownerTickLauncher
+	ownerTickLauncher = func(slug, workDir, logPath string, env []string) (int, error) {
+		// Simulate the detached child completing (recording 'ok' and
+		// clearing its pid) before the parent's dispatch write lands.
+		if _, err := db.Exec(
+			`UPDATE owners SET last_tick_at=?, last_tick_status='ok', tick_pid=NULL, tick_started=NULL WHERE slug=?`,
+			flowdb.NowISO(), slug,
+		); err != nil {
+			t.Fatal(err)
+		}
+		return 7777, nil
+	}
+	t.Cleanup(func() { ownerTickLauncher = old })
+
+	if rc := cmdOwner([]string{"tick-due"}); rc != 0 {
+		t.Fatalf("tick-due rc=%d", rc)
+	}
+
+	o, err := flowdb.GetOwner(db, "o1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if o.LastTickStatus.String != "ok" {
+		t.Errorf("LastTickStatus = %q, want ok (child result clobbered by dispatch write)", o.LastTickStatus.String)
+	}
+	// The schedule must still advance (the dispatch did its own job).
+	next, perr := time.Parse(time.RFC3339, o.NextWakeAt.String)
+	if perr != nil || !next.After(time.Now()) {
+		t.Errorf("next_wake_at = %q not advanced", o.NextWakeAt.String)
+	}
+}
+
+// A tick that self-paces mid-run (sets next_wake_at via `flow owner next`)
+// must keep that value — the finish write must not overwrite next_wake_at
+// with the stale value loaded when the tick started.
+func TestCmdOwnerTickPreservesSelfPacedNextWake(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	initial := time.Now().Add(30 * time.Minute).UTC().Format(time.RFC3339)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{
+		Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m",
+		NextWakeAt: sql.NullString{String: initial, Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	selfPaced := time.Now().Add(5 * time.Minute).UTC().Format(time.RFC3339)
+
+	old := ownerTickRunner
+	ownerTickRunner = func(h harness.Harness, prompt string) error {
+		// Simulate the tick calling `flow owner next o1 --in 5m`.
+		if _, err := db.Exec(`UPDATE owners SET next_wake_at=? WHERE slug=?`, selfPaced, "o1"); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}
+	t.Cleanup(func() { ownerTickRunner = old })
+
+	if rc := cmdOwnerTick([]string{"o1"}); rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+	o, err := flowdb.GetOwner(db, "o1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if o.NextWakeAt.String != selfPaced {
+		t.Errorf("next_wake_at = %q, want self-paced %q (finish write clobbered it)", o.NextWakeAt.String, selfPaced)
+	}
+	if o.LastTickStatus.String != "ok" {
+		t.Errorf("LastTickStatus = %q, want ok", o.LastTickStatus.String)
+	}
+}
+
 func TestCmdOwnerTickClearsTickPID(t *testing.T) {
 	setupFlowRoot(t)
 	db := openFlowDB(t)

--- a/internal/app/owner_tick_test.go
+++ b/internal/app/owner_tick_test.go
@@ -243,6 +243,87 @@ func TestBuildOwnerTickPromptRoutesWorkThroughTasksAndPlaybooks(t *testing.T) {
 	}
 }
 
+func TestOwnerTickManualInteractiveSpawnsTab(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var spawnedOwner, spawnedPrompt string
+	oldI := ownerInteractiveLauncher
+	ownerInteractiveLauncher = func(o *flowdb.Owner, prompt string) error {
+		spawnedOwner, spawnedPrompt = o.Slug, prompt
+		return nil
+	}
+	t.Cleanup(func() { ownerInteractiveLauncher = oldI })
+
+	var headlessCalled bool
+	oldH := ownerTickLauncher
+	ownerTickLauncher = func(slug, workDir, logPath string, env []string) (int, error) {
+		headlessCalled = true
+		return 1, nil
+	}
+	t.Cleanup(func() { ownerTickLauncher = oldH })
+
+	if rc := cmdOwner([]string{"tick", "o1"}); rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+	if spawnedOwner != "o1" {
+		t.Errorf("interactive launcher should run for o1, got %q", spawnedOwner)
+	}
+	if headlessCalled {
+		t.Errorf("a hand-triggered tick must be interactive, not headless")
+	}
+	if !strings.Contains(spawnedPrompt, "o1") {
+		t.Errorf("interactive prompt should name the owner")
+	}
+}
+
+func TestOwnerTickManualAutoRunsHeadless(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var interactiveCalled bool
+	oldI := ownerInteractiveLauncher
+	ownerInteractiveLauncher = func(o *flowdb.Owner, prompt string) error { interactiveCalled = true; return nil }
+	t.Cleanup(func() { ownerInteractiveLauncher = oldI })
+
+	oldH := ownerTickLauncher
+	ownerTickLauncher = func(slug, workDir, logPath string, env []string) (int, error) { return 4242, nil }
+	t.Cleanup(func() { ownerTickLauncher = oldH })
+
+	if rc := cmdOwner([]string{"tick", "o1", "--auto"}); rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+	if interactiveCalled {
+		t.Errorf("--auto must run headless, not spawn an interactive tab")
+	}
+	o, _ := flowdb.GetOwner(db, "o1")
+	if o.TickPID.Int64 != 4242 {
+		t.Errorf("--auto tick should record a running pid, got %+v", o.TickPID)
+	}
+}
+
+func TestBuildOwnerTickPromptInteractiveAllowsHuman(t *testing.T) {
+	p := strings.ToLower(buildOwnerTickPromptInteractive("desk"))
+	if !strings.Contains(p, "askuserquestion") {
+		t.Errorf("interactive prompt should permit AskUserQuestion (human present)")
+	}
+	if strings.Contains(p, "do not use askuserquestion") {
+		t.Errorf("interactive prompt must NOT forbid AskUserQuestion")
+	}
+	// Still orchestrates + journals like the headless tick.
+	for _, want := range []string{"flow owner show desk", "owners/desk/updates", "never execute work inline"} {
+		if !strings.Contains(p, want) {
+			t.Errorf("interactive prompt missing %q", want)
+		}
+	}
+}
+
 func TestBuildOwnerTickPromptReadsAndWritesJournal(t *testing.T) {
 	p := strings.ToLower(buildOwnerTickPrompt("desk"))
 	for _, want := range []string{

--- a/internal/app/owner_tick_test.go
+++ b/internal/app/owner_tick_test.go
@@ -82,6 +82,88 @@ func TestOwnerTickDueRecordsRunningPID(t *testing.T) {
 	}
 }
 
+// Tick prompts must reference the ABSOLUTE owner dir, so a headless run
+// (cwd=work_dir) reads/writes the real charter+journal under $FLOW_ROOT
+// instead of creating a stray owners/ dir inside the user's repo.
+func TestOwnerTickPromptUsesAbsoluteOwnerDir(t *testing.T) {
+	dir := "/Users/x/.flow/owners/desk"
+	for label, p := range map[string]string{
+		"headless":    buildOwnerTickPrompt("desk", dir),
+		"interactive": buildOwnerTickPromptInteractive("desk", dir),
+	} {
+		if !strings.Contains(p, dir+"/charter.md") {
+			t.Errorf("%s prompt must use absolute charter path %q; got:\n%s", label, dir+"/charter.md", p)
+		}
+		if !strings.Contains(p, dir+"/updates/") {
+			t.Errorf("%s prompt must use absolute journal path %q", label, dir+"/updates/")
+		}
+	}
+	if !strings.Contains(strings.ToLower(buildOwnerTickPrompt("desk", dir)), "not your work_dir") {
+		t.Errorf("headless prompt should warn the charter is NOT under work_dir")
+	}
+}
+
+// A dispatched tick that skips a now-non-active owner must clear the
+// tick_pid the scheduler stamped (gap 8) — else the owner shows "tick
+// running" and reconcile later mislabels the clean skip as 'dead'.
+func TestCmdOwnerTickSkipClearsTickPID(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{
+		Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m", Status: "paused",
+		TickPID:     sql.NullInt64{Int64: 4242, Valid: true},
+		TickStarted: sql.NullString{String: time.Now().Format(time.RFC3339), Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	ran := false
+	old := ownerTickRunner
+	ownerTickRunner = func(h harness.Harness, prompt string) error { ran = true; return nil }
+	t.Cleanup(func() { ownerTickRunner = old })
+
+	if rc := cmdOwnerTick([]string{"o1"}); rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+	if ran {
+		t.Errorf("paused owner must not run the harness")
+	}
+	o, _ := flowdb.GetOwner(db, "o1")
+	if o.TickPID.Valid {
+		t.Errorf("skip must clear the stale tick_pid, got %v", o.TickPID)
+	}
+}
+
+// An owner whose tick_pid looks alive (pid reuse after a reboot) but whose
+// tick started long ago must NOT be skipped forever (gap 6) — the staleness
+// cap lets the scheduler re-dispatch it.
+func TestOwnerTickDueRedispatchesStaleTick(t *testing.T) {
+	setupFlowRoot(t)
+	db := openFlowDB(t)
+	past := sql.NullString{String: time.Now().Add(-time.Hour).Format(time.RFC3339), Valid: true}
+	staleStart := time.Now().Add(-2 * time.Hour).Format(time.RFC3339)
+	if err := flowdb.CreateOwner(db, &flowdb.Owner{
+		Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m", Status: "active", NextWakeAt: past,
+		TickPID:     sql.NullInt64{Int64: 4242, Valid: true},
+		TickStarted: sql.NullString{String: staleStart, Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	oldAlive := processAlive
+	processAlive = func(pid int) bool { return true } // pid reuse → "alive"
+	t.Cleanup(func() { processAlive = oldAlive })
+	dispatched := false
+	old := ownerTickLauncher
+	ownerTickLauncher = func(slug, workDir, logPath string, env []string) (int, error) { dispatched = true; return 5, nil }
+	t.Cleanup(func() { ownerTickLauncher = old })
+
+	if rc := cmdOwner([]string{"tick-due"}); rc != 0 {
+		t.Fatalf("tick-due rc=%d", rc)
+	}
+	if !dispatched {
+		t.Errorf("a stale overdue tick (pid reused) must be re-dispatched, not skipped forever")
+	}
+}
+
 // After dispatch advances next_wake_at into the future, an immediate
 // second scheduler pass must not re-dispatch the same owner.
 func TestOwnerTickDueSecondPassDoesNotRedispatch(t *testing.T) {
@@ -353,9 +435,11 @@ func TestCmdOwnerTickClearsTickPID(t *testing.T) {
 func TestOwnerShowShowsRunningTick(t *testing.T) {
 	setupFlowRoot(t)
 	db := openFlowDB(t)
+	// A genuinely-running tick has a RECENT start (a stale start trips the
+	// pid-reuse staleness cap and is reconciled to 'dead' instead).
 	if err := flowdb.CreateOwner(db, &flowdb.Owner{
 		Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m",
-		TickPID: sql.NullInt64{Int64: 4242, Valid: true}, TickStarted: sql.NullString{String: "2026-06-09T00:00:00Z", Valid: true},
+		TickPID: sql.NullInt64{Int64: 4242, Valid: true}, TickStarted: sql.NullString{String: time.Now().Format(time.RFC3339), Valid: true},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -516,7 +600,7 @@ func TestCmdOwnerTickRecordsErrorStatus(t *testing.T) {
 }
 
 func TestBuildOwnerTickPromptRoutesWorkThroughTasksAndPlaybooks(t *testing.T) {
-	p := strings.ToLower(buildOwnerTickPrompt("desk"))
+	p := strings.ToLower(buildOwnerTickPrompt("desk", "/flowroot/owners/desk"))
 	// A tick is sessionless and gets no `flow done` KB sweep, so it must
 	// route substantive work through tasks/playbooks (which self-close with
 	// the sweep) rather than doing the work inline.
@@ -612,7 +696,7 @@ func TestOwnerTickManualAutoRunsHeadless(t *testing.T) {
 }
 
 func TestBuildOwnerTickPromptInteractiveAllowsHuman(t *testing.T) {
-	p := strings.ToLower(buildOwnerTickPromptInteractive("desk"))
+	p := strings.ToLower(buildOwnerTickPromptInteractive("desk", "/flowroot/owners/desk"))
 	if !strings.Contains(p, "askuserquestion") {
 		t.Errorf("interactive prompt should permit AskUserQuestion (human present)")
 	}
@@ -671,8 +755,8 @@ func TestCmdOwnerNextSetsNextWake(t *testing.T) {
 
 func TestTickPromptsSelfPaceNextWake(t *testing.T) {
 	for label, p := range map[string]string{
-		"headless":    buildOwnerTickPrompt("desk"),
-		"interactive": buildOwnerTickPromptInteractive("desk"),
+		"headless":    buildOwnerTickPrompt("desk", "/flowroot/owners/desk"),
+		"interactive": buildOwnerTickPromptInteractive("desk", "/flowroot/owners/desk"),
 	} {
 		if !strings.Contains(strings.ToLower(p), "flow owner next desk") {
 			t.Errorf("%s tick prompt must instruct self-paced scheduling via `flow owner next`; got:\n%s", label, p)
@@ -681,7 +765,7 @@ func TestTickPromptsSelfPaceNextWake(t *testing.T) {
 }
 
 func TestBuildOwnerTickPromptReadsAndWritesJournal(t *testing.T) {
-	p := strings.ToLower(buildOwnerTickPrompt("desk"))
+	p := strings.ToLower(buildOwnerTickPrompt("desk", "/flowroot/owners/desk"))
 	for _, want := range []string{
 		"flow owner show desk", // review via owner show (includes runs), not list-tasks
 		"owners/desk/updates",  // journal location (like playbook/task updates)

--- a/internal/app/show.go
+++ b/internal/app/show.go
@@ -12,10 +12,10 @@ import (
 	"time"
 )
 
-// cmdShow dispatches `flow show task|project|playbook`. Per spec §5.4.
+// cmdShow dispatches `flow show task|project|playbook|owner`. Per spec §5.4.
 func cmdShow(args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "error: show requires 'task', 'project', or 'playbook'")
+		fmt.Fprintln(os.Stderr, "error: show requires 'task', 'project', 'playbook', or 'owner'")
 		return 2
 	}
 	switch args[0] {
@@ -25,6 +25,10 @@ func cmdShow(args []string) int {
 		return showProjectCmd(args[1:])
 	case "playbook":
 		return showPlaybookCmd(args[1:])
+	case "owner":
+		// Verb-first alias for `flow owner show <slug>` — see cmdList's
+		// "owners" case for the rationale.
+		return ownerShow(args[1:])
 	}
 	fmt.Fprintf(os.Stderr, "error: unknown show subcommand %q\n", args[0])
 	return 2

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -1813,6 +1813,43 @@ tick crashes or never sets its next wake, the owner still re-wakes on
 per-run; `--every` is just the backstop. The agent sets this itself — it
 does NOT ask the user to confirm tick timing, even on an interactive tick.
 
+**Ensuring the tick scheduler (host setup — once per machine).** flow has
+**no daemon and no OS-specific scheduler code** — it only provides `flow
+owner tick-due` (scan for due owners, dispatch their ticks). Firing that on
+an interval is **this skill's job, per host**. So when the user creates or
+starts their first owner — or asks "are my owners actually running?" —
+ensure a host scheduler exists that runs `flow owner tick-due` ~every 60s.
+Idempotent: check first, install only if missing, reload if it fell out.
+
+Recipe:
+1. Resolve the binary (`which flow`) and detect the OS (`uname`).
+2. **Check** if already loaded:
+   - macOS: `launchctl list | grep cloud.facets.flow.owner-scheduler` →
+     present means it's running; report and stop.
+3. **Install if missing (macOS / launchd):** write
+   `~/Library/LaunchAgents/cloud.facets.flow.owner-scheduler.plist` with
+   `Label=cloud.facets.flow.owner-scheduler`,
+   `ProgramArguments=[<abs flow path>, owner, tick-due]`,
+   `StartInterval=60`, `RunAtLoad=true`, and
+   `StandardOutPath`/`StandardErrorPath` = `~/.flow/owner-scheduler.{log,err.log}`.
+   Then `launchctl load -w <plist>` (use `launchctl bootstrap gui/$UID
+   <plist>` on newer macOS if `load` is unavailable).
+4. **Verify** by re-running `launchctl list | grep flow.owner-scheduler`;
+   report "scheduler installed — owners now tick on their own."
+5. **Linux:** a systemd **user** timer (`OnUnitActiveSec=60s` + a `.service`
+   running `flow owner tick-due`, `systemctl --user enable --now`), or a
+   crontab line `* * * * * <flow> owner tick-due`. Pick what the host has.
+
+**Verify-and-respawn** is a health check you can re-run whenever the user
+touches owners: if `launchctl list` no longer shows it (unloaded, reboot
+quirk), reload the plist. To **stop all owners** from ticking, unload it
+(`launchctl unload -w <plist>` + delete the file); to stop just one, `flow
+owner pause <slug>`.
+
+**It's opt-in.** Installing the scheduler makes owners run unattended
+forever until paused/unloaded — offer it via `AskUserQuestion` when the
+first owner is created/started; never install it silently.
+
 **Waking an owner on demand / the first tick:** the scheduler fires ticks
 on the interval, but the user can also wake an owner **now** with `flow
 owner tick <slug>` — to check something early, test, or run the guided

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -105,9 +105,10 @@ an intent, follow the matching recipe instead of re-asking via §1a.
   that take ongoing responsibility for an outcome (e.g. "keep all PRs in
   repo X green"; "maintain repo Y: fix bugs → PR → merge → deploy → verify").
   An owner is NOT a single Claude session — it is state (a `charter.md`
-  operating manual + a ledger) plus a clock: it wakes on a fixed interval
-  (`--every`), runs a *fresh headless tick* (a brand-new session each time),
-  acts, then schedules its next tick. Each owner has a slug, work_dir,
+  operating manual + a ledger) plus a clock: each tick it runs a *fresh
+  headless tick* (a brand-new session each time), acts, then **self-paces**
+  its next wake (`flow owner next`); `--every` is only the fallback
+  heartbeat floor, not a fixed schedule. Each owner has a slug, work_dir,
   optional `project_slug`, a status (`active`/`paused`/`retired`), and an
   interval. The tasks an owner creates or manages are tagged `owner:<slug>`;
   a task it parks for a human decision is also tagged `question`. See §4.17.

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -218,7 +218,8 @@ Owners (autonomous ownership — see §4.17)
   flow owner show   <slug>          charter + what it owns (in-flight / playbook runs / questions) + next tick
   flow owner start  <slug>          begin ticking (first tick due now, then every <dur>)
   flow owner pause  <slug>          stop ticking, keep all state
-  (ticks run headlessly on a launchd timer — you never invoke them by hand)
+  flow owner tick   <slug>          wake the owner NOW, interactively (a tab you drive); --auto = headless now
+  (scheduled ticks run headlessly; `flow owner tick` is the on-demand / guided-first-run path)
 
 Read
   flow show task    [<ref>]     (no arg → reverse-lookup via $CLAUDE_CODE_SESSION_ID)
@@ -1798,6 +1799,22 @@ when they ask "what does <owner> need from me?" — list
 (charter, status, next tick, and what it owns split into in-flight /
 playbook runs / questions). "what owners do I have?" → `flow owner list`
 (status + next tick per owner).
+
+**Waking an owner on demand / the first tick:** the scheduler fires ticks
+on the interval, but the user can also wake an owner **now** with `flow
+owner tick <slug>` — to check something early, test, or run the guided
+first tick. It's an *extra* tick; it does not disturb the schedule. By
+default it's **interactive** (spawns a tab the user drives — the session
+MAY use AskUserQuestion and the user can course-correct and refine the
+charter); `flow owner tick <slug> --auto` runs it headless instead.
+
+**Strongly prefer an interactive FIRST tick.** When an owner has never
+ticked (`flow owner show` reports `last tick: (never)`), proactively offer
+to run the first tick interactively via `AskUserQuestion` — the first tick
+is where the charter meets reality, and having the user in the loop lets
+them navigate the agent, catch charter gaps, and tune it before it runs
+unattended (mirrors playbook first-run capture, §4.13). After the guided
+first tick, let the scheduler take over headless.
 
 **Lifecycle:** `flow owner start` begins ticking; `flow owner pause` stops
 ticking but keeps all state; `flow owner edit` (charter) and retire/archive

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -1830,10 +1830,15 @@ Recipe:
    `~/Library/LaunchAgents/cloud.facets.flow.owner-scheduler.plist` with
    `Label=cloud.facets.flow.owner-scheduler`,
    `ProgramArguments=[<abs flow path>, owner, tick-due]`,
-   `StartInterval=60`, `RunAtLoad=true`, and
-   `StandardOutPath`/`StandardErrorPath` = `~/.flow/owner-scheduler.{log,err.log}`.
-   Then `launchctl load -w <plist>` (use `launchctl bootstrap gui/$UID
-   <plist>` on newer macOS if `load` is unavailable).
+   `StartInterval=60`, `RunAtLoad=true`,
+   `StandardOutPath`/`StandardErrorPath` = `~/.flow/owner-scheduler.{log,err.log}`,
+   and — **CRITICAL** — `EnvironmentVariables.PATH` set to the user's full
+   interactive `$PATH`. launchd's default PATH is minimal, so WITHOUT this
+   the tick fails with `exec: "claude": executable file not found in $PATH`
+   (claude/gh/git live in `~/.local/bin`, homebrew, etc., which launchd
+   doesn't include). Capture `echo "$PATH"` and embed it. Then `launchctl
+   load -w <plist>` (use `launchctl bootstrap gui/$UID <plist>` on newer
+   macOS if `load` is unavailable).
 4. **Verify** by re-running `launchctl list | grep flow.owner-scheduler`;
    report "scheduler installed — owners now tick on their own."
 5. **Linux:** a systemd **user** timer (`OnUnitActiveSec=60s` + a `.service`

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -219,6 +219,7 @@ Owners (autonomous ownership — see §4.17)
   flow owner start  <slug>          begin ticking (first tick due now, then every <dur>)
   flow owner pause  <slug>          stop ticking, keep all state
   flow owner tick   <slug>          wake the owner NOW, interactively (a tab you drive); --auto = headless now
+  flow owner next   <slug> --in <dur> | --at <when>   set the next tick time (how a tick self-paces)
   (scheduled ticks run headlessly; `flow owner tick` is the on-demand / guided-first-run path)
 
 Read
@@ -1737,7 +1738,10 @@ operate*, not just what. Ask, one at a time:
    the workdir registry, `gh` — and only ask the gaps.
 4. **When to ask vs. act** — which decisions need a human (approvals,
    ambiguous calls) vs. what it may just do.
-5. **Interval** — `--every` (e.g. `30m`, `1h`).
+5. **Fallback interval** — `--every` (e.g. `1h`, `24h`; optional, default
+   `24h`). This is NOT a rigid schedule — it's only the *heartbeat floor*.
+   Ticks **self-pace**: each run decides its own next wake. So don't
+   interview for a fixed cron cadence; just pick a loose fallback.
 Then `flow add owner "<name>" --work-dir <p> --every <dur> [--project <s>] [--slug <s>]`,
 and write the gathered operating manual into the owner's `charter.md`
 (overwrite the stub — Read once, then Write). Offer to **start** it
@@ -1799,6 +1803,15 @@ when they ask "what does <owner> need from me?" — list
 (charter, status, next tick, and what it owns split into in-flight /
 playbook runs / questions). "what owners do I have?" → `flow owner list`
 (status + next tick per owner).
+
+**Scheduling is self-paced, not a fixed cron.** Each tick decides when it
+next needs to run and sets it with `flow owner next <slug> --in <dur>` (or
+`--at <when>`) before exiting — e.g. `+15m` while watching a deploy, `+1d`
+when idle. The `--every` value is only a *fallback heartbeat floor*: if a
+tick crashes or never sets its next wake, the owner still re-wakes on
+`--every` instead of going dark. So the cadence is dynamic and decided
+per-run; `--every` is just the backstop. The agent sets this itself — it
+does NOT ask the user to confirm tick timing, even on an interactive tick.
 
 **Waking an owner on demand / the first tick:** the scheduler fires ticks
 on the interval, but the user can also wake an owner **now** with `flow

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -1784,6 +1784,34 @@ interactively so the user navigates the agent and tunes the charter before it
 runs unattended (like playbook first-run capture, §4.13). Then let the
 scheduler take over.
 
+**Event-driven owners (advanced; default is poll-based).** By default an
+owner is a *poller* — scheduled ticks, self-paced via `flow owner next`. For
+a window that needs faster reaction than polling (a deploy in flight, a CI
+run, a PR's checks), an owner can become **event-driven** — but a tick is
+headless and **exits**, so it cannot hold a Monitor itself. Instead the tick
+spins up a **bounded watcher** and goes back to sleep:
+
+- The tick dispatches a one-time TASK (`flow add task "watch <event> for
+  <owner>" --tag owner:<slug>`, then `flow do --auto`) whose brief says: use
+  the **Monitor tool** to watch `<event>` with a clear stop condition **and**
+  a timeout.
+- When the event fires, that watcher session (a) appends a focus note to the
+  owner's journal (`owners/<slug>/updates/<today>-EVENT.md` — what fired,
+  what to check), then (b) runs `flow owner tick <slug> --auto` to fire a
+  **focused tick** now, then **exits**.
+- The triggered tick reads the journal (its normal step 3), sees the focus
+  note, acts on it, and re-sleeps at its normal cadence. (`flow owner tick
+  --auto` is overlap-guarded, so an event trigger that races a scheduled tick
+  won't double-fire.)
+
+This gives both modes from one primitive: cheap spaced **polling** by
+default, an event-driven **focused tick** on demand — without keeping a mind
+alive between events. **Bounded only:** the watcher is a living session that
+costs tokens while it watches, so use it for windows with a clear end (deploy
+/ CI / PR-checks), **never** as a permanent watcher (that's back to the
+expensive long-running-session model an owner exists to avoid). Always give
+the watcher a timeout so a never-fired event doesn't strand it running.
+
 **Lifecycle:** `start` begins ticking; `pause` stops but keeps state (resume
 with `start`); `flow owner retire <slug>` stops it (retired+archived — no
 longer ticks, off the default list, but charter/journal/owned-tasks

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -101,6 +101,16 @@ an intent, follow the matching recipe instead of re-asking via §1a.
   own session, its own snapshotted `brief.md`, and its own
   `updates/`. Editing a playbook's `brief.md` does not affect past
   runs; runs are reproducible.
+- **Owners** are durable, named, repo-scoped *self-prompting controllers*
+  that take ongoing responsibility for an outcome (e.g. "keep all PRs in
+  repo X green"; "maintain repo Y: fix bugs → PR → merge → deploy → verify").
+  An owner is NOT a single Claude session — it is state (a `charter.md`
+  operating manual + a ledger) plus a clock: it wakes on a fixed interval
+  (`--every`), runs a *fresh headless tick* (a brand-new session each time),
+  acts, then schedules its next tick. Each owner has a slug, work_dir,
+  optional `project_slug`, a status (`active`/`paused`/`retired`), and an
+  interval. The tasks an owner creates or manages are tagged `owner:<slug>`;
+  a task it parks for a human decision is also tagged `question`. See §4.17.
 - **Workdirs** is a convenience registry of known local repo paths. It
   exists so this skill can match repo intent ("the budgeting app")
   to a path on disk. It is not the source of truth for any task's
@@ -182,7 +192,9 @@ Create
   flow add project "<name>" --work-dir <path> [--slug <s>] [--priority h|m|l] [--mkdir]
   flow add task    "<name>" [--slug <s>] [--project <slug>] [--work-dir <path>] [--mkdir]
                            [--priority high|medium|low] [--due <date>] [--assignee <name>]
+                           [--tag <t> ...]
   flow add playbook "<name>" --work-dir <path> [--slug <s>] [--project <slug>] [--mkdir]
+  flow add owner    "<name>" --work-dir <path> --every <dur> [--slug <s>] [--project <slug>] [--mkdir]
 
 Sessions
   flow do               <ref> [--fresh] [--dangerously-skip-permissions] [--force]
@@ -200,6 +212,13 @@ Playbook runs
   flow run playbook <slug> --here   bind THIS Claude session to the new run (no new tab)
   flow run playbook <slug> --auto   run the playbook headlessly in the background (no tab, no human)
   flow list runs [<playbook-slug>]  list playbook runs (filter by playbook optional)
+
+Owners (autonomous ownership — see §4.17)
+  flow owner list                   all owners with status + next tick
+  flow owner show   <slug>          charter + what it owns (in-flight / playbook runs / questions) + next tick
+  flow owner start  <slug>          begin ticking (first tick due now, then every <dur>)
+  flow owner pause  <slug>          stop ticking, keep all state
+  (ticks run headlessly on a launchd timer — you never invoke them by hand)
 
 Read
   flow show task    [<ref>]     (no arg → reverse-lookup via $CLAUDE_CODE_SESSION_ID)
@@ -1685,6 +1704,104 @@ session start. Bash subprocess cwd is irrelevant. `cd
   in another tab.** The env var is per-process; `--here` always
   attaches the *current* session. To attach a session in another
   tab, switch to that tab and run `flow do --here` there.
+
+### 4.17 Owners (autonomous ownership)
+
+An **owner** takes durable, ongoing responsibility for an outcome and
+drives it *itself* — re-waking on an interval, re-evaluating the world,
+and acting — instead of being a one-shot run. It is the self-perpetuating
+layer above tasks/playbooks. An owner is **not a single Claude session**:
+it is a `charter.md` (its operating manual) + a ledger + a clock. Each
+interval it runs a **fresh headless tick** (a new session) that reads the
+charter, reviews what it owns, acts, and exits — then the next tick is
+scheduled automatically.
+
+**Triggers (create an owner):** "create an owner for X", "have something
+keep X true", "automate maintenance of <repo>", "keep all PRs green",
+"own <repo>'s bug-fixing", "run this on a loop forever".
+
+**Creating an owner — interview (operational, like task intake):** the
+charter is the owner's operating manual, so the interview is about *how to
+operate*, not just what. Ask, one at a time:
+1. **What it owns** — the outcome/responsibility in one sentence.
+2. **Where** — work_dir (use the §6 recipe).
+3. **How to observe & act** — what to look at (open PRs, CI, prod health)
+   and what to do when something is off-target. Bootstrap from what flow
+   already knows — the repo's `CLAUDE.md`, the KB (`processes.md` etc.),
+   the workdir registry, `gh` — and only ask the gaps.
+4. **When to ask vs. act** — which decisions need a human (approvals,
+   ambiguous calls) vs. what it may just do.
+5. **Interval** — `--every` (e.g. `30m`, `1h`).
+Then `flow add owner "<name>" --work-dir <p> --every <dur> [--project <s>] [--slug <s>]`,
+and write the gathered operating manual into the owner's `charter.md`
+(overwrite the stub — Read once, then Write). Offer to **start** it
+(`flow owner start <slug>`) so it begins ticking.
+
+**The tag contract — this is how everything an owner touches is tracked:**
+- Every task an owner creates or manages is tagged **`owner:<slug>`**.
+  That makes the owner's ledger just `flow list tasks --tag owner:<slug>`,
+  and the tag renders on `flow show task` so any task shows which owner
+  owns it (bidirectional visibility). Playbook *runs* an owner triggers
+  are tasks too — tag them `owner:<slug>` and they appear in the ledger.
+- A task an owner parks for a human decision is **also tagged `question`**
+  (and assigned to the user). It is a normal task — **never run with
+  `--auto`** — that surfaces in the user's `flow list tasks` queue.
+
+**If you are running as an owner tick** (your bootstrap prompt says "You
+are the autonomous OWNER …"): **you orchestrate; you NEVER execute work
+inline.** A tick is a *sessionless* run that never calls `flow done`, so
+any substantive work you do directly is **lost to the KB and leaves no
+transcript** — the `flow done` close-out sweep (KB entries + project
+update) is what captures learnings, and a tick doesn't get it. So route
+EVERY piece of work through a unit that runs as its own session and
+self-closes with the sweep:
+- **recurring work → a playbook**: create it if needed (`flow add playbook
+  …`), then `flow run playbook <slug> --auto`; tag the run `owner:<slug>`.
+- **one-time work → a task**: `flow add task "<what>" --tag owner:<slug>`,
+  then `flow do --auto <task>` (it self-`flow done`s → the sweep runs).
+- **a human decision → a question task**: `flow add task "<the question>"
+  --tag question --tag owner:<slug>`, assigned to the user.
+
+Each tick: read `owners/<slug>/charter.md`, review what you own via `flow
+list tasks --tag owner:<slug>` (advance/check on in-flight units; never
+duplicate work already tracked), observe per the charter, **dispatch** the
+needed playbook-runs / tasks / questions, and exit. Keep ticks SHORT —
+spin work out, never perform it inline. Do **not** use AskUserQuestion and
+do **not** block. Be conservative with irreversible/outward-facing actions
+unless the charter explicitly authorizes them.
+
+**Answering an owner's question (the human side):** an owner question is a
+normal task tagged `question` + `owner:<slug>`. Answer it **in context** —
+read it (`flow show task <q>`), or `flow do` it for a real back-and-forth,
+capture the answer on the task (a note or the session), then **mark it
+done**. The owner reads the answer on its next tick, resumes the parked
+work, and remembers it (so it won't ask again). Surface these to the user
+when they ask "what does <owner> need from me?" — list
+`flow list tasks --tag owner:<slug> --tag question`.
+
+**Visibility / status:** "how is <owner> doing?" → `flow owner show <slug>`
+(charter, status, next tick, and what it owns split into in-flight /
+playbook runs / questions). "what owners do I have?" → `flow owner list`
+(status + next tick per owner).
+
+**Lifecycle:** `flow owner start` begins ticking; `flow owner pause` stops
+ticking but keeps all state; `flow owner edit` (charter) and retire/archive
+come later. Pausing is the safe "stop it for now" — it never deletes the
+charter, ledger, or owned tasks.
+
+**Anti-patterns:**
+- **Do not auto-create owners.** Like playbooks, owners are created only on
+  an explicit request — they run unattended, so the user must opt in.
+- **Do not let an owner execute work inline in a tick.** Ticks are
+  *sessionless* — no `flow done` KB/project sweep, no transcript. Owners
+  must orchestrate: recurring work becomes a playbook (`flow run playbook
+  … --auto`), one-time work becomes a task (`flow do --auto`), so each unit
+  self-closes with the sweep. Inline work silently loses the learnings the
+  user installed flow to capture.
+- **Do not run a `question`-tagged task with `--auto`.** It is *for* the
+  human; running it autonomously defeats the purpose.
+- **Do not invoke `flow __owner-tick` or `flow owner tick-due` by hand** —
+  those are the scheduler's internal entry points.
 
 ## 6. The `work_dir` question — rules
 

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -220,6 +220,7 @@ Owners (autonomous ownership — see §4.17)
   flow owner pause  <slug>          stop ticking, keep all state
   flow owner tick   <slug>          wake the owner NOW, interactively (a tab you drive); --auto = headless now
   flow owner next   <slug> --in <dur> | --at <when>   set the next tick time (how a tick self-paces)
+  flow owner retire <slug> [--delete]   stop permanently (status=retired+archived); --delete removes row + dir
   (scheduled ticks run headlessly; `flow owner tick` is the on-demand / guided-first-run path)
 
 Read
@@ -1872,9 +1873,16 @@ unattended (mirrors playbook first-run capture, §4.13). After the guided
 first tick, let the scheduler take over headless.
 
 **Lifecycle:** `flow owner start` begins ticking; `flow owner pause` stops
-ticking but keeps all state; `flow owner edit` (charter) and retire/archive
-come later. Pausing is the safe "stop it for now" — it never deletes the
-charter, ledger, or owned tasks.
+ticking but keeps all state (resume with `start`). `flow owner retire
+<slug>` stops it **permanently** (status=retired + archived): it no longer
+ticks and drops off the default list, but its charter/journal/tick-logs and
+the tasks it spawned are preserved. `flow owner retire <slug> --delete`
+hard-removes the row + the `owners/<slug>/` directory (use this instead of
+hand-editing the DB) — owned tasks (tag `owner:<slug>`) still survive.
+Confirm retire/delete via `AskUserQuestion` before running it (it's a
+state mutation; `--delete` is destructive). Pause is the reversible "stop
+for now"; retire is "done with this owner." (`flow owner edit` for the
+charter comes later — for now edit `owners/<slug>/charter.md` directly.)
 
 **Anti-patterns:**
 - **Do not auto-create owners.** Like playbooks, owners are created only on

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -214,8 +214,8 @@ Playbook runs
   flow list runs [<playbook-slug>]  list playbook runs (filter by playbook optional)
 
 Owners (autonomous ownership — see §4.17)
-  flow owner list                   all owners with status + next tick
-  flow owner show   <slug>          charter + what it owns (in-flight / playbook runs / questions) + next tick
+  flow owner list                   all owners with status + next tick   (alias: flow list owners)
+  flow owner show   <slug>          charter + what it owns (in-flight / playbook runs / questions) + next tick   (alias: flow show owner <slug>)
   flow owner start  <slug>          begin ticking (first tick due now, then every <dur>)
   flow owner pause  <slug>          stop ticking, keep all state
   flow owner tick   <slug>          wake the owner NOW, interactively (a tab you drive); --auto = headless now

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -1715,188 +1715,116 @@ session start. Bash subprocess cwd is irrelevant. `cd
 
 ### 4.17 Owners (autonomous ownership)
 
-An **owner** takes durable, ongoing responsibility for an outcome and
-drives it *itself* — re-waking on an interval, re-evaluating the world,
-and acting — instead of being a one-shot run. It is the self-perpetuating
-layer above tasks/playbooks. An owner is **not a single Claude session**:
-it is a `charter.md` (its operating manual) + a ledger + a clock. Each
-interval it runs a **fresh headless tick** (a new session) that reads the
-charter, reviews what it owns, acts, and exits — then the next tick is
-scheduled automatically.
+An **owner** takes durable, ongoing responsibility for an outcome and drives
+it itself — re-waking, re-evaluating, acting — instead of a one-shot run. It
+is **not a single Claude session**: it's a `charter.md` (operating manual) +
+a `updates/` journal + a clock. Each interval it runs a **fresh headless
+tick** (new session) that reads the charter + journal, reviews what it owns,
+orchestrates, self-paces its next wake, and exits.
 
-**Triggers (create an owner):** "create an owner for X", "have something
-keep X true", "automate maintenance of <repo>", "keep all PRs green",
-"own <repo>'s bug-fixing", "run this on a loop forever".
+**Triggers:** "create an owner for X", "keep X true", "automate maintenance
+of <repo>", "own <repo>'s bug-fixing", "run this on a loop".
 
-**Creating an owner — interview (operational, like task intake):** the
-charter is the owner's operating manual, so the interview is about *how to
-operate*, not just what. Ask, one at a time:
-1. **What it owns** — the outcome/responsibility in one sentence.
-2. **Where** — work_dir (use the §6 recipe).
-3. **How to observe & act** — what to look at (open PRs, CI, prod health)
-   and what to do when something is off-target. Bootstrap from what flow
-   already knows — the repo's `CLAUDE.md`, the KB (`processes.md` etc.),
-   the workdir registry, `gh` — and only ask the gaps.
-4. **When to ask vs. act** — which decisions need a human (approvals,
-   ambiguous calls) vs. what it may just do.
-5. **Fallback interval** — `--every` (e.g. `1h`, `24h`; optional, default
-   `24h`). This is NOT a rigid schedule — it's only the *heartbeat floor*.
-   Ticks **self-pace**: each run decides its own next wake. So don't
-   interview for a fixed cron cadence; just pick a loose fallback.
-Then `flow add owner "<name>" --work-dir <p> --every <dur> [--project <s>] [--slug <s>]`,
-and write the gathered operating manual into the owner's `charter.md`
-(overwrite the stub — Read once, then Write). Offer to **start** it
-(`flow owner start <slug>`) so it begins ticking.
+**Creating one — operational interview** (the charter is the *how-to-operate*
+manual). Ask one at a time: (1) **what it owns** (one sentence); (2) **where**
+(work_dir, §6 recipe); (3) **how to observe & act** — what to watch (PRs, CI,
+prod health) and do when off-target, bootstrapping from CLAUDE.md / KB /
+workdir registry / `gh`, asking only the gaps; (4) **when to ask vs. act**;
+(5) **fallback interval** `--every` (optional, default 24h) — NOT a fixed
+schedule, just the heartbeat floor (ticks self-pace). Then `flow add owner
+"<name>" --work-dir <p> [--every <dur>] [--project <s>] [--slug <s>]`, write
+the manual into `charter.md` (Read stub once, then Write), and offer to `flow
+owner start <slug>`.
 
-**The tag contract — this is how everything an owner touches is tracked:**
-- Every task an owner creates or manages is tagged **`owner:<slug>`**.
-  That makes the owner's ledger just `flow list tasks --tag owner:<slug>`,
-  and the tag renders on `flow show task` so any task shows which owner
-  owns it (bidirectional visibility). Playbook *runs* an owner triggers
-  are tasks too — tag them `owner:<slug>` and they appear in the ledger.
-- A task an owner parks for a human decision is **also tagged `question`**
-  (and assigned to the user). It is a normal task — **never run with
-  `--auto`** — that surfaces in the user's `flow list tasks` queue.
+**The tag contract (how everything an owner touches is tracked):**
+- Every task an owner creates/manages is tagged **`owner:<slug>`** → its
+  ledger is `flow list tasks --tag owner:<slug>`, and the tag renders on
+  `flow show task` (bidirectional). Playbook *runs* it triggers are tasks
+  too — tag them likewise.
+- A task it parks for a human is **also tagged `question`** (assigned to the
+  user) — a normal task, **never `--auto`**, surfacing in the user's queue.
 
-**If you are running as an owner tick** (your bootstrap prompt says "You
-are the autonomous OWNER …"): **you orchestrate; you NEVER execute work
-inline.** A tick is a *sessionless* run that never calls `flow done`, so
-any substantive work you do directly is **lost to the KB and leaves no
-transcript** — the `flow done` close-out sweep (KB entries + project
-update) is what captures learnings, and a tick doesn't get it. So route
-EVERY piece of work through a unit that runs as its own session and
-self-closes with the sweep:
-- **recurring work → a playbook**: create it if needed (`flow add playbook
-  …`), then `flow run playbook <slug> --auto`; tag the run `owner:<slug>`.
-- **one-time work → a task**: `flow add task "<what>" --tag owner:<slug>`,
-  then `flow do --auto <task>` (it self-`flow done`s → the sweep runs).
-- **a human decision → a question task**: `flow add task "<the question>"
-  --tag question --tag owner:<slug>`, assigned to the user.
+**Orchestrate, never execute inline.** A tick is *sessionless* and never
+calls `flow done`, so work done directly is lost to the KB (no sweep, no
+transcript). Route EVERY piece of work through a unit that self-closes:
+**recurring → a playbook** (`flow run playbook <slug> --auto`), **one-time →
+a task** (`flow add task "<what>" --tag owner:<slug>` then `flow do --auto
+<task>`), **a human decision → a question task** (`--tag question --tag
+owner:<slug>`). The tick *dispatches*; it never does the fix-work itself.
 
-Each tick: (1) read `owners/<slug>/charter.md`; (2) **read your recent
-notes under `owners/<slug>/updates/`** — that's your *journal* from prior
-ticks (what you dispatched, what you're waiting on, what to check now), the
-same `updates/` convention tasks and playbooks use; (3) review everything
-you own with **`flow owner show <slug>`** — it lists in-flight tasks,
-**playbook runs**, and open questions with status (use this, NOT `flow list
-tasks`, which hides playbook runs); (4) observe per the charter and
-**dispatch** the needed playbook-runs / tasks / questions; (5) **before
-exiting, append a short note to `owners/<slug>/updates/<date>-tick.md`**
-recording what you observed, what you dispatched (with slugs), and what the
-next tick should check. That journal note is the owner's memory — the next
-tick starts from a *blank session* and knows only what's in the journal
-plus the task records. Keep ticks SHORT — spin work out, never perform it
-inline. Do **not** use AskUserQuestion and do **not** block. Be
-conservative with irreversible/outward-facing actions unless the charter
-explicitly authorizes them. Never duplicate work already tracked or
-re-spawn a run that's still in progress.
+**The tick procedure** (the tick's own prompt enforces this; restated for the
+human-side picture). Each tick: read `charter.md`; read recent
+`owners/<slug>/updates/` (its **journal** — what it dispatched / is waiting
+on); review what it owns via **`flow owner show <slug>`** (NOT `flow list
+tasks`, which hides playbook runs); dispatch the needed runs/tasks/questions;
+**self-pace** the next wake (`flow owner next <slug> --in <dur> | --at
+<when>`); append a journal note (what it saw, dispatched-with-slugs, what to
+check next). The next tick starts blank and knows only the journal + task
+records. No AskUserQuestion, no blocking; conservative with
+irreversible/outward actions unless the charter allows; never re-spawn an
+in-progress run.
 
-**Answering an owner's question (the human side):** an owner question is a
-normal task tagged `question` + `owner:<slug>`. Answer it **in context** —
-read it (`flow show task <q>`), or `flow do` it for a real back-and-forth,
-capture the answer on the task (a note or the session), then **mark it
-done**. The owner reads the answer on its next tick, resumes the parked
-work, and remembers it (so it won't ask again). Surface these to the user
-when they ask "what does <owner> need from me?" — list
-`flow list tasks --tag owner:<slug> --tag question`.
+**Answering an owner's question (human side):** it's a normal task tagged
+`question` + `owner:<slug>`. Read it (`flow show task <q>`) or `flow do` it,
+capture the answer on the task, **mark it done** — the owner reads it next
+tick and won't ask again. "What does <owner> need from me?" → `flow list
+tasks --tag owner:<slug> --tag question`.
 
-**Visibility / status:** "how is <owner> doing?" → `flow owner show <slug>`
-(charter, status, next tick, and what it owns split into in-flight /
-playbook runs / questions). "what owners do I have?" → `flow owner list`
-(status + next tick per owner).
+**Status:** `flow owner show <slug>` (charter, status, next tick, in-flight /
+runs / questions); `flow owner list` (all owners + next tick).
 
-**Scheduling is self-paced, not a fixed cron.** Each tick decides when it
-next needs to run and sets it with `flow owner next <slug> --in <dur>` (or
-`--at <when>`) before exiting — e.g. `+15m` while watching a deploy, `+1d`
-when idle. The `--every` value is only a *fallback heartbeat floor*: if a
-tick crashes or never sets its next wake, the owner still re-wakes on
-`--every` instead of going dark. So the cadence is dynamic and decided
-per-run; `--every` is just the backstop. The agent sets this itself — it
-does NOT ask the user to confirm tick timing, even on an interactive tick.
+**Waking on demand / the first tick.** Scheduled ticks fire automatically,
+but `flow owner tick <slug>` runs one **now** — interactive by default
+(spawns a tab the user drives; MAY use AskUserQuestion, can refine the
+charter live); `--auto` runs it headless. It's an extra tick, doesn't disturb
+the schedule. **Strongly prefer an interactive FIRST tick:** when an owner
+shows `last tick: (never)`, offer (via AskUserQuestion) to run it
+interactively so the user navigates the agent and tunes the charter before it
+runs unattended (like playbook first-run capture, §4.13). Then let the
+scheduler take over.
 
-**Ensuring the tick scheduler (host setup — once per machine).** flow has
-**no daemon and no OS-specific scheduler code** — it only provides `flow
-owner tick-due` (scan for due owners, dispatch their ticks). Firing that on
-an interval is **this skill's job, per host**. So when the user creates or
-starts their first owner — or asks "are my owners actually running?" —
-ensure a host scheduler exists that runs `flow owner tick-due` ~every 60s.
-Idempotent: check first, install only if missing, reload if it fell out.
+**Lifecycle:** `start` begins ticking; `pause` stops but keeps state (resume
+with `start`); `flow owner retire <slug>` stops it **permanently**
+(retired+archived — no longer ticks, off the default list, but
+charter/journal/owned-tasks preserved); `--delete` hard-removes the row +
+`owners/<slug>/` dir (use instead of editing the DB; owned tasks survive).
+Confirm retire/delete via AskUserQuestion (`--delete` is destructive). Edit
+the charter directly at `owners/<slug>/charter.md`.
 
-Recipe:
-1. Resolve the binary (`which flow`) and detect the OS (`uname`).
-2. **Check** if already loaded:
-   - macOS: `launchctl list | grep cloud.facets.flow.owner-scheduler` →
-     present means it's running; report and stop.
-3. **Install if missing (macOS / launchd):** write
-   `~/Library/LaunchAgents/cloud.facets.flow.owner-scheduler.plist` with
-   `Label=cloud.facets.flow.owner-scheduler`,
-   `ProgramArguments=[<abs flow path>, owner, tick-due]`,
-   `StartInterval=60`, `RunAtLoad=true`,
-   `StandardOutPath`/`StandardErrorPath` = `~/.flow/owner-scheduler.{log,err.log}`,
-   and — **CRITICAL** — `EnvironmentVariables.PATH` set to the user's full
-   interactive `$PATH`. launchd's default PATH is minimal, so WITHOUT this
-   the tick fails with `exec: "claude": executable file not found in $PATH`
-   (claude/gh/git live in `~/.local/bin`, homebrew, etc., which launchd
-   doesn't include). Capture `echo "$PATH"` and embed it. Then `launchctl
-   load -w <plist>` (use `launchctl bootstrap gui/$UID <plist>` on newer
-   macOS if `load` is unavailable).
-4. **Verify** by re-running `launchctl list | grep flow.owner-scheduler`;
-   report "scheduler installed — owners now tick on their own."
-5. **Linux:** a systemd **user** timer (`OnUnitActiveSec=60s` + a `.service`
-   running `flow owner tick-due`, `systemctl --user enable --now`), or a
-   crontab line `* * * * * <flow> owner tick-due`. Pick what the host has.
+**Ensuring the tick scheduler (host setup, once per machine).** flow has **no
+daemon and no OS-specific scheduler code** — it only provides `flow owner
+tick-due` (scan due owners, dispatch detached ticks). Firing it on an
+interval is **this skill's job, per host**. When the user creates/starts
+their first owner — or asks "are my owners running?" — ensure (idempotently:
+check → install if missing → reload if dropped) a host scheduler runs `flow
+owner tick-due` ~every 60s:
+- **macOS (launchd):** if `launchctl list | grep
+  cloud.facets.flow.owner-scheduler` is absent, write
+  `~/Library/LaunchAgents/cloud.facets.flow.owner-scheduler.plist` —
+  `Label`, `ProgramArguments=[<abs flow>, owner, tick-due]`,
+  `StartInterval=60`, `RunAtLoad=true`,
+  `StandardOut/ErrorPath=~/.flow/owner-scheduler.{log,err.log}`, and —
+  **CRITICAL** — `EnvironmentVariables.PATH` = the user's full interactive
+  `$PATH` (launchd's default PATH is minimal; without it the tick fails
+  `exec: "claude": executable file not found` — claude/gh/git live in
+  ~/.local/bin, homebrew). `launchctl load -w <plist>` (or `bootstrap
+  gui/$UID`), then verify with `launchctl list`.
+- **Linux:** a systemd **user** timer (`OnUnitActiveSec=60s` + a `.service`
+  running `flow owner tick-due`), or `* * * * * <flow> owner tick-due` in
+  crontab.
 
-**Verify-and-respawn** is a health check you can re-run whenever the user
-touches owners: if `launchctl list` no longer shows it (unloaded, reboot
-quirk), reload the plist. To **stop all owners** from ticking, unload it
-(`launchctl unload -w <plist>` + delete the file); to stop just one, `flow
-owner pause <slug>`.
-
-**It's opt-in.** Installing the scheduler makes owners run unattended
-forever until paused/unloaded — offer it via `AskUserQuestion` when the
-first owner is created/started; never install it silently.
-
-**Waking an owner on demand / the first tick:** the scheduler fires ticks
-on the interval, but the user can also wake an owner **now** with `flow
-owner tick <slug>` — to check something early, test, or run the guided
-first tick. It's an *extra* tick; it does not disturb the schedule. By
-default it's **interactive** (spawns a tab the user drives — the session
-MAY use AskUserQuestion and the user can course-correct and refine the
-charter); `flow owner tick <slug> --auto` runs it headless instead.
-
-**Strongly prefer an interactive FIRST tick.** When an owner has never
-ticked (`flow owner show` reports `last tick: (never)`), proactively offer
-to run the first tick interactively via `AskUserQuestion` — the first tick
-is where the charter meets reality, and having the user in the loop lets
-them navigate the agent, catch charter gaps, and tune it before it runs
-unattended (mirrors playbook first-run capture, §4.13). After the guided
-first tick, let the scheduler take over headless.
-
-**Lifecycle:** `flow owner start` begins ticking; `flow owner pause` stops
-ticking but keeps all state (resume with `start`). `flow owner retire
-<slug>` stops it **permanently** (status=retired + archived): it no longer
-ticks and drops off the default list, but its charter/journal/tick-logs and
-the tasks it spawned are preserved. `flow owner retire <slug> --delete`
-hard-removes the row + the `owners/<slug>/` directory (use this instead of
-hand-editing the DB) — owned tasks (tag `owner:<slug>`) still survive.
-Confirm retire/delete via `AskUserQuestion` before running it (it's a
-state mutation; `--delete` is destructive). Pause is the reversible "stop
-for now"; retire is "done with this owner." (`flow owner edit` for the
-charter comes later — for now edit `owners/<slug>/charter.md` directly.)
+It's **opt-in** (owners then run unattended until paused/unloaded) — offer
+via AskUserQuestion; never install silently. Re-verify/respawn whenever the
+user touches owners. **Stop all:** unload the plist; **stop one:** `flow
+owner pause`.
 
 **Anti-patterns:**
-- **Do not auto-create owners.** Like playbooks, owners are created only on
-  an explicit request — they run unattended, so the user must opt in.
-- **Do not let an owner execute work inline in a tick.** Ticks are
-  *sessionless* — no `flow done` KB/project sweep, no transcript. Owners
-  must orchestrate: recurring work becomes a playbook (`flow run playbook
-  … --auto`), one-time work becomes a task (`flow do --auto`), so each unit
-  self-closes with the sweep. Inline work silently loses the learnings the
-  user installed flow to capture.
-- **Do not run a `question`-tagged task with `--auto`.** It is *for* the
-  human; running it autonomously defeats the purpose.
-- **Do not invoke `flow __owner-tick` or `flow owner tick-due` by hand** —
-  those are the scheduler's internal entry points.
+- **Don't auto-create owners** — explicit request only (they run unattended).
+- **Don't let a tick execute work inline** — sessionless, no sweep/transcript;
+  orchestrate via playbook/task runs that self-close.
+- **Don't `--auto` a `question`-tagged task** — it's for the human.
+- **Don't invoke `flow __owner-tick` / `flow owner tick-due` by hand** —
+  scheduler internals.
 
 ## 6. The `work_dir` question — rules
 

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -782,6 +782,11 @@ that…", "record that I…", "document that I just…".
      ("noticed flaky output when X", "next iteration should consolidate
      steps 2 and 3"). Use this when capturing things that should inform
      the playbook itself, not a single run.
+   - For an **owner**, notes go under `~/.flow/owners/<slug>/updates/` —
+     this is the owner's cross-tick **journal** (§4.17). Each headless
+     tick reads the recent notes here to recover what it dispatched and
+     what to check, and appends a new note before exiting. Same `updates/`
+     convention as tasks and playbooks.
 5. Use the `Write` tool to create
    `~/.flow/tasks/<slug>/updates/<filename>.md` with the confirmed
    content. If the user is noting project-level progress, use
@@ -1762,13 +1767,23 @@ self-closes with the sweep:
 - **a human decision → a question task**: `flow add task "<the question>"
   --tag question --tag owner:<slug>`, assigned to the user.
 
-Each tick: read `owners/<slug>/charter.md`, review what you own via `flow
-list tasks --tag owner:<slug>` (advance/check on in-flight units; never
-duplicate work already tracked), observe per the charter, **dispatch** the
-needed playbook-runs / tasks / questions, and exit. Keep ticks SHORT —
-spin work out, never perform it inline. Do **not** use AskUserQuestion and
-do **not** block. Be conservative with irreversible/outward-facing actions
-unless the charter explicitly authorizes them.
+Each tick: (1) read `owners/<slug>/charter.md`; (2) **read your recent
+notes under `owners/<slug>/updates/`** — that's your *journal* from prior
+ticks (what you dispatched, what you're waiting on, what to check now), the
+same `updates/` convention tasks and playbooks use; (3) review everything
+you own with **`flow owner show <slug>`** — it lists in-flight tasks,
+**playbook runs**, and open questions with status (use this, NOT `flow list
+tasks`, which hides playbook runs); (4) observe per the charter and
+**dispatch** the needed playbook-runs / tasks / questions; (5) **before
+exiting, append a short note to `owners/<slug>/updates/<date>-tick.md`**
+recording what you observed, what you dispatched (with slugs), and what the
+next tick should check. That journal note is the owner's memory — the next
+tick starts from a *blank session* and knows only what's in the journal
+plus the task records. Keep ticks SHORT — spin work out, never perform it
+inline. Do **not** use AskUserQuestion and do **not** block. Be
+conservative with irreversible/outward-facing actions unless the charter
+explicitly authorizes them. Never duplicate work already tracked or
+re-spawn a run that's still in progress.
 
 **Answering an owner's question (the human side):** an owner question is a
 normal task tagged `question` + `owner:<slug>`. Answer it **in context** —

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -217,7 +217,7 @@ Playbook runs
 Owners (autonomous ownership — see §4.17)
   flow owner list                   all owners with status + next tick   (alias: flow list owners)
   flow owner show   <slug>          charter + what it owns (in-flight / playbook runs / questions) + next tick   (alias: flow show owner <slug>)
-  flow owner start  <slug>          begin ticking (first tick due now, then every <dur>)
+  flow owner start  <slug>          begin ticking — first tick now, then every <dur> (reactivates a paused OR retired owner)
   flow owner pause  <slug>          stop ticking, keep all state
   flow owner tick   <slug>          wake the owner NOW, interactively (a tab you drive); --auto = headless now
   flow owner next   <slug> --in <dur> | --at <when>   set the next tick time (how a tick self-paces)
@@ -1785,9 +1785,11 @@ runs unattended (like playbook first-run capture, §4.13). Then let the
 scheduler take over.
 
 **Lifecycle:** `start` begins ticking; `pause` stops but keeps state (resume
-with `start`); `flow owner retire <slug>` stops it **permanently**
-(retired+archived — no longer ticks, off the default list, but
-charter/journal/owned-tasks preserved); `--delete` hard-removes the row +
+with `start`); `flow owner retire <slug>` stops it (retired+archived — no
+longer ticks, off the default list, but charter/journal/owned-tasks
+preserved). Retire is reversible: `flow owner start <slug>` reactivates a
+paused OR retired owner (it un-archives and schedules a tick now). For a
+truly permanent removal, `--delete` hard-removes the row +
 `owners/<slug>/` dir (use instead of editing the DB; owned tasks survive).
 Confirm retire/delete via AskUserQuestion (`--delete` is destructive). Edit
 the charter directly at `owners/<slug>/charter.md`.

--- a/internal/flowdb/db.go
+++ b/internal/flowdb/db.go
@@ -194,7 +194,8 @@ type TaskFilter struct {
 	Priority        string
 	Kind            string // "regular" (default), "playbook_run", or "" for all
 	PlaybookSlug    string // optional; filter to runs of one playbook
-	Tag             string // optional; only tasks carrying this tag (already normalized)
+	Tag             string   // optional; only tasks carrying this tag (already normalized)
+	Tags            []string // optional; tasks must carry ALL of these (intersection; already normalized)
 	Since           string // RFC3339 or "" for no lower bound
 	IncludeArchived bool
 	ExcludeDone     bool // hide status=done; ignored if Status is set explicitly
@@ -789,6 +790,16 @@ func ListTasks(db *sql.DB, filter TaskFilter) ([]*Task, error) {
 	if filter.Tag != "" {
 		where = append(where, "slug IN (SELECT task_slug FROM task_tags WHERE tag = ?)")
 		args = append(args, filter.Tag)
+	}
+	// Intersection: each tag adds its own EXISTS-style subquery, ANDed
+	// together, so a task must carry EVERY requested tag (e.g.
+	// `--tag owner:x --tag question`).
+	for _, t := range filter.Tags {
+		if t == "" {
+			continue
+		}
+		where = append(where, "slug IN (SELECT task_slug FROM task_tags WHERE tag = ?)")
+		args = append(args, t)
 	}
 	if filter.Since != "" {
 		where = append(where, "updated_at >= ?")

--- a/internal/flowdb/db.go
+++ b/internal/flowdb/db.go
@@ -85,6 +85,24 @@ CREATE TABLE IF NOT EXISTS task_tags (
     PRIMARY KEY (task_slug, tag)
 );
 
+CREATE TABLE IF NOT EXISTS owners (
+    slug              TEXT PRIMARY KEY,
+    name              TEXT NOT NULL,
+    work_dir          TEXT NOT NULL,
+    project_slug      TEXT REFERENCES projects(slug),
+    status            TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','paused','retired')),
+    every             TEXT NOT NULL,
+    next_wake_at      TEXT,
+    last_tick_at      TEXT,
+    last_tick_status  TEXT,
+    tick_pid          INTEGER,
+    tick_started      TEXT,
+    harness           TEXT,
+    created_at        TEXT NOT NULL,
+    updated_at        TEXT NOT NULL,
+    archived_at       TEXT
+);
+
 CREATE INDEX IF NOT EXISTS idx_tasks_project    ON tasks(project_slug);
 CREATE INDEX IF NOT EXISTS idx_tasks_status     ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_tasks_updated_at ON tasks(updated_at);
@@ -340,6 +358,24 @@ func runMigrations(db *sql.DB) error {
 		if !has {
 			if _, err := db.Exec(col.ddl); err != nil {
 				return fmt.Errorf("add tasks.%s: %w", col.name, err)
+			}
+		}
+	}
+
+	// owners: live-tick bookkeeping columns (the tick-running indicator).
+	// Fresh DBs get these from schemaDDL; DBs whose owners table predates
+	// the columns get them via ALTER. All nullable.
+	for _, col := range []struct{ name, ddl string }{
+		{"tick_pid", "ALTER TABLE owners ADD COLUMN tick_pid INTEGER"},
+		{"tick_started", "ALTER TABLE owners ADD COLUMN tick_started TEXT"},
+	} {
+		has, err := columnExists(db, "owners", col.name)
+		if err != nil {
+			return err
+		}
+		if !has {
+			if _, err := db.Exec(col.ddl); err != nil {
+				return fmt.Errorf("add owners.%s: %w", col.name, err)
 			}
 		}
 	}

--- a/internal/flowdb/owners.go
+++ b/internal/flowdb/owners.go
@@ -1,0 +1,211 @@
+package flowdb
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Owner mirrors the owners table. An owner is a durable, named,
+// repo-scoped self-prompting controller: it wakes on a time interval
+// (Every), runs a headless tick, and schedules its NextWakeAt. It is
+// not a single Claude session — each tick is a fresh run. See
+// docs/superpowers/specs/2026-06-08-autonomous-owner-harness-design.md.
+type Owner struct {
+	Slug           string
+	Name           string
+	WorkDir        string
+	ProjectSlug    sql.NullString
+	Status         string // 'active' | 'paused' | 'retired'
+	Every          string // interval, e.g. "30m"
+	NextWakeAt     sql.NullString
+	LastTickAt     sql.NullString
+	LastTickStatus sql.NullString
+	// Live-tick bookkeeping: when a tick is dispatched, TickPID holds the
+	// detached `flow __owner-tick` supervisor pid and TickStarted the start
+	// time; both are cleared when the tick finishes. A non-NULL TickPID
+	// whose process is still alive means "a tick is running right now"
+	// (read paths reconcile a dead pid — see reconcileOwnerTick).
+	TickPID     sql.NullInt64
+	TickStarted sql.NullString
+	Harness     sql.NullString
+	CreatedAt   string
+	UpdatedAt   string
+	ArchivedAt  sql.NullString
+}
+
+// OwnerFilter holds optional filters for ListOwners.
+type OwnerFilter struct {
+	Status          string
+	IncludeArchived bool
+}
+
+const OwnerCols = "slug, name, work_dir, project_slug, status, every, next_wake_at, last_tick_at, last_tick_status, tick_pid, tick_started, harness, created_at, updated_at, archived_at"
+
+func ScanOwner(row interface{ Scan(dest ...any) error }) (*Owner, error) {
+	var o Owner
+	err := row.Scan(
+		&o.Slug, &o.Name, &o.WorkDir, &o.ProjectSlug, &o.Status, &o.Every,
+		&o.NextWakeAt, &o.LastTickAt, &o.LastTickStatus, &o.TickPID, &o.TickStarted, &o.Harness,
+		&o.CreatedAt, &o.UpdatedAt, &o.ArchivedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &o, nil
+}
+
+// CreateOwner inserts a new owner. Status defaults to 'active' and
+// timestamps are stamped if unset. NextWakeAt is left as-is (NULL until
+// the owner is started).
+func CreateOwner(db *sql.DB, o *Owner) error {
+	now := NowISO()
+	if o.CreatedAt == "" {
+		o.CreatedAt = now
+	}
+	o.UpdatedAt = now
+	if o.Status == "" {
+		o.Status = "active"
+	}
+	_, err := db.Exec(`
+		INSERT INTO owners (slug, name, work_dir, project_slug, status, every,
+			next_wake_at, last_tick_at, last_tick_status, tick_pid, tick_started, harness, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		o.Slug, o.Name, o.WorkDir, o.ProjectSlug, o.Status, o.Every,
+		o.NextWakeAt, o.LastTickAt, o.LastTickStatus, o.TickPID, o.TickStarted, o.Harness, o.CreatedAt, o.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("create owner %s: %w", o.Slug, err)
+	}
+	return nil
+}
+
+func GetOwner(db *sql.DB, slug string) (*Owner, error) {
+	row := db.QueryRow("SELECT "+OwnerCols+" FROM owners WHERE slug = ?", slug)
+	return ScanOwner(row)
+}
+
+// UpdateOwner persists an owner's mutable fields (name, work_dir,
+// project_slug, status, every, scheduling, last-tick bookkeeping,
+// harness) by slug and re-stamps updated_at. The caller loads an owner,
+// mutates fields, and calls this — the single update path used by
+// start/pause and by tick recording. archived_at is not touched here
+// (use a dedicated archive command).
+func UpdateOwner(db *sql.DB, o *Owner) error {
+	o.UpdatedAt = NowISO()
+	res, err := db.Exec(`
+		UPDATE owners SET
+			name             = ?,
+			work_dir         = ?,
+			project_slug     = ?,
+			status           = ?,
+			every            = ?,
+			next_wake_at     = ?,
+			last_tick_at     = ?,
+			last_tick_status = ?,
+			tick_pid         = ?,
+			tick_started     = ?,
+			harness          = ?,
+			updated_at       = ?
+		WHERE slug = ?`,
+		o.Name, o.WorkDir, o.ProjectSlug, o.Status, o.Every,
+		o.NextWakeAt, o.LastTickAt, o.LastTickStatus, o.TickPID, o.TickStarted, o.Harness, o.UpdatedAt, o.Slug,
+	)
+	if err != nil {
+		return fmt.Errorf("update owner %s: %w", o.Slug, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fmt.Errorf("update owner %s: no such owner", o.Slug)
+	}
+	return nil
+}
+
+// DueOwners returns active, non-archived owners whose next_wake_at is
+// set and at or before nowISO — i.e. the owners the scheduler should
+// tick now. Paused/retired owners and owners that have never been
+// started (NULL next_wake_at) are excluded.
+//
+// Comparison is done on PARSED times, not raw strings: next_wake_at may
+// be stored with any timezone offset (flow's NowISO uses local tz), so a
+// lexicographic string compare against a differently-offset now would be
+// wrong (e.g. "…23:55+05:30" sorts after "…18:30Z" but is earlier). We
+// filter the small candidate set in Go after parsing. Sorted by wake
+// time so the most-overdue owner ticks first.
+func DueOwners(db *sql.DB, nowISO string) ([]*Owner, error) {
+	now, err := time.Parse(time.RFC3339, nowISO)
+	if err != nil {
+		return nil, fmt.Errorf("due owners: parse now %q: %w", nowISO, err)
+	}
+	q := "SELECT " + OwnerCols + ` FROM owners
+		WHERE status = 'active'
+		  AND archived_at IS NULL
+		  AND next_wake_at IS NOT NULL
+		ORDER BY next_wake_at, slug`
+	rows, err := db.Query(q)
+	if err != nil {
+		return nil, fmt.Errorf("due owners: %w", err)
+	}
+	defer rows.Close()
+	var candidates []*Owner
+	for rows.Next() {
+		o, err := ScanOwner(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan owner: %w", err)
+		}
+		candidates = append(candidates, o)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	var out []*Owner
+	for _, o := range candidates {
+		wake, err := time.Parse(time.RFC3339, o.NextWakeAt.String)
+		if err != nil {
+			// Unparseable next_wake_at: skip rather than crash the whole
+			// scheduler pass on one bad row.
+			continue
+		}
+		if !wake.After(now) { // wake <= now → due
+			out = append(out, o)
+		}
+	}
+	return out, nil
+}
+
+// ListOwners returns owners matching filter, sorted by slug. Archived
+// owners are excluded unless IncludeArchived is set.
+func ListOwners(db *sql.DB, filter OwnerFilter) ([]*Owner, error) {
+	var where []string
+	var args []any
+	if filter.Status != "" {
+		where = append(where, "status = ?")
+		args = append(args, filter.Status)
+	}
+	if !filter.IncludeArchived {
+		where = append(where, "archived_at IS NULL")
+	}
+	q := "SELECT " + OwnerCols + " FROM owners"
+	if len(where) > 0 {
+		q += " WHERE " + strings.Join(where, " AND ")
+	}
+	q += " ORDER BY slug"
+	rows, err := db.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list owners: %w", err)
+	}
+	defer rows.Close()
+	var out []*Owner
+	for rows.Next() {
+		o, err := ScanOwner(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan owner: %w", err)
+		}
+		out = append(out, o)
+	}
+	return out, rows.Err()
+}

--- a/internal/flowdb/owners.go
+++ b/internal/flowdb/owners.go
@@ -8,9 +8,10 @@ import (
 )
 
 // Owner mirrors the owners table. An owner is a durable, named,
-// repo-scoped self-prompting controller: it wakes on a time interval
-// (Every), runs a headless tick, and schedules its NextWakeAt. It is
-// not a single Claude session — each tick is a fresh run. See
+// repo-scoped self-prompting controller: each tick runs a headless run
+// and self-paces its NextWakeAt; Every is only the fallback heartbeat
+// floor, not a fixed schedule. It is not a single Claude session — each
+// tick is a fresh run. See
 // docs/superpowers/specs/2026-06-08-autonomous-owner-harness-design.md.
 type Owner struct {
 	Slug           string

--- a/internal/flowdb/owners.go
+++ b/internal/flowdb/owners.go
@@ -125,6 +125,47 @@ func UpdateOwner(db *sql.DB, o *Owner) error {
 	return nil
 }
 
+// RetireOwner permanently stops an owner: sets status='retired' and
+// archives it. It no longer ticks (DueOwners requires active) and is
+// hidden from the default list. On-disk files (charter, journal, tick
+// logs) and any owned tasks are preserved. Errors if no such owner.
+func RetireOwner(db *sql.DB, slug string) error {
+	now := NowISO()
+	res, err := db.Exec(
+		`UPDATE owners SET status='retired', archived_at=COALESCE(archived_at, ?), updated_at=? WHERE slug=?`,
+		now, now, slug,
+	)
+	if err != nil {
+		return fmt.Errorf("retire owner %s: %w", slug, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fmt.Errorf("retire owner %s: no such owner", slug)
+	}
+	return nil
+}
+
+// DeleteOwner removes the owner row entirely. The caller is responsible
+// for removing the on-disk owners/<slug>/ directory. Errors if no such
+// owner. Owned tasks (tagged owner:<slug>) are independent and untouched.
+func DeleteOwner(db *sql.DB, slug string) error {
+	res, err := db.Exec(`DELETE FROM owners WHERE slug=?`, slug)
+	if err != nil {
+		return fmt.Errorf("delete owner %s: %w", slug, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fmt.Errorf("delete owner %s: no such owner", slug)
+	}
+	return nil
+}
+
 // DueOwners returns active, non-archived owners whose next_wake_at is
 // set and at or before nowISO — i.e. the owners the scheduler should
 // tick now. Paused/retired owners and owners that have never been

--- a/internal/flowdb/owners.go
+++ b/internal/flowdb/owners.go
@@ -126,6 +126,57 @@ func UpdateOwner(db *sql.DB, o *Owner) error {
 	return nil
 }
 
+// affectedOwnerRow checks an UPDATE result for the "exactly one owner
+// matched" contract shared by the targeted owner-mutation helpers below.
+func affectedOwnerRow(res sql.Result, err error, op, slug string) error {
+	if err != nil {
+		return fmt.Errorf("%s owner %s: %w", op, slug, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fmt.Errorf("%s owner %s: no such owner", op, slug)
+	}
+	return nil
+}
+
+// SetOwnerNextWake sets ONLY next_wake_at (targeted column write). Used by
+// `flow owner next` and a tick's self-pacing. It deliberately does not
+// load+rewrite the whole row, so it can never clobber the tick-bookkeeping
+// columns (tick_pid/last_tick_*) a concurrent tick may be writing.
+func SetOwnerNextWake(db *sql.DB, slug, nextWakeAt string) error {
+	res, err := db.Exec(
+		`UPDATE owners SET next_wake_at=?, updated_at=? WHERE slug=?`,
+		nextWakeAt, NowISO(), slug,
+	)
+	return affectedOwnerRow(res, err, "set next wake", slug)
+}
+
+// ActivateOwner marks an owner active, schedules its next wake, and CLEARS
+// archived_at — so `flow owner start` un-retires a retired owner (otherwise
+// DueOwners' `archived_at IS NULL` filter would leave it active-but-never-
+// ticking and hidden from the list). Targeted write; touches no tick
+// bookkeeping.
+func ActivateOwner(db *sql.DB, slug, nextWakeAt string) error {
+	res, err := db.Exec(
+		`UPDATE owners SET status='active', next_wake_at=?, archived_at=NULL, updated_at=? WHERE slug=?`,
+		nextWakeAt, NowISO(), slug,
+	)
+	return affectedOwnerRow(res, err, "activate", slug)
+}
+
+// PauseOwner marks an owner paused (targeted; preserves every other column,
+// including any in-flight tick bookkeeping).
+func PauseOwner(db *sql.DB, slug string) error {
+	res, err := db.Exec(
+		`UPDATE owners SET status='paused', updated_at=? WHERE slug=?`,
+		NowISO(), slug,
+	)
+	return affectedOwnerRow(res, err, "pause", slug)
+}
+
 // RetireOwner permanently stops an owner: sets status='retired' and
 // archives it. It no longer ticks (DueOwners requires active) and is
 // hidden from the default list. On-disk files (charter, journal, tick

--- a/internal/flowdb/owners_test.go
+++ b/internal/flowdb/owners_test.go
@@ -155,6 +155,71 @@ func TestDueOwnersSkipsUnparseableNextWake(t *testing.T) {
 	}
 }
 
+// The targeted owner-mutation helpers must touch ONLY their own columns —
+// never clobber in-flight tick bookkeeping (the dispatch/finish race fix).
+func TestTargetedOwnerMutationsPreserveTickBookkeeping(t *testing.T) {
+	db := openTempDB(t)
+	if err := CreateOwner(db, &Owner{
+		Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m",
+		TickPID:        sql.NullInt64{Int64: 4242, Valid: true},
+		TickStarted:    sql.NullString{String: "2026-06-09T00:00:00Z", Valid: true},
+		LastTickStatus: sql.NullString{String: "ok", Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SetOwnerNextWake(db, "o1", "2026-06-09T01:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	o, _ := GetOwner(db, "o1")
+	if o.NextWakeAt.String != "2026-06-09T01:00:00Z" {
+		t.Errorf("SetOwnerNextWake didn't set next_wake_at: %q", o.NextWakeAt.String)
+	}
+	if o.TickPID.Int64 != 4242 || o.LastTickStatus.String != "ok" {
+		t.Errorf("SetOwnerNextWake clobbered tick bookkeeping: pid=%v status=%q", o.TickPID, o.LastTickStatus.String)
+	}
+
+	if err := PauseOwner(db, "o1"); err != nil {
+		t.Fatal(err)
+	}
+	o, _ = GetOwner(db, "o1")
+	if o.Status != "paused" {
+		t.Errorf("PauseOwner status=%q, want paused", o.Status)
+	}
+	if o.TickPID.Int64 != 4242 {
+		t.Errorf("PauseOwner clobbered tick_pid: %v", o.TickPID)
+	}
+}
+
+// ActivateOwner clears archived_at so `flow owner start` un-retires a
+// retired owner (otherwise it'd be active-but-hidden and never tick).
+func TestActivateOwnerUnretires(t *testing.T) {
+	db := openTempDB(t)
+	if err := CreateOwner(db, &Owner{Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := RetireOwner(db, "o1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := ActivateOwner(db, "o1", "2000-01-01T00:00:00Z"); err != nil {
+		t.Fatal(err)
+	}
+	o, _ := GetOwner(db, "o1")
+	if o.Status != "active" {
+		t.Errorf("status=%q, want active", o.Status)
+	}
+	if o.ArchivedAt.Valid {
+		t.Errorf("ActivateOwner must clear archived_at, got %q", o.ArchivedAt.String)
+	}
+	due, err := DueOwners(db, "2026-06-08T12:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(due) != 1 || due[0].Slug != "o1" {
+		t.Errorf("reactivated owner should be due (archived_at NULL + past wake), got %v", due)
+	}
+}
+
 func TestRetireOwner(t *testing.T) {
 	db := openTempDB(t)
 	if err := CreateOwner(db, &Owner{

--- a/internal/flowdb/owners_test.go
+++ b/internal/flowdb/owners_test.go
@@ -127,6 +127,34 @@ func TestDueOwnersReturnsOnlyActivePastDue(t *testing.T) {
 	}
 }
 
+// A row whose next_wake_at can't be parsed must be skipped, not crash the
+// whole scheduler pass — DueOwners is defensive against a corrupt value.
+func TestDueOwnersSkipsUnparseableNextWake(t *testing.T) {
+	db := openTempDB(t)
+
+	const now = "2026-06-08T12:00:00Z"
+	past := sql.NullString{String: "2026-06-08T11:00:00Z", Valid: true}
+	if err := CreateOwner(db, &Owner{Slug: "good", Name: "n", WorkDir: "/x", Every: "1h", Status: "active", NextWakeAt: past}); err != nil {
+		t.Fatal(err)
+	}
+	if err := CreateOwner(db, &Owner{Slug: "garbage", Name: "n", WorkDir: "/x", Every: "1h", Status: "active",
+		NextWakeAt: sql.NullString{String: "not-a-timestamp", Valid: true}}); err != nil {
+		t.Fatal(err)
+	}
+
+	due, err := DueOwners(db, now)
+	if err != nil {
+		t.Fatalf("DueOwners must not error on a garbage row: %v", err)
+	}
+	if len(due) != 1 || due[0].Slug != "good" {
+		var slugs []string
+		for _, o := range due {
+			slugs = append(slugs, o.Slug)
+		}
+		t.Fatalf("DueOwners = %v, want only [good] (garbage row skipped)", slugs)
+	}
+}
+
 func TestRetireOwner(t *testing.T) {
 	db := openTempDB(t)
 	if err := CreateOwner(db, &Owner{

--- a/internal/flowdb/owners_test.go
+++ b/internal/flowdb/owners_test.go
@@ -2,6 +2,7 @@ package flowdb
 
 import (
 	"database/sql"
+	"errors"
 	"testing"
 )
 
@@ -123,6 +124,56 @@ func TestDueOwnersReturnsOnlyActivePastDue(t *testing.T) {
 			slugs = append(slugs, o.Slug)
 		}
 		t.Fatalf("DueOwners = %v, want only [due-now]", slugs)
+	}
+}
+
+func TestRetireOwner(t *testing.T) {
+	db := openTempDB(t)
+	if err := CreateOwner(db, &Owner{
+		Slug: "o1", Name: "O", WorkDir: "/x", Every: "1h", Status: "active",
+		NextWakeAt: sql.NullString{String: "2020-01-01T00:00:00Z", Valid: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RetireOwner(db, "o1"); err != nil {
+		t.Fatalf("RetireOwner: %v", err)
+	}
+	o, err := GetOwner(db, "o1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if o.Status != "retired" {
+		t.Errorf("status = %q, want retired", o.Status)
+	}
+	if !o.ArchivedAt.Valid {
+		t.Errorf("archived_at should be set on retire")
+	}
+	// Hidden from the default list and never due.
+	if list, _ := ListOwners(db, OwnerFilter{}); len(list) != 0 {
+		t.Errorf("retired owner should be hidden from default list, got %d", len(list))
+	}
+	if due, _ := DueOwners(db, "2099-01-01T00:00:00Z"); len(due) != 0 {
+		t.Errorf("retired owner must never be due, got %d", len(due))
+	}
+	if err := RetireOwner(db, "nope"); err == nil {
+		t.Errorf("retiring an unknown owner should error")
+	}
+}
+
+func TestDeleteOwner(t *testing.T) {
+	db := openTempDB(t)
+	if err := CreateOwner(db, &Owner{Slug: "o1", Name: "O", WorkDir: "/x", Every: "1h"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := DeleteOwner(db, "o1"); err != nil {
+		t.Fatalf("DeleteOwner: %v", err)
+	}
+	if _, err := GetOwner(db, "o1"); !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("owner row should be gone, got err=%v", err)
+	}
+	if err := DeleteOwner(db, "o1"); err == nil {
+		t.Errorf("deleting an already-gone owner should error")
 	}
 }
 

--- a/internal/flowdb/owners_test.go
+++ b/internal/flowdb/owners_test.go
@@ -1,0 +1,214 @@
+package flowdb
+
+import (
+	"database/sql"
+	"testing"
+)
+
+func TestCreateAndGetOwner(t *testing.T) {
+	db := openTempDB(t)
+
+	o := &Owner{
+		Slug:    "af-maint",
+		Name:    "agent-factory maintenance",
+		WorkDir: "/Users/anshulsao/code/agent-factory",
+		Every:   "30m",
+	}
+	if err := CreateOwner(db, o); err != nil {
+		t.Fatalf("CreateOwner: %v", err)
+	}
+
+	got, err := GetOwner(db, "af-maint")
+	if err != nil {
+		t.Fatalf("GetOwner: %v", err)
+	}
+	if got.Name != "agent-factory maintenance" {
+		t.Errorf("Name = %q, want %q", got.Name, "agent-factory maintenance")
+	}
+	if got.WorkDir != "/Users/anshulsao/code/agent-factory" {
+		t.Errorf("WorkDir = %q", got.WorkDir)
+	}
+	if got.Every != "30m" {
+		t.Errorf("Every = %q, want 30m", got.Every)
+	}
+	if got.Status != "active" {
+		t.Errorf("Status = %q, want default active", got.Status)
+	}
+	if got.CreatedAt == "" || got.UpdatedAt == "" {
+		t.Errorf("timestamps not set: created=%q updated=%q", got.CreatedAt, got.UpdatedAt)
+	}
+	if got.NextWakeAt.Valid {
+		t.Errorf("NextWakeAt should be NULL on a freshly created (un-started) owner, got %q", got.NextWakeAt.String)
+	}
+}
+
+func TestListOwnersOrdersAndFilters(t *testing.T) {
+	db := openTempDB(t)
+
+	for _, o := range []*Owner{
+		{Slug: "ccc", Name: "C", WorkDir: "/c", Every: "30m"},
+		{Slug: "aaa", Name: "A", WorkDir: "/a", Every: "1h"},
+		{Slug: "bbb", Name: "B", WorkDir: "/b", Every: "1h", Status: "paused"},
+	} {
+		if err := CreateOwner(db, o); err != nil {
+			t.Fatalf("CreateOwner %s: %v", o.Slug, err)
+		}
+	}
+	// Archive one so the default list should exclude it.
+	if _, err := db.Exec(`UPDATE owners SET archived_at = ? WHERE slug = 'ccc'`, NowISO()); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+
+	// Default: non-archived, sorted by slug.
+	got, err := ListOwners(db, OwnerFilter{})
+	if err != nil {
+		t.Fatalf("ListOwners: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("default list len = %d, want 2 (ccc archived)", len(got))
+	}
+	if got[0].Slug != "aaa" || got[1].Slug != "bbb" {
+		t.Errorf("order = [%s %s], want [aaa bbb]", got[0].Slug, got[1].Slug)
+	}
+
+	// Status filter.
+	paused, err := ListOwners(db, OwnerFilter{Status: "paused"})
+	if err != nil {
+		t.Fatalf("ListOwners(paused): %v", err)
+	}
+	if len(paused) != 1 || paused[0].Slug != "bbb" {
+		t.Errorf("paused filter = %v, want [bbb]", paused)
+	}
+
+	// IncludeArchived surfaces the archived owner too.
+	all, err := ListOwners(db, OwnerFilter{IncludeArchived: true})
+	if err != nil {
+		t.Fatalf("ListOwners(all): %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("IncludeArchived list len = %d, want 3", len(all))
+	}
+}
+
+func TestDueOwnersReturnsOnlyActivePastDue(t *testing.T) {
+	db := openTempDB(t)
+
+	const now = "2026-06-08T12:00:00Z"
+	past := sql.NullString{String: "2026-06-08T11:00:00Z", Valid: true}
+	future := sql.NullString{String: "2026-06-08T13:00:00Z", Valid: true}
+
+	owners := []*Owner{
+		{Slug: "due-now", Name: "n", WorkDir: "/x", Every: "1h", Status: "active", NextWakeAt: past},
+		{Slug: "future", Name: "n", WorkDir: "/x", Every: "1h", Status: "active", NextWakeAt: future},
+		{Slug: "never-started", Name: "n", WorkDir: "/x", Every: "1h", Status: "active"}, // NextWakeAt NULL
+		{Slug: "paused-due", Name: "n", WorkDir: "/x", Every: "1h", Status: "paused", NextWakeAt: past},
+		{Slug: "archived-due", Name: "n", WorkDir: "/x", Every: "1h", Status: "active", NextWakeAt: past},
+	}
+	for _, o := range owners {
+		if err := CreateOwner(db, o); err != nil {
+			t.Fatalf("CreateOwner %s: %v", o.Slug, err)
+		}
+	}
+	if _, err := db.Exec(`UPDATE owners SET archived_at = ? WHERE slug = 'archived-due'`, now); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+
+	due, err := DueOwners(db, now)
+	if err != nil {
+		t.Fatalf("DueOwners: %v", err)
+	}
+	if len(due) != 1 || due[0].Slug != "due-now" {
+		var slugs []string
+		for _, o := range due {
+			slugs = append(slugs, o.Slug)
+		}
+		t.Fatalf("DueOwners = %v, want only [due-now]", slugs)
+	}
+}
+
+func TestDueOwnersHandlesMixedTimezoneOffsets(t *testing.T) {
+	db := openTempDB(t)
+
+	// next_wake stored with a +05:30 offset == 18:25:00 UTC. It IS due when
+	// "now" is 18:30:00Z, but a naive string comparison ("23:55…+05:30" >
+	// "18:30…Z") would wrongly skip it. Comparison must be timezone-correct.
+	wake := sql.NullString{String: "2026-06-08T23:55:00+05:30", Valid: true}
+	if err := CreateOwner(db, &Owner{
+		Slug: "o", Name: "O", WorkDir: "/x", Every: "30m", Status: "active", NextWakeAt: wake,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := DueOwners(db, "2026-06-08T18:30:00Z")
+	if err != nil {
+		t.Fatalf("DueOwners: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("owner due at 18:25Z must be returned when now=18:30Z (mixed offsets); got %d", len(got))
+	}
+}
+
+func TestOwnerTickFieldsPersist(t *testing.T) {
+	db := openTempDB(t)
+	o := &Owner{Slug: "o", Name: "O", WorkDir: "/x", Every: "30m"}
+	if err := CreateOwner(db, o); err != nil {
+		t.Fatal(err)
+	}
+	// A freshly created owner has no tick running.
+	if o.TickPID.Valid {
+		t.Errorf("new owner should have NULL tick_pid")
+	}
+
+	o.TickPID = sql.NullInt64{Int64: 4242, Valid: true}
+	o.TickStarted = sql.NullString{String: "2026-06-09T00:00:00Z", Valid: true}
+	if err := UpdateOwner(db, o); err != nil {
+		t.Fatal(err)
+	}
+	got, err := GetOwner(db, "o")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.TickPID.Int64 != 4242 {
+		t.Errorf("TickPID = %+v, want 4242", got.TickPID)
+	}
+	if got.TickStarted.String != "2026-06-09T00:00:00Z" {
+		t.Errorf("TickStarted = %+v", got.TickStarted)
+	}
+}
+
+func TestUpdateOwnerPersistsMutableFields(t *testing.T) {
+	db := openTempDB(t)
+
+	o := &Owner{Slug: "o1", Name: "O", WorkDir: "/x", Every: "30m"}
+	if err := CreateOwner(db, o); err != nil {
+		t.Fatalf("CreateOwner: %v", err)
+	}
+
+	o.Status = "paused"
+	o.NextWakeAt = sql.NullString{String: "2026-06-08T13:00:00Z", Valid: true}
+	o.LastTickAt = sql.NullString{String: "2026-06-08T12:00:00Z", Valid: true}
+	o.LastTickStatus = sql.NullString{String: "ok", Valid: true}
+	if err := UpdateOwner(db, o); err != nil {
+		t.Fatalf("UpdateOwner: %v", err)
+	}
+
+	got, err := GetOwner(db, "o1")
+	if err != nil {
+		t.Fatalf("GetOwner: %v", err)
+	}
+	if got.Status != "paused" {
+		t.Errorf("Status = %q, want paused", got.Status)
+	}
+	if got.NextWakeAt.String != "2026-06-08T13:00:00Z" {
+		t.Errorf("NextWakeAt = %q", got.NextWakeAt.String)
+	}
+	if got.LastTickAt.String != "2026-06-08T12:00:00Z" {
+		t.Errorf("LastTickAt = %q", got.LastTickAt.String)
+	}
+	if got.LastTickStatus.String != "ok" {
+		t.Errorf("LastTickStatus = %q, want ok", got.LastTickStatus.String)
+	}
+	if got.UpdatedAt == "" {
+		t.Errorf("UpdatedAt not set")
+	}
+}


### PR DESCRIPTION
## What

Adds **owners** — durable, named, repo-scoped *self-prompting controllers* that take ongoing responsibility for an outcome (re-wake, re-evaluate, act until done), vs. flow's one-shot `flow do --auto` and manual playbooks.

An owner is **not a single Claude session**. It is a charter (operating manual) + a journal + a clock. Each tick is a *fresh headless run* that reads its charter + journal, reviews what it owns, **orchestrates** (never executes inline — it routes work through tasks/playbook-runs that self-close with the `flow done` KB sweep), parks human decisions as question-tasks, **self-paces** its next wake, and journals.

Design doc: `docs/superpowers/specs/2026-06-08-autonomous-owner-harness-design.md`

## How ticks fire (no daemon, portable)

- flow stays **pure CLI** — no daemon, **no OS-specific scheduler code**. It only provides `flow owner tick-due` (scan due owners → dispatch detached ticks).
- A **launchd agent** set up per-host **by the flow skill** (not compiled in) polls it every ~60s. Linux → systemd-timer/cron via the same skill recipe.

## Commands

```
flow add owner "<name>" --work-dir <p> [--every <dur>] [--project] [--slug]
flow owner list | show | start | pause     # list/show also verb-first:
flow list owners                  # alias of: flow owner list
flow show owner <slug>            # alias of: flow owner show <slug>
flow owner tick <slug>            interactive (you drive); --auto = headless now
flow owner next <slug> --in <dur> | --at <when>   self-pace the next wake
flow owner retire <slug> [--delete]
flow owner tick-due               scheduler entry (+ internal flow __owner-tick)
```

## Model highlights

- **Orchestrate, never inline** — ticks are sessionless (no `flow done` sweep), so they route work through tasks (one-time) / playbooks (recurring) that self-close and capture learnings.
- **Tags, not new tables** — the only new table is `owners`; owner↔task linkage and the question marker reuse the existing tag system (`owner:<slug>`, `question`).
- **Self-paced scheduling** — each tick sets its own next wake (`flow owner next`); `--every` is just a fallback heartbeat floor.
- **Cross-tick journal** — `owners/<slug>/updates/`, read at tick start, written before exit (the owner's memory across blank-session ticks).
- **Live tick indicator** + **overlap guard** (skip owners with a running tick) + dead-pid reconciliation.

## Tests

All TDD (RED → GREEN). Full suite green, no regressions.

## Status

**Draft** — opening for review before merge. Dogfooding live: an `af-stability` owner is already watching Agent Factory prod (found a stuck scheduled job, autonomously raised a GitHub issue + TDD'd PR, stopped before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

