### PR TITLE
feat: add `flow checkpoint` for mid-session progress notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   gap where flow injects context at `SessionStart` but nothing prompts for
   the `updates/` notes a future `flow do` reads back on resume — so on
   heavy days they go unwritten and the next resume reads a stale brief.
-  ([#72](https://github.com/Facets-cloud/flow/issues/72))
+  ([#73](https://github.com/Facets-cloud/flow/pull/73) by
+  [@sanmesh-kakade](https://github.com/sanmesh-kakade), closes
+  [#72](https://github.com/Facets-cloud/flow/issues/72))
 
 ## [0.1.0-alpha.21] — 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+
+- **`flow checkpoint [<ref>]` — mid-session progress note from the live
+  transcript.** The non-terminal sibling of `flow done`: where done flips
+  status and runs a strict KB + project-update sweep at the end of a
+  task's life, checkpoint runs a lighter, task-local sweep at any
+  breakpoint *during* the work. It reuses the headless `claude -p` engine
+  to read the task's transcript and draft ONE dated note into
+  `tasks/<slug>/updates/` for the user to review — no status change, no KB
+  writes. Resolution mirrors `flow show task`: an explicit ref resolves by
+  slug, no ref reverse-looks-up the task bound to the current session;
+  either way the task must carry a session_id. This closes the write-back
+  gap where flow injects context at `SessionStart` but nothing prompts for
+  the `updates/` notes a future `flow do` reads back on resume — so on
+  heavy days they go unwritten and the next resume reads a stale brief.
+  ([#72](https://github.com/Facets-cloud/flow/issues/72))
+
 ## [0.1.0-alpha.21] — 2026-06-11
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,5 +9,6 @@ Thanks to everyone who has contributed to flow.
 - [Swapnil Dahiphale](https://github.com/swapnildahiphale) (@swapnildahiphale)
 - [Vishnu Kadavarath Viswambharan](https://github.com/vishnukv-facets) (@vishnukv-facets)
 - [Ashish Chaturvedi](https://github.com/cyphernext) (@cyphernext)
+- [Sanmesh Kakade](https://github.com/sanmesh-kakade) (@sanmesh-kakade)
 
 To add yourself, open a PR — see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ the next one smarter.
   a headless Claude pass that re-reads the entire transcript and
   pulls anything kb-worthy that the live scoop missed. The status
   flip is the contract; the sweep is best-effort.
+- **Checkpoint (mid-session):** `flow checkpoint` runs the same
+  headless pass *without* closing the task — it reads the live
+  transcript and drafts one dated note into the task's `updates/`
+  for you to review. It's the non-terminal sibling of the sweep:
+  use it at a breakpoint on a long or heavy day so the next
+  `flow do` resume isn't reading a stale brief. No status change,
+  no kb writes — just the running log.
 - **Cross-reference:** `flow transcript <sibling-task>` lets a
   current session read what was decided in a related one — useful
   when the brief alone doesn't carry enough context.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -53,6 +53,8 @@ func Run(args []string) int {
 		return cmdRun(rest)
 	case "done":
 		return cmdDone(rest)
+	case "checkpoint":
+		return cmdCheckpoint(rest)
 	case "show":
 		return cmdShow(rest)
 	case "list":
@@ -100,6 +102,7 @@ Create:
 Sessions:
   flow do                <ref> [--fresh] [--dangerously-skip-permissions]
   flow do --auto         <ref>                 (run headlessly in the background; self-completes via flow done)
+  flow checkpoint        [<ref>]               (draft a progress note from the live transcript; no status change)
   flow done              <ref>
   flow hook session-start                      (SessionStart hook handler — wire via ~/.claude/settings.json)
 

--- a/internal/app/checkpoint.go
+++ b/internal/app/checkpoint.go
@@ -1,0 +1,200 @@
+package app
+
+import (
+	"flow/internal/flowdb"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// cmdCheckpoint drafts a mid-session progress note for an in-flight task
+// WITHOUT closing it. It is the non-terminal sibling of `flow done`:
+// where done flips status and runs a strict KB + project-update sweep at
+// the END of a task's life, checkpoint runs a lighter, task-local sweep
+// at any breakpoint DURING the work.
+//
+// Why this exists: flow injects context at SessionStart but has no
+// write-back. The dated notes under tasks/<slug>/updates/ are the durable
+// per-session record that a future `flow do` reads back on resume — yet
+// nothing prompts for them, so on heavy days they don't get written and
+// the next resume reads a stale brief. checkpoint closes that gap by
+// reusing the headless `claude -p` sweep engine to read the live
+// transcript and draft ONE updates/ note for the user to review. No
+// status change, no KB writes — deliberately local and repeatable.
+//
+// Resolution mirrors `flow show task`: an explicit ref resolves by slug;
+// no ref reverse-looks-up the task bound to the current Claude session.
+// Either way the task must carry a session_id — that's the transcript the
+// sweep reads.
+//
+// Exit codes: 0 on a successful sweep (whether or not a note was
+// warranted — an empty checkpoint is still a success, mirroring done's
+// "empty output is a successful sweep"); 1 on resolution/IO failure or a
+// non-zero sweep exit. Unlike `flow done`, checkpoint has no status flip
+// to protect, so a failed sweep is the whole operation failing and is
+// surfaced as rc=1 rather than swallowed.
+func cmdCheckpoint(args []string) int {
+	fs := flagSet("checkpoint")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	ref := ""
+	if fs.NArg() > 0 {
+		ref = fs.Arg(0)
+	}
+
+	dbPath, err := flowDBPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	db, err := flowdb.OpenDB(dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	defer db.Close()
+
+	var task *flowdb.Task
+	if ref == "" {
+		// No explicit ref: reverse-lookup via the current Claude session,
+		// exactly like `flow show task`. This is the common path —
+		// checkpoint is most useful fired from inside the live session
+		// whose work it's recording.
+		bound, lookupErr := currentSessionTask(db)
+		if lookupErr != nil {
+			if isNoBindingErr(lookupErr) {
+				if currentSessionID() == "" {
+					fmt.Fprintln(os.Stderr, "error: no task ref given and not running inside a Claude session ($CLAUDE_CODE_SESSION_ID unset)")
+				} else {
+					fmt.Fprintln(os.Stderr, "error: no task ref given and this Claude session is not bound to a task — pass a slug or run `flow do --here <slug>` first")
+				}
+				return 1
+			}
+			fmt.Fprintf(os.Stderr, "error: lookup task by session: %v\n", lookupErr)
+			return 1
+		}
+		task = bound
+	} else {
+		t, rc := findTask(db, ref)
+		if rc != 0 {
+			return rc
+		}
+		task = t
+	}
+
+	// The transcript is the whole point of a checkpoint. A task that was
+	// never started via `flow do` has no session to read.
+	if !task.SessionID.Valid || task.SessionID.String == "" {
+		fmt.Fprintf(os.Stderr,
+			"error: task %q has no session_id — checkpoint reads the task's Claude transcript, which requires at least one prior `flow do` (or `flow do --here`).\n",
+			task.Slug)
+		return 1
+	}
+
+	root, err := flowRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	updatesDir := filepath.Join(root, "tasks", task.Slug, "updates")
+
+	h, lookupErr := harnessForTask(task)
+	if lookupErr != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", lookupErr)
+		return 1
+	}
+
+	// Snapshot the updates dir so we can report which file (if any) the
+	// sweep produced — SkipPermissionsRun discards the headless session's
+	// stdout, so a before/after diff is how we learn what it wrote.
+	before := updatesSnapshot(updatesDir)
+
+	fmt.Print("drafting checkpoint note...")
+	if err := h.SkipPermissionsRun(buildCheckpointSweepPrompt(task.Slug)); err != nil {
+		fmt.Println()
+		fmt.Fprintf(os.Stderr, "warning: checkpoint sweep failed: %v\n", err)
+		return 1
+	}
+	fmt.Println(" done")
+
+	created := updatesCreatedSince(updatesDir, before)
+	if len(created) == 0 {
+		fmt.Println("no checkpoint note written — the transcript didn't warrant one yet.")
+	} else {
+		for _, f := range created {
+			fmt.Printf("wrote: %s\n", filepath.Join(updatesDir, f))
+		}
+	}
+	return 0
+}
+
+// updatesSnapshot returns the set of regular-file names currently in dir.
+// A missing dir yields an empty set (not an error) — checkpoint may be
+// the very first note a task ever gets.
+func updatesSnapshot(dir string) map[string]bool {
+	set := map[string]bool{}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return set
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			set[e.Name()] = true
+		}
+	}
+	return set
+}
+
+// updatesCreatedSince returns file names present in dir now but absent
+// from the pre-sweep snapshot, sorted for stable output.
+func updatesCreatedSince(dir string, before map[string]bool) []string {
+	var created []string
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return created
+	}
+	for _, e := range entries {
+		if e.IsDir() || before[e.Name()] {
+			continue
+		}
+		created = append(created, e.Name())
+	}
+	sort.Strings(created)
+	return created
+}
+
+// buildCheckpointSweepPrompt composes the headless prompt that drives a
+// mid-session checkpoint. Unlike buildCloseoutSweepPrompt (KB + project
+// update at the strict/forever bar), this writes exactly one TASK-level
+// progress note at the §4.5 shape — the running log, not the durable KB.
+// It deliberately does NOT touch the KB or change status: a checkpoint
+// is local, cheap, and repeatable.
+//
+// The prompt is passed as a single positional arg to `claude -p` via
+// exec.Command — no shell interpolation, so any characters are safe.
+func buildCheckpointSweepPrompt(slug string) string {
+	// Substitute the real flow root so the headless sweep isn't pointed
+	// at ~/.flow when the user has $FLOW_ROOT set elsewhere.
+	root := "~/.flow"
+	if r, err := flowRoot(); err == nil {
+		root = r
+	}
+
+	return fmt.Sprintf(
+		"You are running an automated mid-session checkpoint for in-flight flow task %q.\n\n"+
+			"The goal: capture this session's progress as ONE durable note so a future `flow do` resume isn't reading a stale brief. This is NOT a close-out — do NOT change task status, do NOT write to the knowledge base (%s/kb/).\n\n"+
+			"## Steps\n\n"+
+			"1. Invoke the flow skill via the Skill tool. This loads §4.5 (the progress-note shape).\n\n"+
+			"2. Run: flow transcript %s\n"+
+			"   Read the conversation transcript end to end — this is the session's work.\n\n"+
+			"3. Read any notes already under %s/tasks/%s/updates/ first. Your job is to capture what THIS session did that ISN'T already recorded there — do not restate prior notes.\n\n"+
+			"4. Write ONE new progress note at:\n"+
+			"     %s/tasks/%s/updates/YYYY-MM-DD-<kebab-title>.md\n"+
+			"   Shape per §4.5: under ~10 lines. Paragraph 1 — what got done this session, specific, no hedging. Paragraph 2 — what's next or now open. Optional trailing 'Blocked on: <X>' line. Prioritise decisions made, risks surfaced, and the next concrete step — those are what a resume most needs.\n\n"+
+			"5. Bar: write the note only if the session did substantive work not already captured. If the work was trivial or everything is already logged, write nothing — that is a successful checkpoint too. Never write a 'no progress' placeholder.\n\n"+
+			"6. Do not output a chat summary. Write the file silently and exit.\n",
+		slug, root, slug, root, slug, root, slug,
+	)
+}

--- a/internal/app/checkpoint_test.go
+++ b/internal/app/checkpoint_test.go
@@ -1,0 +1,169 @@
+package app
+
+import (
+	"errors"
+	"flow/internal/flowdb"
+	"testing"
+)
+
+// TestCmdCheckpointRunsSweepWhenSessionExists verifies the happy path:
+// a task with a session_id gets exactly one sweep call carrying a prompt
+// that loads the skill, reads the transcript, and targets the task's
+// updates/ dir — and returns rc=0.
+func TestCmdCheckpointRunsSweepWhenSessionExists(t *testing.T) {
+	setupFlowRoot(t)
+	calls := stubClaudeRunner(t, nil)
+	if rc := cmdAdd([]string{"task", "Has Session"}); rc != 0 {
+		t.Fatalf("add rc=%d", rc)
+	}
+	// Seed a session_id so the transcript gate fires.
+	db := openFlowDB(t)
+	if _, err := db.Exec(
+		`UPDATE tasks SET session_id=?, session_started=? WHERE slug=?`,
+		"deadbeef-uuid", flowdb.NowISO(), "has-session",
+	); err != nil {
+		t.Fatalf("seed session_id: %v", err)
+	}
+	db.Close()
+
+	if rc := cmdCheckpoint([]string{"has-session"}); rc != 0 {
+		t.Fatalf("checkpoint rc=%d, want 0", rc)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("expected 1 sweep call, got %d", len(*calls))
+	}
+	got := (*calls)[0].prompt
+	for _, want := range []string{
+		"flow skill",
+		"flow transcript has-session",
+		"/tasks/has-session/updates/",
+		"checkpoint",
+	} {
+		if !contains(got, want) {
+			t.Errorf("prompt missing %q", want)
+		}
+	}
+}
+
+// TestCmdCheckpointDoesNotTouchKB locks the contract that a checkpoint is
+// task-local: the prompt must NOT instruct the headless session to write
+// KB entries (that's `flow done`'s job at the strict bar). The only kb/
+// mention allowed is the explicit "do NOT write to the knowledge base"
+// guard, so we assert there is no kb-file write target.
+func TestCmdCheckpointDoesNotTouchKB(t *testing.T) {
+	setupFlowRoot(t)
+	calls := stubClaudeRunner(t, nil)
+	if rc := cmdAdd([]string{"task", "No KB"}); rc != 0 {
+		t.Fatalf("add rc=%d", rc)
+	}
+	db := openFlowDB(t)
+	if _, err := db.Exec(
+		`UPDATE tasks SET session_id=?, session_started=? WHERE slug=?`,
+		"nokb-uuid", flowdb.NowISO(), "no-kb",
+	); err != nil {
+		t.Fatalf("seed session_id: %v", err)
+	}
+	db.Close()
+
+	if rc := cmdCheckpoint([]string{"no-kb"}); rc != 0 {
+		t.Fatalf("checkpoint rc=%d", rc)
+	}
+	got := (*calls)[0].prompt
+	for _, unwanted := range []string{"kb/user.md", "kb/org.md", "kb/products.md"} {
+		if contains(got, unwanted) {
+			t.Errorf("checkpoint prompt unexpectedly targets a KB file: %q", unwanted)
+		}
+	}
+}
+
+// TestCmdCheckpointRefusesTaskWithoutSession: a backlog task with no
+// session_id has no transcript to read, so checkpoint refuses (rc=1) and
+// never calls the sweep.
+func TestCmdCheckpointRefusesTaskWithoutSession(t *testing.T) {
+	setupFlowRoot(t)
+	calls := stubClaudeRunner(t, errors.New("should not be called"))
+	if rc := cmdAdd([]string{"task", "No Session Task"}); rc != 0 {
+		t.Fatalf("add rc=%d", rc)
+	}
+	if rc := cmdCheckpoint([]string{"no-session-task"}); rc != 1 {
+		t.Errorf("checkpoint rc=%d, want 1 (sessionless task should be refused)", rc)
+	}
+	if len(*calls) != 0 {
+		t.Errorf("expected 0 sweep calls, got %d", len(*calls))
+	}
+}
+
+// TestCmdCheckpointUnknownRef: an explicit ref that resolves to nothing
+// is a hard error.
+func TestCmdCheckpointUnknownRef(t *testing.T) {
+	setupFlowRoot(t)
+	stubClaudeRunner(t, nil)
+	if rc := cmdCheckpoint([]string{"nope"}); rc == 0 {
+		t.Error("expected rc!=0 for unknown task")
+	}
+}
+
+// TestCmdCheckpointNoBindingNoRef: no ref and no bound session (the test
+// process has no $CLAUDE_CODE_SESSION_ID) → friendly rc=1, no sweep.
+func TestCmdCheckpointNoBindingNoRef(t *testing.T) {
+	setupFlowRoot(t)
+	calls := stubClaudeRunner(t, errors.New("should not be called"))
+	if rc := cmdCheckpoint(nil); rc != 1 {
+		t.Errorf("checkpoint rc=%d, want 1 (no ref, unbound session)", rc)
+	}
+	if len(*calls) != 0 {
+		t.Errorf("expected 0 sweep calls, got %d", len(*calls))
+	}
+}
+
+// TestCmdCheckpointSweepFailureIsError: unlike `flow done` (which swallows
+// sweep failures because the status flip is the durability boundary),
+// checkpoint has no status flip to protect — a non-zero sweep exit is the
+// whole operation failing, surfaced as rc=1.
+func TestCmdCheckpointSweepFailureIsError(t *testing.T) {
+	setupFlowRoot(t)
+	stubClaudeRunner(t, errors.New("exec: claude: executable file not found in $PATH"))
+	if rc := cmdAdd([]string{"task", "Sweep Fail"}); rc != 0 {
+		t.Fatalf("add rc=%d", rc)
+	}
+	db := openFlowDB(t)
+	if _, err := db.Exec(
+		`UPDATE tasks SET session_id=?, session_started=? WHERE slug=?`,
+		"sf-uuid", flowdb.NowISO(), "sweep-fail",
+	); err != nil {
+		t.Fatalf("seed session_id: %v", err)
+	}
+	db.Close()
+
+	if rc := cmdCheckpoint([]string{"sweep-fail"}); rc != 1 {
+		t.Errorf("checkpoint rc=%d, want 1 when the sweep fails", rc)
+	}
+	// Status must be untouched — checkpoint never mutates the row.
+	db = openFlowDB(t)
+	task, err := flowdb.GetTask(db, "sweep-fail")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.Status != "backlog" {
+		t.Errorf("status = %q, want backlog unchanged (checkpoint must not mutate the row)", task.Status)
+	}
+}
+
+// TestBuildCheckpointSweepPromptShape pins the key instructions so a
+// future edit that drops the skill load, the transcript step, or the
+// no-status-change / no-KB guards gets caught.
+func TestBuildCheckpointSweepPromptShape(t *testing.T) {
+	setupFlowRoot(t)
+	p := buildCheckpointSweepPrompt("demo")
+	for _, want := range []string{
+		"flow skill",
+		"flow transcript demo",
+		"/tasks/demo/updates/",
+		"do NOT change task status",
+		"NOT a close-out",
+	} {
+		if !contains(p, want) {
+			t.Errorf("prompt missing %q", want)
+		}
+	}
+}

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -205,6 +205,7 @@ Sessions
                               (run headlessly in the background — no tab, no human; the
                                session does the work and self-completes via `flow done`.
                                Implies --dangerously-skip-permissions. Cannot combine with --here.)
+  flow checkpoint       [<ref>]   (draft a progress note from the live transcript; no status change)
   flow done             <ref>
 
 Playbook runs
@@ -797,7 +798,23 @@ that…", "record that I…", "document that I just…".
    `~/.flow/projects/<slug>/updates/` instead.
 6. Confirm to the user: "saved: <absolute path>".
 
-Do NOT run any `flow` command for this — updates are just files.
+Do NOT run any `flow` command for this hand-written path — updates are
+just files.
+
+**Assisted alternative — `flow checkpoint`.** When the user wants the
+*whole session so far* distilled into a note rather than dictating one
+("checkpoint this", "snapshot where we are", "save progress from this
+session", or at a natural breakpoint on a long/heavy session), run
+`flow checkpoint` (no arg → the task bound to this session; or
+`flow checkpoint <slug>`). It spawns a headless pass that reads the
+task's transcript and drafts ONE `updates/` note for the user to
+review — no status change, no KB writes. This is the non-terminal
+sibling of the `flow done` close-out sweep (§4.7): use checkpoint
+mid-stream so a future `flow do` resume isn't reading a stale brief;
+use `flow done` only when the task is actually finished. The task must
+have a `session_id` (a prior `flow do`). Prefer the hand-written path
+above for a quick, targeted note; prefer checkpoint when the session
+was substantial and you want it captured without re-typing.
 
 ### 4.6 Waiting on someone
 


### PR DESCRIPTION
Closes #72.

## What

Adds `flow checkpoint [<ref>]` — a non-terminal command that drafts a mid-session progress note into `tasks/<slug>/updates/` from the live transcript, reusing the existing headless `claude -p` sweep engine.

## Why

flow injects context **in** at `SessionStart` but has no write-back. The dated notes under `tasks/<slug>/updates/` are the durable per-session record a future `flow do` reads on resume — yet nothing prompts for them. On heavy days they go unwritten, and the next resume reads a stale brief. The only transcript→record path today is the `flow done` sweep, which is terminal (flips status) and aimed at KB + project-update, not a task note.

`flow checkpoint` is the **non-terminal sibling of `flow done`**:

- **No status change, no KB writes** — deliberately task-local and repeatable.
- **Resolution mirrors `flow show task`**: explicit ref by slug; no ref reverse-looks-up the task bound to the current session (`$CLAUDE_CODE_SESSION_ID`). Either way the task must carry a `session_id`.
- **Reports what it wrote**: `SkipPermissionsRun` discards the headless session's stdout, so the command snapshots `updates/` before/after and prints any new file. An empty checkpoint (nothing warranted) is a success, mirroring `done`.
- **Sweep failure = rc 1**: unlike `done` (which swallows sweep failures because the status flip is the durability boundary), checkpoint has no status flip to protect.

**Skill / contract change (called out per CONTRIBUTING):** `internal/app/skill/SKILL.md` is updated so Claude sessions actually offer the command — added to the Sessions command reference, and §4.5 (Save a progress note) now describes checkpoint as the assisted, transcript-drafted alternative to a hand-written note and its relationship to the §4.7 `flow done` sweep.

## Test plan

- [x] `make test` passes
- [x] CI green (`go vet`, `go test ./...`, build) — verified locally; vet clean, full suite green, gofmt-clean on changed files
- [x] Manually exercised the command end-to-end: built the binary, pointed a throwaway task in a temp `FLOW_ROOT` at a real 931KB session transcript, ran `flow checkpoint` no-arg → live `claude -p` produced one correctly-shaped `updates/` note, rc=0, before/after diff reported the path, and the KB was untouched (verifying the no-KB contract)
- [x] Skill changed → re-embedded via `go build` (go:embed) and documented above

## Files

- `internal/app/checkpoint.go` — `cmdCheckpoint`, `buildCheckpointSweepPrompt`, `updates/` before/after diff helpers.
- `internal/app/checkpoint_test.go` — happy path, no-KB-write contract, sessionless refusal, unknown ref, unbound-no-ref, sweep-failure→rc1, prompt shape.
- `internal/app/app.go` — dispatch case + usage line.
- `internal/app/skill/SKILL.md` — command reference + §4.5 mention.
- `CHANGELOG.md`, `CONTRIBUTORS.md`, `README.md`.

## Notes

- The transcript render has no time cutoff, so a checkpoint summarizes the whole session-so-far. The prompt instructs the headless pass to read existing `updates/` first and only capture what isn't already logged, which keeps repeated checkpoints from duplicating. A future refinement could scope to "since the last note" if that proves noisy.
- A `Stop`-hook variant (auto-prompt at session end) was discussed in #72 as the other half of the fix; this PR is the manual command only — self-contained, reuses existing machinery. Happy to follow up with the hook separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
