### PR TITLE
feat(do): terminal-free background-agent spawn backend ($FLOW_TERM=bg)

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,13 +287,18 @@ single `claude agents --json` lookup — then records *that* id on the
 task. (Background-capable harnesses manage their own session id, so
 flow captures the real one after launch rather than pre-allocating it.)
 
-Re-running `flow do <task>` is idempotent: if the session is still live
-in the Agent View, flow reports "already running" instead of spawning a
-duplicate; if it has exited, flow resumes the same id (transcript
-preserved). flow opens nothing — you switch to the session yourself via
-the Agent View (`claude attach <id>` / `claude logs <id>`).
+Re-running `flow do <task>` is idempotent and mirrors how the Agent View
+itself works. If the session is still known to the Agent View — running,
+idle, or even stopped/failed after a shutdown — flow doesn't spawn a
+duplicate; it points you at it (`claude attach <id>`), and attaching a
+stopped or failed session restarts it from where it left off, keeping its
+id. Only when the session has been removed from the Agent View entirely
+does flow bring the conversation back: `claude --bg` starts a fresh
+process seeded from the saved transcript, and because `--bg` manages its
+own id (it does **not** preserve `--resume`'s id), flow captures and
+re-records the new id so the task never points at a dead session.
 `flow show` and `flow list` surface each bg task's live status (busy /
-idle, working / blocked, pid) from the same `claude agents --json`
+idle, working / blocked / done, pid) from a `claude agents --json --all`
 query, and `flow transcript <task>` finds the jsonl by globbing the
 session id (so it resolves even when a bg session relocates into a git
 worktree). Background mode is Claude-only today — pointing `FLOW_TERM=bg`

--- a/README.md
+++ b/README.md
@@ -225,8 +225,10 @@ handles the rest.
   current zellij session (requires zellij ≥ 0.40) — flow picks
   whichever you launched it from. Override with
   `FLOW_TERM=warp|iterm|terminal|zellij|kitty` when you're on a
-  non-standard host. Tomorrow's `flow do <task>` resumes the same
-  conversation.
+  non-standard host — or set `FLOW_TERM=bg` to launch the session as a
+  **terminal-free Claude background agent** (Claude Code's Agent View,
+  `claude agents`) with no tab at all. Tomorrow's `flow do <task>`
+  resumes the same conversation either way.
 - **Interview-driven task capture.** No forms. flow asks
   what / why / where / done-when, then writes a structured brief.
 - **A knowledge base that grows.** Five markdown buckets for
@@ -273,6 +275,30 @@ toggle for "Terminal" if you launched flow from Terminal.app, "iTerm"
 from iTerm2, "Claude" if Claude Code is the host, etc.; add it via the
 + button if it's not listed). After the grant the spawn is silent.
 iTerm2 doesn't need this — it has a native `create tab` verb.
+
+### Background agents (`FLOW_TERM=bg`)
+
+If you live in Claude Code's **Agent View** (`claude agents`), set
+`FLOW_TERM=bg` and `flow do <task>` spawns the session as a
+terminal-free background agent instead of opening a tab. flow runs
+`claude --bg --name "<project>/<task>" <prompt>`, reads the short id
+from the launch banner, and resolves the real, full session id with a
+single `claude agents --json` lookup — then records *that* id on the
+task. (Background-capable harnesses manage their own session id, so
+flow captures the real one after launch rather than pre-allocating it.)
+
+Re-running `flow do <task>` is idempotent: if the session is still live
+in the Agent View, flow reports "already running" instead of spawning a
+duplicate; if it has exited, flow resumes the same id (transcript
+preserved). flow opens nothing — you switch to the session yourself via
+the Agent View (`claude attach <id>` / `claude logs <id>`).
+`flow show` and `flow list` surface each bg task's live status (busy /
+idle, working / blocked, pid) from the same `claude agents --json`
+query, and `flow transcript <task>` finds the jsonl by globbing the
+session id (so it resolves even when a bg session relocates into a git
+worktree). Background mode is Claude-only today — pointing `FLOW_TERM=bg`
+at a task pinned to another harness fails with a clear error rather than
+silently falling back to a tab.
 
 ### One-shot instructions with `--with`
 
@@ -367,8 +393,10 @@ and reinstall the skill + hook.
 ## Where flow runs (and where we'd love help)
 
 Today flow runs on **macOS (iTerm2, Warp, stock Terminal.app, kitty,
-or zellij) + Claude Code only**. That's the stack we use, and that's
-what the session-spawn layer was built and tested against. zellij
+zellij, or Claude Code background agents via `FLOW_TERM=bg`) + Claude
+Code only**. That's the stack we use, and that's what the session-spawn
+layer was built and tested against. The background-agent backend is
+platform-agnostic (no terminal, no AppleScript) but Claude-only. zellij
 and kitty work on Linux too as a side effect — both are
 cross-platform and flow's zellij / kitty backends don't depend on
 any macOS APIs. Kitty needs `allow_remote_control yes` (or

--- a/README.md
+++ b/README.md
@@ -287,23 +287,25 @@ single `claude agents --json` lookup — then records *that* id on the
 task. (Background-capable harnesses manage their own session id, so
 flow captures the real one after launch rather than pre-allocating it.)
 
-Re-running `flow do <task>` is idempotent and mirrors how the Agent View
-itself works. If the session is still known to the Agent View — running,
-idle, or even stopped/failed after a shutdown — flow doesn't spawn a
-duplicate; it points you at it (`claude attach <id>`), and attaching a
-stopped or failed session restarts it from where it left off, keeping its
-id. Only when the session has been removed from the Agent View entirely
-does flow bring the conversation back: `claude --bg` starts a fresh
-process seeded from the saved transcript, and because `--bg` manages its
-own id (it does **not** preserve `--resume`'s id), flow captures and
-re-records the new id so the task never points at a dead session.
-`flow show` and `flow list` surface each bg task's live status (busy /
-idle, working / blocked / done, pid) from a `claude agents --json --all`
-query, and `flow transcript <task>` finds the jsonl by globbing the
-session id (so it resolves even when a bg session relocates into a git
-worktree). Background mode is Claude-only today — pointing `FLOW_TERM=bg`
-at a task pinned to another harness fails with a clear error rather than
-silently falling back to a tab.
+Re-running `flow do <task>` is idempotent. If the session is still
+**live** in the Agent View (its process is up — running or idle-waiting),
+flow doesn't spawn or resume anything; it just tells you it's open, since
+you continue it from the Agent View (`claude agents`). If the session is
+**not running** (stopped, failed, or finished) or has been removed
+entirely, flow brings the conversation back as a background agent:
+`claude --bg --resume <id>` starts a fresh process seeded from the saved
+transcript. Because `--bg` manages its own id it does **not** preserve
+`--resume`'s id (plain `claude --resume` would keep the id but wouldn't be
+a background agent, so it can't be used here) — so flow captures and
+re-records the new id, carrying the prior conversation forward while never
+leaving the task pointed at a dead session. `flow show` and `flow list`
+surface each bg task's live status (busy / idle, working / blocked / done,
+pid) from a `claude agents --json --all` query, and `flow transcript
+<task>` finds the jsonl by globbing the session id (so it resolves even
+when a bg session relocates into a git worktree). The bg session is
+launched in the task's `work_dir`. Background mode is Claude-only today —
+pointing `FLOW_TERM=bg` at a task pinned to another harness fails with a
+clear error rather than silently falling back to a tab.
 
 ### One-shot instructions with `--with`
 

--- a/README.md
+++ b/README.md
@@ -180,27 +180,6 @@ doesn't refuse to run the unsigned binary.
 
 </details>
 
-### For those who use Claude's agents view
-
-`flow do` and `flow run` don't pass `--bg` today — the aliases below
-will, so flow's sessions (and your own direct invocations) land in
-the agents view. Add to your shell rc (`~/.zshrc` or `~/.bashrc`) and
-`source` it.
-
-```bash
-# Bare `claude` now drops into the agents view. Add
-# `--dangerously-skip-permissions` if you'd also like dispatched
-# sessions to skip per-tool permission prompts (optional flavor).
-alias claude='claude --bg'
-
-# Since `claude` is now aliased, any `claude <sub>` invocation would
-# also pick up `--bg`. For each subcommand you use, add an alias that
-# routes through `command claude` to bypass the outer alias. The one
-# below is for the agents subcommand — the same shape works for
-# `mcp`, `doctor`, etc.
-alias ca='command claude agents'
-```
-
 ## Upgrade
 
 In any Claude Code session:
@@ -283,8 +262,8 @@ If you live in Claude Code's **Agent View** (`claude agents`), set
 terminal-free background agent instead of opening a tab. flow runs
 `claude --bg --name "<project>/<task>" <prompt>`, reads the short id
 from the launch banner, and resolves the real, full session id with a
-single `claude agents --json` lookup — then records *that* id on the
-task. (Background-capable harnesses manage their own session id, so
+single `claude agents --json --all` lookup — then records *that* id on
+the task. (Background-capable harnesses manage their own session id, so
 flow captures the real one after launch rather than pre-allocating it.)
 
 Re-running `flow do <task>` is idempotent. If the session is still

--- a/internal/app/background_test.go
+++ b/internal/app/background_test.go
@@ -66,17 +66,20 @@ func stubBGMode(t *testing.T) {
 }
 
 type bgCalls struct {
-	spawn, resume, agents int
-	lastSpawn, lastResume []string
+	spawn, resume, agents     int
+	lastSpawn, lastResume     []string
+	spawnBanner, resumeBanner string
 }
 
 // stubBGCommand swaps claude.BGCommandRunner with a recorder that
-// dispatches on args: `agents --json` returns *agentsJSON (mutable so a
-// test can change registry state mid-run), `--resume` is a resume, the
-// rest are spawns (returning bgBanner).
+// dispatches on args: `agents` returns *agentsJSON (mutable so a test can
+// change registry state mid-run), `--resume` returns resumeBanner, the
+// rest are spawns (returning spawnBanner). Both banners default to
+// bgBanner; tests set resumeBanner to simulate the new id --bg mints on
+// resume.
 func stubBGCommand(t *testing.T, agentsJSON *string) *bgCalls {
 	t.Helper()
-	c := &bgCalls{}
+	c := &bgCalls{spawnBanner: bgBanner, resumeBanner: bgBanner}
 	old := claude.BGCommandRunner
 	claude.BGCommandRunner = func(args []string) ([]byte, error) {
 		if len(args) >= 1 && args[0] == "agents" {
@@ -87,12 +90,12 @@ func stubBGCommand(t *testing.T, agentsJSON *string) *bgCalls {
 			if a == "--resume" {
 				c.resume++
 				c.lastResume = args
-				return []byte(""), nil
+				return []byte(c.resumeBanner), nil
 			}
 		}
 		c.spawn++
 		c.lastSpawn = args
-		return []byte(bgBanner), nil
+		return []byte(c.spawnBanner), nil
 	}
 	t.Cleanup(func() { claude.BGCommandRunner = old })
 	return c
@@ -162,8 +165,9 @@ func TestCmdDoBackgroundAlreadyRunning(t *testing.T) {
 	}
 }
 
-// TestCmdDoBackgroundResumeWhenGone: a bound session absent from the
-// registry is resumed (same id), not re-spawned.
+// TestCmdDoBackgroundResumeWhenGone: a bound session ABSENT from the
+// registry is brought back via --bg --resume <oldid>, and because --bg
+// mints a fresh id, flow re-records the NEW captured id (not the dead one).
 func TestCmdDoBackgroundResumeWhenGone(t *testing.T) {
 	setupFlowRoot(t)
 	seedTask(t, "bgt")
@@ -175,18 +179,32 @@ func TestCmdDoBackgroundResumeWhenGone(t *testing.T) {
 	if rc := cmdDo([]string{"bgt"}); rc != 0 { // fresh spawn, binds bgFullSID
 		t.Fatalf("first cmdDo rc=%d", rc)
 	}
-	reg = "[]" // session no longer running
+
+	// Old session removed; resume forks a new id (99aabbcc…), which must
+	// be the only thing in the registry at capture time.
+	const newSID = "99aabbcc-0000-4000-8000-000000000000"
+	reg = bgAgentsJSON(newSID)
+	c.resumeBanner = "backgrounded · 99aabbcc · bgt\n"
+
 	if rc := cmdDo([]string{"bgt"}); rc != 0 {
 		t.Fatalf("resume cmdDo rc=%d", rc)
 	}
 	if c.spawn != 1 {
-		t.Errorf("spawn calls = %d, want 1 (resume must not re-spawn)", c.spawn)
+		t.Errorf("spawn calls = %d, want 1 (resume must not re-spawn fresh)", c.spawn)
 	}
 	if c.resume != 1 {
 		t.Fatalf("resume calls = %d, want 1", c.resume)
 	}
 	if !pairArg(c.lastResume, "--resume", bgFullSID) {
-		t.Errorf("resume argv wrong: %v", c.lastResume)
+		t.Errorf("resume must --resume the OLD id; argv: %v", c.lastResume)
+	}
+	db := openFlowDB(t)
+	task, err := flowdb.GetTask(db, "bgt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.SessionID.String != newSID {
+		t.Errorf("session_id after resume = %q, want re-recorded new id %q", task.SessionID.String, newSID)
 	}
 }
 

--- a/internal/app/background_test.go
+++ b/internal/app/background_test.go
@@ -1,0 +1,308 @@
+package app
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"flow/internal/flowdb"
+	"flow/internal/harness"
+	"flow/internal/harness/claude"
+	"flow/internal/spawner"
+)
+
+// TestMain defaults claude.BGCommandRunner to an empty background-agent
+// registry for the whole app test package. Without this, every show /
+// list / do over a session-bound task would spawn a real
+// `claude agents --json` subprocess (slow + non-hermetic). Tests that
+// exercise bg behavior override it via stubBGCommand and restore on
+// cleanup.
+func TestMain(m *testing.M) {
+	claude.BGCommandRunner = func(args []string) ([]byte, error) {
+		if len(args) >= 1 && args[0] == "agents" {
+			return []byte("[]"), nil
+		}
+		return nil, fmt.Errorf("BGCommandRunner not stubbed for args %v", args)
+	}
+	os.Exit(m.Run())
+}
+
+const bgFullSID = "48d287d9-1ef0-4738-84b9-3110beb988c4"
+
+// bgBanner is what the stubbed `claude --bg` spawn returns: short id
+// 48d287d9 (the prefix of bgFullSID).
+const bgBanner = "backgrounded · 48d287d9 · flow/x\n"
+
+// bgAgentsJSON builds a `claude agents --json` array containing one entry
+// per session id (short id = first 8 chars).
+func bgAgentsJSON(sids ...string) string {
+	var b strings.Builder
+	b.WriteString("[")
+	for i, sid := range sids {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		short := sid
+		if len(short) >= 8 {
+			short = short[:8]
+		}
+		fmt.Fprintf(&b,
+			`{"pid":%d,"id":%q,"cwd":"/w","kind":"background","startedAt":1,"sessionId":%q,"name":"n","status":"busy","state":"working"}`,
+			1000+i, short, sid)
+	}
+	b.WriteString("]")
+	return b.String()
+}
+
+// stubBGMode forces spawner.IsBackground() true for the test.
+func stubBGMode(t *testing.T) {
+	t.Helper()
+	tru := true
+	old := spawner.BackgroundOverride
+	spawner.BackgroundOverride = &tru
+	t.Cleanup(func() { spawner.BackgroundOverride = old })
+}
+
+type bgCalls struct {
+	spawn, resume, agents int
+	lastSpawn, lastResume []string
+}
+
+// stubBGCommand swaps claude.BGCommandRunner with a recorder that
+// dispatches on args: `agents --json` returns *agentsJSON (mutable so a
+// test can change registry state mid-run), `--resume` is a resume, the
+// rest are spawns (returning bgBanner).
+func stubBGCommand(t *testing.T, agentsJSON *string) *bgCalls {
+	t.Helper()
+	c := &bgCalls{}
+	old := claude.BGCommandRunner
+	claude.BGCommandRunner = func(args []string) ([]byte, error) {
+		if len(args) >= 1 && args[0] == "agents" {
+			c.agents++
+			return []byte(*agentsJSON), nil
+		}
+		for _, a := range args {
+			if a == "--resume" {
+				c.resume++
+				c.lastResume = args
+				return []byte(""), nil
+			}
+		}
+		c.spawn++
+		c.lastSpawn = args
+		return []byte(bgBanner), nil
+	}
+	t.Cleanup(func() { claude.BGCommandRunner = old })
+	return c
+}
+
+// TestCmdDoBackgroundFreshSpawn: $FLOW_TERM=bg flow do <task> spawns a bg
+// agent, captures the REAL full session id (not a pre-allocated phantom),
+// records it + harness, flips to in-progress, and opens NO terminal tab.
+func TestCmdDoBackgroundFreshSpawn(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "bgt")
+	stubBGMode(t)
+	itermCount, _ := stubITerm(t)
+	reg := bgAgentsJSON(bgFullSID)
+	c := stubBGCommand(t, &reg)
+
+	if rc := cmdDo([]string{"bgt"}); rc != 0 {
+		t.Fatalf("cmdDo (bg) rc=%d, want 0", rc)
+	}
+	if *itermCount != 0 {
+		t.Errorf("terminal spawn count = %d, want 0 (bg opens no tab)", *itermCount)
+	}
+	if c.spawn != 1 {
+		t.Fatalf("bg spawn calls = %d, want 1", c.spawn)
+	}
+	if !containsArg(c.lastSpawn, "--bg") || !pairArg(c.lastSpawn, "--name", "bgt") {
+		t.Errorf("spawn argv wrong: %v", c.lastSpawn)
+	}
+
+	db := openFlowDB(t)
+	task, err := flowdb.GetTask(db, "bgt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.SessionID.String != bgFullSID {
+		t.Errorf("session_id = %q, want captured %q", task.SessionID.String, bgFullSID)
+	}
+	if task.Status != "in-progress" {
+		t.Errorf("status = %q, want in-progress", task.Status)
+	}
+	if !task.Harness.Valid || task.Harness.String != "claude" {
+		t.Errorf("harness = %+v, want claude", task.Harness)
+	}
+}
+
+// TestCmdDoBackgroundAlreadyRunning: re-running while the session is alive
+// in the registry must NOT spawn or resume — just report.
+func TestCmdDoBackgroundAlreadyRunning(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "bgt")
+	stubBGMode(t)
+	stubITerm(t)
+	reg := bgAgentsJSON(bgFullSID)
+	c := stubBGCommand(t, &reg)
+
+	if rc := cmdDo([]string{"bgt"}); rc != 0 { // fresh spawn, binds bgFullSID
+		t.Fatalf("first cmdDo rc=%d", rc)
+	}
+	if rc := cmdDo([]string{"bgt"}); rc != 0 { // session still alive
+		t.Fatalf("second cmdDo rc=%d", rc)
+	}
+	if c.spawn != 1 {
+		t.Errorf("spawn calls = %d, want 1 (no re-spawn when already running)", c.spawn)
+	}
+	if c.resume != 0 {
+		t.Errorf("resume calls = %d, want 0 (already running, not gone)", c.resume)
+	}
+}
+
+// TestCmdDoBackgroundResumeWhenGone: a bound session absent from the
+// registry is resumed (same id), not re-spawned.
+func TestCmdDoBackgroundResumeWhenGone(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "bgt")
+	stubBGMode(t)
+	stubITerm(t)
+	reg := bgAgentsJSON(bgFullSID)
+	c := stubBGCommand(t, &reg)
+
+	if rc := cmdDo([]string{"bgt"}); rc != 0 { // fresh spawn, binds bgFullSID
+		t.Fatalf("first cmdDo rc=%d", rc)
+	}
+	reg = "[]" // session no longer running
+	if rc := cmdDo([]string{"bgt"}); rc != 0 {
+		t.Fatalf("resume cmdDo rc=%d", rc)
+	}
+	if c.spawn != 1 {
+		t.Errorf("spawn calls = %d, want 1 (resume must not re-spawn)", c.spawn)
+	}
+	if c.resume != 1 {
+		t.Fatalf("resume calls = %d, want 1", c.resume)
+	}
+	if !pairArg(c.lastResume, "--resume", bgFullSID) {
+		t.Errorf("resume argv wrong: %v", c.lastResume)
+	}
+}
+
+// nonBGHarness satisfies harness.Harness (via embedded interface) but NOT
+// harness.BackgroundLauncher, so it exercises the capability gate.
+type nonBGHarness struct{ harness.Harness }
+
+func (nonBGHarness) Name() harness.Name { return harness.Name("codex") }
+
+func TestBackgroundLauncherForGate(t *testing.T) {
+	if _, err := backgroundLauncherFor(claude.New()); err != nil {
+		t.Errorf("claude must implement BackgroundLauncher: %v", err)
+	}
+	_, err := backgroundLauncherFor(nonBGHarness{})
+	if err == nil {
+		t.Fatalf("non-bg harness must error (clean capability gate)")
+	}
+	if !strings.Contains(err.Error(), "codex") {
+		t.Errorf("gate error should name the harness, got: %v", err)
+	}
+}
+
+// TestBGAgentStatus: a claude-bound task whose session is in the registry
+// resolves to its live agent (status/state/pid); absent or session-less
+// tasks resolve to nil.
+func TestBGAgentStatus(t *testing.T) {
+	reg := bgAgentsJSON(bgFullSID)
+	stubBGCommand(t, &reg)
+
+	live := &flowdb.Task{
+		Slug:      "x",
+		Harness:   sql.NullString{String: "claude", Valid: true},
+		SessionID: sql.NullString{String: bgFullSID, Valid: true},
+	}
+	a := bgAgentStatus(live)
+	if a == nil {
+		t.Fatal("bgAgentStatus = nil, want the live agent")
+	}
+	if a.Status != "busy" || a.State != "working" || a.PID == 0 {
+		t.Errorf("agent fields = %+v, want busy/working with a pid", *a)
+	}
+
+	absent := &flowdb.Task{
+		Harness:   sql.NullString{String: "claude", Valid: true},
+		SessionID: sql.NullString{String: "ffffffff-0000-4000-8000-000000000000", Valid: true},
+	}
+	if bgAgentStatus(absent) != nil {
+		t.Error("bgAgentStatus for absent session = non-nil, want nil")
+	}
+
+	noSession := &flowdb.Task{Harness: sql.NullString{String: "claude", Valid: true}}
+	if bgAgentStatus(noSession) != nil {
+		t.Error("bgAgentStatus for session-less task = non-nil, want nil")
+	}
+}
+
+// TestLiveSessionsIncludesBackgroundAgents: the [live] detection used by
+// `flow list` must count background agents (which don't show in the ps
+// scan) as live.
+func TestLiveSessionsIncludesBackgroundAgents(t *testing.T) {
+	stubPS(t, "") // nothing live via the process table
+	reg := bgAgentsJSON(bgFullSID)
+	stubBGCommand(t, &reg)
+
+	tasks := []*flowdb.Task{{
+		Harness:   sql.NullString{String: "claude", Valid: true},
+		SessionID: sql.NullString{String: bgFullSID, Valid: true},
+	}}
+	merged := liveSessionsForTasks(tasks)
+	if merged[strings.ToLower(bgFullSID)] == 0 {
+		t.Errorf("background agent not counted as live: %v", merged)
+	}
+}
+
+// TestCmdShowRendersBackgroundStatus: `flow show` surfaces a live bg
+// session's status/state/pid via the per-render registry lookup.
+func TestCmdShowRendersBackgroundStatus(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "bgt")
+	stubBGMode(t)
+	stubITerm(t)
+	reg := bgAgentsJSON(bgFullSID)
+	stubBGCommand(t, &reg)
+
+	if rc := cmdDo([]string{"bgt"}); rc != 0 { // bind a bg session
+		t.Fatalf("bg spawn rc=%d", rc)
+	}
+	out := captureStdout(t, func() {
+		if rc := cmdShow([]string{"task", "bgt"}); rc != 0 {
+			t.Errorf("show rc=%d", rc)
+		}
+	})
+	if !strings.Contains(out, "bg_status:") {
+		t.Fatalf("flow show missing bg_status line:\n%s", out)
+	}
+	if !strings.Contains(out, "busy") || !strings.Contains(out, "working") {
+		t.Errorf("bg_status missing status/state:\n%s", out)
+	}
+}
+
+// ---- helpers ----
+
+func containsArg(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func pairArg(ss []string, flag, val string) bool {
+	for i := 0; i+1 < len(ss); i++ {
+		if ss[i] == flag && ss[i+1] == val {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/background_test.go
+++ b/internal/app/background_test.go
@@ -20,12 +20,18 @@ import (
 // exercise bg behavior override it via stubBGCommand and restore on
 // cleanup.
 func TestMain(m *testing.M) {
-	claude.BGCommandRunner = func(args []string) ([]byte, error) {
+	claude.BGCommandRunner = func(workDir string, args []string) ([]byte, error) {
 		if len(args) >= 1 && args[0] == "agents" {
 			return []byte("[]"), nil
 		}
 		return nil, fmt.Errorf("BGCommandRunner not stubbed for args %v", args)
 	}
+	// Insulate the suite from an ambient $FLOW_TERM=bg in the developer's
+	// environment: default the whole app package to NON-background so
+	// cmdDo tests exercise the terminal path. bg tests opt in via
+	// stubBGMode (which saves/restores this override).
+	notBG := false
+	spawner.BackgroundOverride = &notBG
 	os.Exit(m.Run())
 }
 
@@ -35,8 +41,8 @@ const bgFullSID = "48d287d9-1ef0-4738-84b9-3110beb988c4"
 // 48d287d9 (the prefix of bgFullSID).
 const bgBanner = "backgrounded · 48d287d9 · flow/x\n"
 
-// bgAgentsJSON builds a `claude agents --json` array containing one entry
-// per session id (short id = first 8 chars).
+// bgAgentsJSON builds a `claude agents --json` array of LIVE entries
+// (pid set) — one per session id (short id = first 8 chars).
 func bgAgentsJSON(sids ...string) string {
 	var b strings.Builder
 	b.WriteString("[")
@@ -56,6 +62,19 @@ func bgAgentsJSON(sids ...string) string {
 	return b.String()
 }
 
+// bgAgentsJSONExited builds a registry entry for an exited session (no
+// pid / status — `state` only), as `claude agents --json --all` reports a
+// stopped/failed/done session whose process is gone.
+func bgAgentsJSONExited(sid, state string) string {
+	short := sid
+	if len(short) >= 8 {
+		short = short[:8]
+	}
+	return fmt.Sprintf(
+		`[{"id":%q,"cwd":"/w","kind":"background","startedAt":1,"sessionId":%q,"name":"n","state":%q}]`,
+		short, sid, state)
+}
+
 // stubBGMode forces spawner.IsBackground() true for the test.
 func stubBGMode(t *testing.T) {
 	t.Helper()
@@ -69,6 +88,10 @@ type bgCalls struct {
 	spawn, resume, agents     int
 	lastSpawn, lastResume     []string
 	spawnBanner, resumeBanner string
+	// onResume, if set, fires when a --resume command is issued — lets a
+	// test mutate the registry so the resume's capture lookup resolves the
+	// newly-forked id.
+	onResume func()
 }
 
 // stubBGCommand swaps claude.BGCommandRunner with a recorder that
@@ -81,7 +104,7 @@ func stubBGCommand(t *testing.T, agentsJSON *string) *bgCalls {
 	t.Helper()
 	c := &bgCalls{spawnBanner: bgBanner, resumeBanner: bgBanner}
 	old := claude.BGCommandRunner
-	claude.BGCommandRunner = func(args []string) ([]byte, error) {
+	claude.BGCommandRunner = func(workDir string, args []string) ([]byte, error) {
 		if len(args) >= 1 && args[0] == "agents" {
 			c.agents++
 			return []byte(*agentsJSON), nil
@@ -90,6 +113,9 @@ func stubBGCommand(t *testing.T, agentsJSON *string) *bgCalls {
 			if a == "--resume" {
 				c.resume++
 				c.lastResume = args
+				if c.onResume != nil {
+					c.onResume()
+				}
 				return []byte(c.resumeBanner), nil
 			}
 		}
@@ -205,6 +231,43 @@ func TestCmdDoBackgroundResumeWhenGone(t *testing.T) {
 	}
 	if task.SessionID.String != newSID {
 		t.Errorf("session_id after resume = %q, want re-recorded new id %q", task.SessionID.String, newSID)
+	}
+}
+
+// TestCmdDoBackgroundResumeWhenExited: a bound session that's still listed
+// but no longer running (exited, no pid) is resumed (forked + re-recorded),
+// not left as "already open".
+func TestCmdDoBackgroundResumeWhenExited(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "bgt")
+	stubBGMode(t)
+	stubITerm(t)
+	reg := bgAgentsJSON(bgFullSID)
+	c := stubBGCommand(t, &reg)
+
+	if rc := cmdDo([]string{"bgt"}); rc != 0 { // fresh spawn, binds bgFullSID
+		t.Fatalf("first cmdDo rc=%d", rc)
+	}
+
+	// Session now present but EXITED (stopped, no pid): the alive-check must
+	// see it as not-running → resume. The resume forks a new id, so flip the
+	// registry to that new session when the resume command fires (so the
+	// capture lookup resolves it).
+	const newSID = "77665544-0000-4000-8000-000000000000"
+	reg = bgAgentsJSONExited(bgFullSID, "stopped")
+	c.resumeBanner = "backgrounded · 77665544 · bgt\n"
+	c.onResume = func() { reg = bgAgentsJSON(newSID) }
+
+	if rc := cmdDo([]string{"bgt"}); rc != 0 {
+		t.Fatalf("resume cmdDo rc=%d", rc)
+	}
+	if c.resume != 1 {
+		t.Fatalf("resume calls = %d, want 1 (exited session must resume)", c.resume)
+	}
+	db := openFlowDB(t)
+	task, _ := flowdb.GetTask(db, "bgt")
+	if task.SessionID.String != newSID {
+		t.Errorf("session_id after resume = %q, want %q", task.SessionID.String, newSID)
 	}
 }
 

--- a/internal/app/background_test.go
+++ b/internal/app/background_test.go
@@ -294,6 +294,7 @@ func TestBackgroundLauncherForGate(t *testing.T) {
 // resolves to its live agent (status/state/pid); absent or session-less
 // tasks resolve to nil.
 func TestBGAgentStatus(t *testing.T) {
+	stubBGMode(t)
 	reg := bgAgentsJSON(bgFullSID)
 	stubBGCommand(t, &reg)
 
@@ -328,6 +329,7 @@ func TestBGAgentStatus(t *testing.T) {
 // `flow list` must count background agents (which don't show in the ps
 // scan) as live.
 func TestLiveSessionsIncludesBackgroundAgents(t *testing.T) {
+	stubBGMode(t)
 	stubPS(t, "") // nothing live via the process table
 	reg := bgAgentsJSON(bgFullSID)
 	stubBGCommand(t, &reg)
@@ -339,6 +341,35 @@ func TestLiveSessionsIncludesBackgroundAgents(t *testing.T) {
 	merged := liveSessionsForTasks(tasks)
 	if merged[strings.ToLower(bgFullSID)] == 0 {
 		t.Errorf("background agent not counted as live: %v", merged)
+	}
+}
+
+// Regression guard: with FLOW_TERM unset (non-bg mode), flow show / list
+// must NOT query the background-agent registry — no `claude agents`
+// subprocess, no bg_status, no bg-sourced [live]. The TestMain default
+// pins BackgroundOverride=false, so these run in non-bg mode.
+func TestNonBgModeSkipsRegistry(t *testing.T) {
+	bgCalled := false
+	old := claude.BGCommandRunner
+	claude.BGCommandRunner = func(workDir string, args []string) ([]byte, error) {
+		if len(args) >= 1 && args[0] == "agents" {
+			bgCalled = true
+		}
+		return []byte("[]"), nil
+	}
+	t.Cleanup(func() { claude.BGCommandRunner = old })
+	stubPS(t, "")
+
+	task := &flowdb.Task{
+		Harness:   sql.NullString{String: "claude", Valid: true},
+		SessionID: sql.NullString{String: bgFullSID, Valid: true},
+	}
+	if bgAgentStatus(task) != nil {
+		t.Error("bgAgentStatus non-nil in non-bg mode")
+	}
+	_ = liveSessionsForTasks([]*flowdb.Task{task})
+	if bgCalled {
+		t.Error("non-bg mode must not run `claude agents` (latency regression)")
 	}
 }
 

--- a/internal/app/do.go
+++ b/internal/app/do.go
@@ -188,6 +188,20 @@ func cmdDo(args []string) int {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
 	}
+
+	// Background-agent mode ($FLOW_TERM=bg): spawn a terminal-free
+	// background session via the harness's BackgroundLauncher instead of
+	// opening a tab. Checked BEFORE the spawn machinery (parallel to the
+	// --auto branch). bg can't combine with --auto (different spawn
+	// shapes) or --here (binds the current session, no spawn).
+	if spawner.IsBackground() {
+		if *auto {
+			fmt.Fprintln(os.Stderr, "error: $FLOW_TERM=bg cannot be combined with --auto (both spawn their own session; pick one)")
+			return 2
+		}
+		return cmdDoBackground(db, task, h, *fresh, *dangerSkip, injectionText)
+	}
+
 	// The focus-an-existing-tab behavior only makes sense for the
 	// interactive path. For --auto there is no tab to focus; the
 	// equivalent "already in flight" guard is the auto_run_status check
@@ -514,6 +528,169 @@ func cmdDo(args []string) int {
 		fmt.Printf("Resumed %s (session %s)\n", task.Slug, sessionID)
 	}
 	return 0
+}
+
+// backgroundLauncherFor returns the harness's BackgroundLauncher
+// capability, or a clean error if the harness can't host background
+// sessions. This is the capability gate for $FLOW_TERM=bg: flow never
+// silently falls back to a terminal tab when the pinned harness lacks
+// the capability.
+func backgroundLauncherFor(h harness.Harness) (harness.BackgroundLauncher, error) {
+	bg, ok := h.(harness.BackgroundLauncher)
+	if !ok {
+		return nil, fmt.Errorf(
+			"$FLOW_TERM=bg requested a background agent, but harness %q has no background-session support (only claude does today) — unset FLOW_TERM to open a terminal tab instead",
+			h.Name())
+	}
+	return bg, nil
+}
+
+// bgSessionAlive reports whether sessionID is currently in the harness's
+// background-agent registry. A registry-query error is propagated so the
+// caller can decide (the resume path treats "can't tell" as "not alive"
+// and attempts a resume).
+func bgSessionAlive(bg harness.BackgroundLauncher, sessionID string) (bool, error) {
+	agents, err := bg.BackgroundAgents()
+	if err != nil {
+		return false, err
+	}
+	for _, a := range agents {
+		if strings.EqualFold(a.SessionID, sessionID) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// cmdDoBackground is the $FLOW_TERM=bg branch of `flow do`. It spawns (or
+// resumes) a terminal-free background agent via the harness's
+// BackgroundLauncher and captures the harness-minted session id. Unlike
+// the interactive path, the session id is NOT pre-allocated — a
+// backgrounding harness manages its own id, so flow records the REAL id
+// returned after spawn (fixing the phantom-id leak the user's `--bg`
+// alias caused).
+//
+// Resume/already-running protocol:
+//   - no session yet (or --fresh) → spawn fresh + capture id
+//   - session bound AND alive in the registry → report, don't double-spawn
+//   - session bound but gone → resume by id (transcript preserved)
+func cmdDoBackground(db *sql.DB, task *flowdb.Task, h harness.Harness, fresh, skipPerms bool, inject string) int {
+	bg, err := backgroundLauncherFor(h)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	if task.WorkDir == "" {
+		fmt.Fprintf(os.Stderr, "error: task %q has no work_dir\n", task.Slug)
+		return 1
+	}
+	if task.Status == "done" {
+		fmt.Fprintf(os.Stderr,
+			"error: task %q is done; reopen it (flow update task %s --status in-progress) before running it in the background\n",
+			task.Slug, task.Slug)
+		return 1
+	}
+
+	// Project lookup is only for the display title (same as the tab path).
+	var project *flowdb.Project
+	if task.ProjectSlug.Valid {
+		p, perr := flowdb.GetProject(db, task.ProjectSlug.String)
+		if perr != nil && !errors.Is(perr, sql.ErrNoRows) {
+			fmt.Fprintf(os.Stderr, "error: get project: %v\n", perr)
+			return 1
+		}
+		project = p
+	}
+	title := buildTabTitle(project, task)
+	opts := harness.LaunchOpts{SkipPermissions: skipPerms, Inject: inject}
+
+	hasSession := task.SessionID.Valid && task.SessionID.String != ""
+
+	if hasSession && !fresh {
+		sid := task.SessionID.String
+		if alive, _ := bgSessionAlive(bg, sid); alive {
+			fmt.Printf("Already running in background: %s (session %s) — check your Agent View (`claude agents`)\n",
+				task.Slug, sid)
+			return 0
+		}
+		// Bound but no longer running: resume the same id.
+		if err := bg.ResumeBackground(sid, opts); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 1
+		}
+		now := flowdb.NowISO()
+		if _, err := db.Exec(
+			`UPDATE tasks SET status='in-progress',
+			 status_changed_at = CASE WHEN status != 'in-progress' THEN ? ELSE status_changed_at END,
+			 session_last_resumed=?, updated_at=? WHERE slug=?`,
+			now, now, now, task.Slug,
+		); err != nil {
+			fmt.Fprintf(os.Stderr, "error: record resume: %v\n", err)
+			return 1
+		}
+		bumpWorkdirUsed(db, task.WorkDir)
+		fmt.Printf("Resumed %s in background (session %s) — check your Agent View (`claude agents`)\n",
+			task.Slug, sid)
+		return 0
+	}
+
+	// Fresh spawn (no session, or --fresh discards the old one).
+	if fresh && hasSession {
+		fmt.Printf("--fresh: discarding old session %s\n", task.SessionID.String)
+	}
+	playbookSlug, isFirstRun := bgPlaybookContext(db, task)
+	prompt := buildBootstrapPromptForKindV2(task.Slug, task.Kind, playbookSlug, isFirstRun)
+
+	agent, err := bg.SpawnBackground(title, prompt, opts)
+	if err != nil {
+		// Nothing was written to the DB yet — clean failure, next attempt retries.
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	now := flowdb.NowISO()
+	// Record the harness-minted REAL session id alongside status + harness.
+	// COALESCE on harness mirrors the interactive bootstrap: set-once.
+	if _, err := db.Exec(
+		`UPDATE tasks SET status='in-progress',
+		 status_changed_at = CASE WHEN status != 'in-progress' THEN ? ELSE status_changed_at END,
+		 session_id=?, session_started=?,
+		 harness = CASE WHEN harness IS NULL OR harness = '' THEN ? ELSE harness END,
+		 updated_at=? WHERE slug=?`,
+		now, agent.SessionID, now, string(h.Name()), now, task.Slug,
+	); err != nil {
+		fmt.Fprintf(os.Stderr, "error: record session: %v\n", err)
+		return 1
+	}
+	bumpWorkdirUsed(db, task.WorkDir)
+	fmt.Printf("Spawned %s in background (session %s) — %s · %s\n  check your Agent View: `claude agents`\n",
+		task.Slug, agent.SessionID, agent.ShortID, title)
+	return 0
+}
+
+// bgPlaybookContext computes (playbookSlug, isFirstRun) for a task's
+// bootstrap prompt, mirroring the interactive bootstrap path. Returns
+// ("", false) for regular tasks.
+func bgPlaybookContext(db *sql.DB, task *flowdb.Task) (string, bool) {
+	if !task.PlaybookSlug.Valid {
+		return "", false
+	}
+	playbookSlug := task.PlaybookSlug.String
+	var runCount int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM tasks WHERE playbook_slug = ? AND kind = 'playbook_run' AND archived_at IS NULL`,
+		playbookSlug,
+	).Scan(&runCount); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: count playbook runs: %v\n", err)
+	}
+	return playbookSlug, runCount <= 1
+}
+
+// bumpWorkdirUsed updates workdirs.last_used_at, best-effort.
+func bumpWorkdirUsed(db *sql.DB, path string) {
+	if _, err := db.Exec(`UPDATE workdirs SET last_used_at = ? WHERE path = ?`, flowdb.NowISO(), path); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: bump workdir last_used_at: %v\n", err)
+	}
 }
 
 // buildBootstrapPromptForKind dispatches to the right prompt variant

--- a/internal/app/do.go
+++ b/internal/app/do.go
@@ -624,28 +624,24 @@ func cmdDoBackground(db *sql.DB, task *flowdb.Task, h harness.Harness, fresh, sk
 
 	if hasSession && !fresh {
 		sid := task.SessionID.String
-		// Is the session still known to the Agent View (any state)?
-		if a := bgAgentInRegistry(bg, sid); a != nil {
-			// Present — don't spawn. A bg session is recovered by
-			// attaching in the Agent View (a stopped/failed one restarts
-			// from where it left off, keeping its id), so flow points the
-			// user there rather than re-spawning. The recorded id stays
-			// valid.
-			if a.PID > 0 {
-				fmt.Printf("Already running in background: %s (%s, %s) — attach via your Agent View: `claude attach %s`\n",
-					task.Slug, a.ShortID, bgStateLabel(a), a.ShortID)
-			} else {
-				fmt.Printf("%s is in your Agent View (%s, %s) — attach to resume it (a stopped/failed session restarts on attach): `claude attach %s`\n",
-					task.Slug, a.ShortID, bgStateLabel(a), a.ShortID)
-			}
+		// If the session is still LIVE in the Agent View (process alive —
+		// running or idle-waiting), don't spawn or resume: it's already
+		// there, so just point the user at it. (A live bg session keeps a
+		// pid; an exited one — stopped/failed/done — has none.)
+		if a := bgAgentInRegistry(bg, sid); a != nil && a.PID > 0 {
+			fmt.Printf("%s is open in your Agent View (%s, %s) — run `claude agents` to view or reply\n",
+				task.Slug, a.ShortID, bgStateLabel(a))
 			return 0
 		}
 
-		// Absent from the registry (removed / no longer tracked): bring the
-		// conversation back as a fresh bg agent seeded from its transcript.
-		// --bg mints a NEW id, so capture and re-record it (otherwise flow
-		// would keep pointing at the dead id — the phantom-id bug).
-		agent, err := bg.ResumeBackground(sid, opts)
+		// Not running (exited: stopped/failed/done) or removed: bring the
+		// conversation back as a background agent seeded from its
+		// transcript. `claude --bg --resume` mints a NEW id (history
+		// inherited — it can't keep the id under --bg), so capture and
+		// re-record it; otherwise flow would keep pointing at the dead id
+		// (the phantom-id bug). Plain `--resume` would preserve the id but
+		// wouldn't be a background agent, so it can't be used in bg mode.
+		agent, err := bg.ResumeBackground(task.WorkDir, sid, opts)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			return 1
@@ -674,7 +670,7 @@ func cmdDoBackground(db *sql.DB, task *flowdb.Task, h harness.Harness, fresh, sk
 	playbookSlug, isFirstRun := bgPlaybookContext(db, task)
 	prompt := buildBootstrapPromptForKindV2(task.Slug, task.Kind, playbookSlug, isFirstRun)
 
-	agent, err := bg.SpawnBackground(title, prompt, opts)
+	agent, err := bg.SpawnBackground(task.WorkDir, title, prompt, opts)
 	if err != nil {
 		// Nothing was written to the DB yet — clean failure, next attempt retries.
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/internal/app/do.go
+++ b/internal/app/do.go
@@ -545,21 +545,37 @@ func backgroundLauncherFor(h harness.Harness) (harness.BackgroundLauncher, error
 	return bg, nil
 }
 
-// bgSessionAlive reports whether sessionID is currently in the harness's
-// background-agent registry. A registry-query error is propagated so the
-// caller can decide (the resume path treats "can't tell" as "not alive"
-// and attempts a resume).
-func bgSessionAlive(bg harness.BackgroundLauncher, sessionID string) (bool, error) {
+// bgAgentInRegistry returns the registry entry for sessionID (any state:
+// working / blocked / idle / done / failed / stopped), or nil if the
+// session is absent (removed / no longer tracked) or the registry query
+// fails. "Present" means the Agent View still knows it — recoverable by
+// attaching; "absent" means it must be brought back via a resume.
+func bgAgentInRegistry(bg harness.BackgroundLauncher, sessionID string) *harness.BackgroundAgent {
 	agents, err := bg.BackgroundAgents()
 	if err != nil {
-		return false, err
+		return nil
 	}
-	for _, a := range agents {
-		if strings.EqualFold(a.SessionID, sessionID) {
-			return true, nil
+	for i := range agents {
+		if strings.EqualFold(agents[i].SessionID, sessionID) {
+			return &agents[i]
 		}
 	}
-	return false, nil
+	return nil
+}
+
+// bgStateLabel renders a background agent's coarse condition for user
+// messages, e.g. "busy/working" while live or just "stopped" once exited.
+func bgStateLabel(a *harness.BackgroundAgent) string {
+	switch {
+	case a.Status != "" && a.State != "":
+		return a.Status + "/" + a.State
+	case a.State != "":
+		return a.State
+	case a.Status != "":
+		return a.Status
+	default:
+		return "unknown"
+	}
 }
 
 // cmdDoBackground is the $FLOW_TERM=bg branch of `flow do`. It spawns (or
@@ -608,13 +624,29 @@ func cmdDoBackground(db *sql.DB, task *flowdb.Task, h harness.Harness, fresh, sk
 
 	if hasSession && !fresh {
 		sid := task.SessionID.String
-		if alive, _ := bgSessionAlive(bg, sid); alive {
-			fmt.Printf("Already running in background: %s (session %s) — check your Agent View (`claude agents`)\n",
-				task.Slug, sid)
+		// Is the session still known to the Agent View (any state)?
+		if a := bgAgentInRegistry(bg, sid); a != nil {
+			// Present — don't spawn. A bg session is recovered by
+			// attaching in the Agent View (a stopped/failed one restarts
+			// from where it left off, keeping its id), so flow points the
+			// user there rather than re-spawning. The recorded id stays
+			// valid.
+			if a.PID > 0 {
+				fmt.Printf("Already running in background: %s (%s, %s) — attach via your Agent View: `claude attach %s`\n",
+					task.Slug, a.ShortID, bgStateLabel(a), a.ShortID)
+			} else {
+				fmt.Printf("%s is in your Agent View (%s, %s) — attach to resume it (a stopped/failed session restarts on attach): `claude attach %s`\n",
+					task.Slug, a.ShortID, bgStateLabel(a), a.ShortID)
+			}
 			return 0
 		}
-		// Bound but no longer running: resume the same id.
-		if err := bg.ResumeBackground(sid, opts); err != nil {
+
+		// Absent from the registry (removed / no longer tracked): bring the
+		// conversation back as a fresh bg agent seeded from its transcript.
+		// --bg mints a NEW id, so capture and re-record it (otherwise flow
+		// would keep pointing at the dead id — the phantom-id bug).
+		agent, err := bg.ResumeBackground(sid, opts)
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			return 1
 		}
@@ -622,15 +654,16 @@ func cmdDoBackground(db *sql.DB, task *flowdb.Task, h harness.Harness, fresh, sk
 		if _, err := db.Exec(
 			`UPDATE tasks SET status='in-progress',
 			 status_changed_at = CASE WHEN status != 'in-progress' THEN ? ELSE status_changed_at END,
-			 session_last_resumed=?, updated_at=? WHERE slug=?`,
-			now, now, now, task.Slug,
+			 session_id=?, session_started=COALESCE(session_started, ?), session_last_resumed=?, updated_at=?
+			 WHERE slug=?`,
+			now, agent.SessionID, now, now, now, task.Slug,
 		); err != nil {
 			fmt.Fprintf(os.Stderr, "error: record resume: %v\n", err)
 			return 1
 		}
 		bumpWorkdirUsed(db, task.WorkDir)
-		fmt.Printf("Resumed %s in background (session %s) — check your Agent View (`claude agents`)\n",
-			task.Slug, sid)
+		fmt.Printf("Resumed %s in background (prior session was no longer tracked; brought the conversation back as %s · session %s)\n  check your Agent View: `claude agents`\n",
+			task.Slug, agent.ShortID, agent.SessionID)
 		return 0
 	}
 

--- a/internal/app/harness.go
+++ b/internal/app/harness.go
@@ -167,7 +167,11 @@ func liveSessionsForTasks(tasks []*flowdb.Task) map[string]int {
 		if bg, ok := h.(harness.BackgroundLauncher); ok {
 			if agents, err := bg.BackgroundAgents(); err == nil {
 				for _, a := range agents {
-					if a.SessionID != "" {
+					// Only a running process counts as "live". --all
+					// surfaces exited/failed/done sessions too (pid 0);
+					// those are recoverable but not currently running, so
+					// they must not light up the [live] marker.
+					if a.SessionID != "" && a.PID > 0 {
 						merged[strings.ToLower(a.SessionID)]++
 					}
 				}

--- a/internal/app/harness.go
+++ b/internal/app/harness.go
@@ -8,6 +8,7 @@ import (
 	"flow/internal/flowdb"
 	"flow/internal/harness"
 	"flow/internal/harness/claude"
+	"flow/internal/spawner"
 )
 
 // allHarnesses returns every implemented harness adapter. The slice
@@ -164,15 +165,21 @@ func liveSessionsForTasks(tasks []*flowdb.Task) map[string]int {
 				merged[id] += n
 			}
 		}
-		if bg, ok := h.(harness.BackgroundLauncher); ok {
-			if agents, err := bg.BackgroundAgents(); err == nil {
-				for _, a := range agents {
-					// Only a running process counts as "live". --all
-					// surfaces exited/failed/done sessions too (pid 0);
-					// those are recoverable but not currently running, so
-					// they must not light up the [live] marker.
-					if a.SessionID != "" && a.PID > 0 {
-						merged[strings.ToLower(a.SessionID)]++
+		// Only consult the background-agent registry in bg mode. The query
+		// is a `claude agents` subprocess; firing it on every `flow list`
+		// for non-bg users would be a latency regression (and they have no
+		// bg sessions to surface). bg-mode invocations opt into the cost.
+		if spawner.IsBackground() {
+			if bg, ok := h.(harness.BackgroundLauncher); ok {
+				if agents, err := bg.BackgroundAgents(); err == nil {
+					for _, a := range agents {
+						// Only a running process counts as "live". --all
+						// surfaces exited/failed/done sessions too (pid 0);
+						// those are recoverable but not currently running, so
+						// they must not light up the [live] marker.
+						if a.SessionID != "" && a.PID > 0 {
+							merged[strings.ToLower(a.SessionID)]++
+						}
 					}
 				}
 			}
@@ -188,6 +195,12 @@ func liveSessionsForTasks(tasks []*flowdb.Task) map[string]int {
 // per-render `claude agents --json` lookup.
 func bgAgentStatus(t *flowdb.Task) *harness.BackgroundAgent {
 	if t == nil || !t.SessionID.Valid || t.SessionID.String == "" {
+		return nil
+	}
+	// Only consult the registry in bg mode — see liveSessionsForTasks.
+	// Keeps `flow show` free of a `claude agents` subprocess for non-bg
+	// users (and avoids surfacing bg state they never opted into).
+	if !spawner.IsBackground() {
 		return nil
 	}
 	h, err := harnessForTask(t)

--- a/internal/app/harness.go
+++ b/internal/app/harness.go
@@ -140,6 +140,11 @@ func defaultHarness() harness.Harness {
 // contains entries from harnesses that resolved AND whose probe
 // succeeded. Used by `flow list tasks` to render [live] markers
 // without scanning the same process table N times.
+//
+// Background agents (claude --bg) typically don't carry --session-id /
+// --resume in their argv, so the ps scan misses them. For harnesses that
+// support background sessions, their registry (claude agents --json) is
+// merged in too so bg-bound tasks still light up [live].
 func liveSessionsForTasks(tasks []*flowdb.Task) map[string]int {
 	seen := map[harness.Name]bool{}
 	merged := map[string]int{}
@@ -159,6 +164,44 @@ func liveSessionsForTasks(tasks []*flowdb.Task) map[string]int {
 				merged[id] += n
 			}
 		}
+		if bg, ok := h.(harness.BackgroundLauncher); ok {
+			if agents, err := bg.BackgroundAgents(); err == nil {
+				for _, a := range agents {
+					if a.SessionID != "" {
+						merged[strings.ToLower(a.SessionID)]++
+					}
+				}
+			}
+		}
 	}
 	return merged
+}
+
+// bgAgentStatus returns the live background-agent entry for a task's bound
+// session, or nil if the task isn't bg-bound, has no session, the harness
+// can't host background agents, or the session isn't currently running.
+// Used by `flow show` to surface a bg session's status/state/pid via a
+// per-render `claude agents --json` lookup.
+func bgAgentStatus(t *flowdb.Task) *harness.BackgroundAgent {
+	if t == nil || !t.SessionID.Valid || t.SessionID.String == "" {
+		return nil
+	}
+	h, err := harnessForTask(t)
+	if err != nil {
+		return nil
+	}
+	bg, ok := h.(harness.BackgroundLauncher)
+	if !ok {
+		return nil
+	}
+	agents, err := bg.BackgroundAgents()
+	if err != nil {
+		return nil
+	}
+	for i := range agents {
+		if strings.EqualFold(agents[i].SessionID, t.SessionID.String) {
+			return &agents[i]
+		}
+	}
+	return nil
 }

--- a/internal/app/show.go
+++ b/internal/app/show.go
@@ -304,15 +304,16 @@ func printTaskMetadata(db *sql.DB, t *flowdb.Task, root string) {
 	// `claude agents --json` lookup. Only prints when the bound session
 	// is currently a running background agent.
 	if a := bgAgentStatus(t); a != nil {
-		line := a.Status
-		if a.State != "" {
-			line += " / " + a.State
+		line := bgStateLabel(a)
+		if a.PID > 0 {
+			line += fmt.Sprintf(" (pid %d", a.PID)
+			if a.ShortID != "" {
+				line += ", id " + a.ShortID
+			}
+			line += ")"
+		} else if a.ShortID != "" {
+			line += " (id " + a.ShortID + ")"
 		}
-		line += fmt.Sprintf(" (pid %d", a.PID)
-		if a.ShortID != "" {
-			line += ", id " + a.ShortID
-		}
-		line += ")"
 		fmt.Printf("bg_status:             %s\n", line)
 	}
 

--- a/internal/app/show.go
+++ b/internal/app/show.go
@@ -300,6 +300,22 @@ func printTaskMetadata(db *sql.DB, t *flowdb.Task, root string) {
 	}
 	fmt.Printf("session_last_resumed:  %s\n", slast)
 
+	// Live background-agent status (claude --bg): a per-render
+	// `claude agents --json` lookup. Only prints when the bound session
+	// is currently a running background agent.
+	if a := bgAgentStatus(t); a != nil {
+		line := a.Status
+		if a.State != "" {
+			line += " / " + a.State
+		}
+		line += fmt.Sprintf(" (pid %d", a.PID)
+		if a.ShortID != "" {
+			line += ", id " + a.ShortID
+		}
+		line += ")"
+		fmt.Printf("bg_status:             %s\n", line)
+	}
+
 	// Autonomous-run status (only for tasks ever launched with --auto).
 	// Reconcile a stale 'running' whose supervisor died before printing.
 	if t.AutoRunStatus.Valid && t.AutoRunStatus.String != "" {

--- a/internal/harness/claude/background.go
+++ b/internal/harness/claude/background.go
@@ -10,18 +10,27 @@ import (
 	"flow/internal/harness"
 )
 
-// BGCommandRunner executes `claude <args...>` and returns its combined
-// output. It is the single test seam for all background operations
-// (spawn, resume, list): tests dispatch on args to return canned
-// banners / JSON without spawning a real claude. The default execs the
-// real binary; because Go's exec invokes the binary directly (NOT via a
-// shell), the user's interactive `claude` alias — which injects --bg and
-// breaks --session-id pinning — never applies here. flow controls every
-// flag.
+// BGCommandRunner executes `claude <args...>` in workDir and returns its
+// combined output. It is the single test seam for all background
+// operations (spawn, resume, list): tests dispatch on args to return
+// canned banners / JSON without spawning a real claude. The default
+// execs the real binary; because Go's exec invokes the binary directly
+// (NOT via a shell), the user's interactive `claude` alias — which
+// injects --bg and breaks --session-id pinning — never applies here.
+// flow controls every flag.
+//
+// workDir sets the spawned process's cwd: a `claude --bg` session begins
+// there (and keys its transcript/CLAUDE.md context to it), so it must be
+// the task's work_dir. Empty workDir means "inherit flow's cwd" — used
+// for cwd-independent queries like `claude agents --json`.
 var BGCommandRunner = runBGCommand
 
-func runBGCommand(args []string) ([]byte, error) {
-	return exec.Command("claude", args...).CombinedOutput()
+func runBGCommand(workDir string, args []string) ([]byte, error) {
+	cmd := exec.Command("claude", args...)
+	if workDir != "" {
+		cmd.Dir = workDir
+	}
+	return cmd.CombinedOutput()
 }
 
 // ansiRe strips ANSI SGR escape sequences (color/dim) that `claude --bg`
@@ -89,21 +98,21 @@ func parseBackgroundAgents(raw []byte) ([]harness.BackgroundAgent, error) {
 // present but not currently running" — the former needs a resume, the
 // latter just needs the user to attach in the Agent View.
 func (c *claude) BackgroundAgents() ([]harness.BackgroundAgent, error) {
-	out, err := BGCommandRunner([]string{"agents", "--json", "--all"})
+	out, err := BGCommandRunner("", []string{"agents", "--json", "--all"})
 	if err != nil {
 		return nil, fmt.Errorf("claude agents --json --all: %w", err)
 	}
 	return parseBackgroundAgents(out)
 }
 
-// launchAndCapture runs a `claude --bg …` command, parses the short id
-// from its banner, and resolves the full session id by matching that
-// short id in the agent registry. One deterministic lookup — no polling,
-// no race — because `--bg` only prints the banner after the session is
-// registered. Shared by SpawnBackground and ResumeBackground (which
-// differ only in their argv; --bg mints a fresh id either way).
-func (c *claude) launchAndCapture(args []string, what string) (harness.BackgroundAgent, error) {
-	out, err := BGCommandRunner(args)
+// launchAndCapture runs a `claude --bg …` command in workDir, parses the
+// short id from its banner, and resolves the full session id by matching
+// that short id in the agent registry. One deterministic lookup — no
+// polling, no race — because `--bg` only prints the banner after the
+// session is registered. Shared by SpawnBackground and ResumeBackground
+// (which differ only in their argv; --bg mints a fresh id either way).
+func (c *claude) launchAndCapture(workDir string, args []string, what string) (harness.BackgroundAgent, error) {
+	out, err := BGCommandRunner(workDir, args)
 	if err != nil {
 		return harness.BackgroundAgent{}, fmt.Errorf("claude --bg (%s): %w (output: %s)", what, err, strings.TrimSpace(string(out)))
 	}
@@ -128,7 +137,7 @@ func (c *claude) launchAndCapture(args []string, what string) (harness.Backgroun
 // [--dangerously-skip-permissions]` and captures the minted session id.
 // opts.Inject is appended to the prompt behind InjectionMarker, mirroring
 // LaunchCmd.
-func (c *claude) SpawnBackground(name, prompt string, opts harness.LaunchOpts) (harness.BackgroundAgent, error) {
+func (c *claude) SpawnBackground(workDir, name, prompt string, opts harness.LaunchOpts) (harness.BackgroundAgent, error) {
 	if opts.Inject != "" {
 		prompt = prompt + "\n\n" + harness.InjectionMarker + "\n" + opts.Inject
 	}
@@ -136,7 +145,7 @@ func (c *claude) SpawnBackground(name, prompt string, opts harness.LaunchOpts) (
 	if opts.SkipPermissions {
 		args = append(args, "--dangerously-skip-permissions")
 	}
-	return c.launchAndCapture(args, "spawn")
+	return c.launchAndCapture(workDir, args, "spawn")
 }
 
 // ResumeBackground runs `claude --bg --resume <sessionID>
@@ -145,7 +154,7 @@ func (c *claude) SpawnBackground(name, prompt string, opts harness.LaunchOpts) (
 // the prior conversation* under a NEW id (verified against the CLI). So
 // this captures and returns the new id exactly like SpawnBackground; the
 // caller re-records it on the task.
-func (c *claude) ResumeBackground(sessionID string, opts harness.LaunchOpts) (harness.BackgroundAgent, error) {
+func (c *claude) ResumeBackground(workDir, sessionID string, opts harness.LaunchOpts) (harness.BackgroundAgent, error) {
 	args := []string{"--bg", "--resume", sessionID}
 	if opts.Inject != "" {
 		args = append(args, harness.InjectionMarker+"\n"+opts.Inject)
@@ -153,5 +162,5 @@ func (c *claude) ResumeBackground(sessionID string, opts harness.LaunchOpts) (ha
 	if opts.SkipPermissions {
 		args = append(args, "--dangerously-skip-permissions")
 	}
-	return c.launchAndCapture(args, "resume")
+	return c.launchAndCapture(workDir, args, "resume")
 }

--- a/internal/harness/claude/background.go
+++ b/internal/harness/claude/background.go
@@ -1,0 +1,146 @@
+package claude
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"flow/internal/harness"
+)
+
+// BGCommandRunner executes `claude <args...>` and returns its combined
+// output. It is the single test seam for all background operations
+// (spawn, resume, list): tests dispatch on args to return canned
+// banners / JSON without spawning a real claude. The default execs the
+// real binary; because Go's exec invokes the binary directly (NOT via a
+// shell), the user's interactive `claude` alias — which injects --bg and
+// breaks --session-id pinning — never applies here. flow controls every
+// flag.
+var BGCommandRunner = runBGCommand
+
+func runBGCommand(args []string) ([]byte, error) {
+	return exec.Command("claude", args...).CombinedOutput()
+}
+
+// ansiRe strips ANSI SGR escape sequences (color/dim) that `claude --bg`
+// wraps around the short id when stdout is a TTY. Stripping first lets
+// the banner parser work whether or not color is present.
+var ansiRe = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+// bannerShortIDRe matches the 8-char lowercase-hex short id following the
+// "backgrounded" marker on the banner's first line.
+var bannerShortIDRe = regexp.MustCompile(`backgrounded\s*·?\s*([0-9a-f]{8})\b`)
+
+// parseBackgroundBanner extracts the short id from `claude --bg`'s banner
+// (`backgrounded · <shortId> · <name>`). Reads only the first line — the
+// help lines beneath it also mention the short id. Returns an error if no
+// banner line is present (e.g. the spawn failed before registering).
+func parseBackgroundBanner(out string) (string, error) {
+	clean := ansiRe.ReplaceAllString(out, "")
+	firstLine := clean
+	if i := strings.IndexByte(clean, '\n'); i >= 0 {
+		firstLine = clean[:i]
+	}
+	m := bannerShortIDRe.FindStringSubmatch(firstLine)
+	if m == nil {
+		return "", fmt.Errorf("no background banner in output: %q", strings.TrimSpace(clean))
+	}
+	return m[1], nil
+}
+
+// bgAgentJSON mirrors one element of `claude agents --json`.
+type bgAgentJSON struct {
+	PID       int    `json:"pid"`
+	ID        string `json:"id"`
+	Cwd       string `json:"cwd"`
+	SessionID string `json:"sessionId"`
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	State     string `json:"state"`
+}
+
+// parseBackgroundAgents decodes `claude agents --json` into the harness's
+// normalized BackgroundAgent slice.
+func parseBackgroundAgents(raw []byte) ([]harness.BackgroundAgent, error) {
+	var entries []bgAgentJSON
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil, fmt.Errorf("parse claude agents --json: %w", err)
+	}
+	out := make([]harness.BackgroundAgent, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, harness.BackgroundAgent{
+			ShortID:   e.ID,
+			SessionID: e.SessionID,
+			Name:      e.Name,
+			Cwd:       e.Cwd,
+			PID:       e.PID,
+			Status:    e.Status,
+			State:     e.State,
+		})
+	}
+	return out, nil
+}
+
+// BackgroundAgents runs `claude agents --json` and decodes the registry.
+func (c *claude) BackgroundAgents() ([]harness.BackgroundAgent, error) {
+	out, err := BGCommandRunner([]string{"agents", "--json"})
+	if err != nil {
+		return nil, fmt.Errorf("claude agents --json: %w", err)
+	}
+	return parseBackgroundAgents(out)
+}
+
+// SpawnBackground runs `claude --bg --name <name> <prompt>
+// [--dangerously-skip-permissions]`, parses the short id from the banner,
+// then resolves the full session id by matching that short id in the
+// agent registry (one deterministic lookup — no polling, no race, since
+// the banner only prints after the session is registered). opts.Inject is
+// appended to the prompt behind InjectionMarker, mirroring LaunchCmd.
+func (c *claude) SpawnBackground(name, prompt string, opts harness.LaunchOpts) (harness.BackgroundAgent, error) {
+	if opts.Inject != "" {
+		prompt = prompt + "\n\n" + harness.InjectionMarker + "\n" + opts.Inject
+	}
+	args := []string{"--bg", "--name", name, prompt}
+	if opts.SkipPermissions {
+		args = append(args, "--dangerously-skip-permissions")
+	}
+	out, err := BGCommandRunner(args)
+	if err != nil {
+		return harness.BackgroundAgent{}, fmt.Errorf("claude --bg: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	shortID, err := parseBackgroundBanner(string(out))
+	if err != nil {
+		return harness.BackgroundAgent{}, err
+	}
+	agents, err := c.BackgroundAgents()
+	if err != nil {
+		return harness.BackgroundAgent{}, fmt.Errorf("resolve session id for %s: %w", shortID, err)
+	}
+	for _, a := range agents {
+		if a.ShortID == shortID {
+			return a, nil
+		}
+	}
+	return harness.BackgroundAgent{}, fmt.Errorf(
+		"spawned background agent %s but it is not in `claude agents --json` — cannot capture its session id", shortID)
+}
+
+// ResumeBackground runs `claude --bg --resume <sessionID>
+// [<injection>] [--dangerously-skip-permissions]`, continuing the same
+// session (id and transcript preserved). Output is ignored — only the
+// exit status matters.
+func (c *claude) ResumeBackground(sessionID string, opts harness.LaunchOpts) error {
+	args := []string{"--bg", "--resume", sessionID}
+	if opts.Inject != "" {
+		args = append(args, harness.InjectionMarker+"\n"+opts.Inject)
+	}
+	if opts.SkipPermissions {
+		args = append(args, "--dangerously-skip-permissions")
+	}
+	if out, err := BGCommandRunner(args); err != nil {
+		return fmt.Errorf("claude --bg --resume %s: %w (output: %s)", sessionID, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/internal/harness/claude/background.go
+++ b/internal/harness/claude/background.go
@@ -1,11 +1,13 @@
 package claude
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
 	"regexp"
 	"strings"
+	"time"
 
 	"flow/internal/harness"
 )
@@ -26,6 +28,19 @@ import (
 var BGCommandRunner = runBGCommand
 
 func runBGCommand(workDir string, args []string) ([]byte, error) {
+	// The read-only `agents` query runs on the hot path (flow show/list),
+	// so cap it: a stalled claude daemon must never hang those commands.
+	// Spawn/resume have no timeout — they return promptly after the
+	// session registers, and a slow spawn shouldn't be cut off.
+	if len(args) >= 1 && args[0] == "agents" {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "claude", args...)
+		if workDir != "" {
+			cmd.Dir = workDir
+		}
+		return cmd.CombinedOutput()
+	}
 	cmd := exec.Command("claude", args...)
 	if workDir != "" {
 		cmd.Dir = workDir
@@ -64,6 +79,7 @@ type bgAgentJSON struct {
 	PID       int    `json:"pid"`
 	ID        string `json:"id"`
 	Cwd       string `json:"cwd"`
+	Kind      string `json:"kind"`
 	SessionID string `json:"sessionId"`
 	Name      string `json:"name"`
 	Status    string `json:"status"`
@@ -71,7 +87,10 @@ type bgAgentJSON struct {
 }
 
 // parseBackgroundAgents decodes `claude agents --json` into the harness's
-// normalized BackgroundAgent slice.
+// normalized BackgroundAgent slice. Only `kind:"background"` entries are
+// returned — `--all` also lists interactive (terminal-tab) sessions, and
+// counting those would mislabel an ordinary `flow do` tab session as a
+// background agent in flow show / list.
 func parseBackgroundAgents(raw []byte) ([]harness.BackgroundAgent, error) {
 	var entries []bgAgentJSON
 	if err := json.Unmarshal(raw, &entries); err != nil {
@@ -79,6 +98,9 @@ func parseBackgroundAgents(raw []byte) ([]harness.BackgroundAgent, error) {
 	}
 	out := make([]harness.BackgroundAgent, 0, len(entries))
 	for _, e := range entries {
+		if e.Kind != "background" {
+			continue
+		}
 		out = append(out, harness.BackgroundAgent{
 			ShortID:   e.ID,
 			SessionID: e.SessionID,

--- a/internal/harness/claude/background.go
+++ b/internal/harness/claude/background.go
@@ -83,32 +83,29 @@ func parseBackgroundAgents(raw []byte) ([]harness.BackgroundAgent, error) {
 	return out, nil
 }
 
-// BackgroundAgents runs `claude agents --json` and decodes the registry.
+// BackgroundAgents runs `claude agents --json --all` and decodes the
+// registry. --all includes exited / failed / completed sessions (not
+// just live ones) so flow can tell "session removed" apart from "session
+// present but not currently running" — the former needs a resume, the
+// latter just needs the user to attach in the Agent View.
 func (c *claude) BackgroundAgents() ([]harness.BackgroundAgent, error) {
-	out, err := BGCommandRunner([]string{"agents", "--json"})
+	out, err := BGCommandRunner([]string{"agents", "--json", "--all"})
 	if err != nil {
-		return nil, fmt.Errorf("claude agents --json: %w", err)
+		return nil, fmt.Errorf("claude agents --json --all: %w", err)
 	}
 	return parseBackgroundAgents(out)
 }
 
-// SpawnBackground runs `claude --bg --name <name> <prompt>
-// [--dangerously-skip-permissions]`, parses the short id from the banner,
-// then resolves the full session id by matching that short id in the
-// agent registry (one deterministic lookup — no polling, no race, since
-// the banner only prints after the session is registered). opts.Inject is
-// appended to the prompt behind InjectionMarker, mirroring LaunchCmd.
-func (c *claude) SpawnBackground(name, prompt string, opts harness.LaunchOpts) (harness.BackgroundAgent, error) {
-	if opts.Inject != "" {
-		prompt = prompt + "\n\n" + harness.InjectionMarker + "\n" + opts.Inject
-	}
-	args := []string{"--bg", "--name", name, prompt}
-	if opts.SkipPermissions {
-		args = append(args, "--dangerously-skip-permissions")
-	}
+// launchAndCapture runs a `claude --bg …` command, parses the short id
+// from its banner, and resolves the full session id by matching that
+// short id in the agent registry. One deterministic lookup — no polling,
+// no race — because `--bg` only prints the banner after the session is
+// registered. Shared by SpawnBackground and ResumeBackground (which
+// differ only in their argv; --bg mints a fresh id either way).
+func (c *claude) launchAndCapture(args []string, what string) (harness.BackgroundAgent, error) {
 	out, err := BGCommandRunner(args)
 	if err != nil {
-		return harness.BackgroundAgent{}, fmt.Errorf("claude --bg: %w (output: %s)", err, strings.TrimSpace(string(out)))
+		return harness.BackgroundAgent{}, fmt.Errorf("claude --bg (%s): %w (output: %s)", what, err, strings.TrimSpace(string(out)))
 	}
 	shortID, err := parseBackgroundBanner(string(out))
 	if err != nil {
@@ -124,14 +121,31 @@ func (c *claude) SpawnBackground(name, prompt string, opts harness.LaunchOpts) (
 		}
 	}
 	return harness.BackgroundAgent{}, fmt.Errorf(
-		"spawned background agent %s but it is not in `claude agents --json` — cannot capture its session id", shortID)
+		"backgrounded agent %s but it is not in `claude agents --json --all` — cannot capture its session id", shortID)
+}
+
+// SpawnBackground runs `claude --bg --name <name> <prompt>
+// [--dangerously-skip-permissions]` and captures the minted session id.
+// opts.Inject is appended to the prompt behind InjectionMarker, mirroring
+// LaunchCmd.
+func (c *claude) SpawnBackground(name, prompt string, opts harness.LaunchOpts) (harness.BackgroundAgent, error) {
+	if opts.Inject != "" {
+		prompt = prompt + "\n\n" + harness.InjectionMarker + "\n" + opts.Inject
+	}
+	args := []string{"--bg", "--name", name, prompt}
+	if opts.SkipPermissions {
+		args = append(args, "--dangerously-skip-permissions")
+	}
+	return c.launchAndCapture(args, "spawn")
 }
 
 // ResumeBackground runs `claude --bg --resume <sessionID>
-// [<injection>] [--dangerously-skip-permissions]`, continuing the same
-// session (id and transcript preserved). Output is ignored — only the
-// exit status matters.
-func (c *claude) ResumeBackground(sessionID string, opts harness.LaunchOpts) error {
+// [<injection>] [--dangerously-skip-permissions]`. `--bg` does not honor
+// `--resume`'s id — it starts a fresh background process that *inherits
+// the prior conversation* under a NEW id (verified against the CLI). So
+// this captures and returns the new id exactly like SpawnBackground; the
+// caller re-records it on the task.
+func (c *claude) ResumeBackground(sessionID string, opts harness.LaunchOpts) (harness.BackgroundAgent, error) {
 	args := []string{"--bg", "--resume", sessionID}
 	if opts.Inject != "" {
 		args = append(args, harness.InjectionMarker+"\n"+opts.Inject)
@@ -139,8 +153,5 @@ func (c *claude) ResumeBackground(sessionID string, opts harness.LaunchOpts) err
 	if opts.SkipPermissions {
 		args = append(args, "--dangerously-skip-permissions")
 	}
-	if out, err := BGCommandRunner(args); err != nil {
-		return fmt.Errorf("claude --bg --resume %s: %w (output: %s)", sessionID, err, strings.TrimSpace(string(out)))
-	}
-	return nil
+	return c.launchAndCapture(args, "resume")
 }

--- a/internal/harness/claude/background_test.go
+++ b/internal/harness/claude/background_test.go
@@ -88,29 +88,37 @@ func TestParseBackgroundAgents(t *testing.T) {
 	}
 }
 
-// stubBG installs a BGCommandRunner that dispatches on args[0]/presence
-// of --bg: spawn/resume calls get the banner, `agents --json` gets the
-// JSON. Records the last spawn/resume argv for assertions.
-func stubBG(t *testing.T, banner, agentsJSON string) *[]string {
+// bgCap records what a stubbed BGCommandRunner saw on the last
+// spawn/resume (non-`agents`) call.
+type bgCap struct {
+	args    []string
+	workDir string
+}
+
+// stubBG installs a BGCommandRunner that dispatches on args[0]: spawn /
+// resume calls get the banner (and are recorded), `agents` calls get the
+// JSON. Returns the capture for assertions.
+func stubBG(t *testing.T, banner, agentsJSON string) *bgCap {
 	t.Helper()
-	var lastNonAgents []string
+	cap := &bgCap{}
 	old := BGCommandRunner
-	BGCommandRunner = func(args []string) ([]byte, error) {
+	BGCommandRunner = func(workDir string, args []string) ([]byte, error) {
 		if len(args) >= 1 && args[0] == "agents" {
 			return []byte(agentsJSON), nil
 		}
-		lastNonAgents = args
+		cap.args = args
+		cap.workDir = workDir
 		return []byte(banner), nil
 	}
 	t.Cleanup(func() { BGCommandRunner = old })
-	return &lastNonAgents
+	return cap
 }
 
 func TestSpawnBackgroundCapturesSessionID(t *testing.T) {
-	argv := stubBG(t, realBanner, realAgentsJSON)
+	cap := stubBG(t, realBanner, realAgentsJSON)
 	h := New().(harness.BackgroundLauncher)
 
-	agent, err := h.SpawnBackground("flow/bg-probe", "do the work", harness.LaunchOpts{})
+	agent, err := h.SpawnBackground("/work/dir", "flow/bg-probe", "do the work", harness.LaunchOpts{})
 	if err != nil {
 		t.Fatalf("SpawnBackground: %v", err)
 	}
@@ -125,41 +133,54 @@ func TestSpawnBackgroundCapturesSessionID(t *testing.T) {
 	}
 
 	// argv must carry --bg, --name <name>, and the prompt; no skip flag.
-	joined := strings.Join(*argv, "\x00")
+	joined := strings.Join(cap.args, "\x00")
 	if !strings.Contains(joined, "--bg") {
-		t.Errorf("spawn argv missing --bg: %v", *argv)
+		t.Errorf("spawn argv missing --bg: %v", cap.args)
 	}
-	if !containsPair(*argv, "--name", "flow/bg-probe") {
-		t.Errorf("spawn argv missing --name flow/bg-probe: %v", *argv)
+	if !containsPair(cap.args, "--name", "flow/bg-probe") {
+		t.Errorf("spawn argv missing --name flow/bg-probe: %v", cap.args)
 	}
-	if !contains(*argv, "do the work") {
-		t.Errorf("spawn argv missing prompt: %v", *argv)
+	if !contains(cap.args, "do the work") {
+		t.Errorf("spawn argv missing prompt: %v", cap.args)
 	}
-	if contains(*argv, "--dangerously-skip-permissions") {
-		t.Errorf("spawn argv should NOT skip permissions when opts unset: %v", *argv)
+	if contains(cap.args, "--dangerously-skip-permissions") {
+		t.Errorf("spawn argv should NOT skip permissions when opts unset: %v", cap.args)
+	}
+}
+
+// SpawnBackground must run claude in the task's work_dir (a bg session
+// begins there and keys its transcript/CLAUDE.md to it), not flow's cwd.
+func TestSpawnBackgroundRunsInWorkDir(t *testing.T) {
+	cap := stubBG(t, realBanner, realAgentsJSON)
+	h := New().(harness.BackgroundLauncher)
+	if _, err := h.SpawnBackground("/repo/app", "n", "p", harness.LaunchOpts{}); err != nil {
+		t.Fatalf("SpawnBackground: %v", err)
+	}
+	if cap.workDir != "/repo/app" {
+		t.Errorf("spawn cwd = %q, want /repo/app", cap.workDir)
 	}
 }
 
 func TestSpawnBackgroundSkipPermissions(t *testing.T) {
-	argv := stubBG(t, realBanner, realAgentsJSON)
+	cap := stubBG(t, realBanner, realAgentsJSON)
 	h := New().(harness.BackgroundLauncher)
-	if _, err := h.SpawnBackground("n", "p", harness.LaunchOpts{SkipPermissions: true}); err != nil {
+	if _, err := h.SpawnBackground("/w", "n", "p", harness.LaunchOpts{SkipPermissions: true}); err != nil {
 		t.Fatalf("SpawnBackground: %v", err)
 	}
-	if !contains(*argv, "--dangerously-skip-permissions") {
-		t.Errorf("spawn argv missing skip flag: %v", *argv)
+	if !contains(cap.args, "--dangerously-skip-permissions") {
+		t.Errorf("spawn argv missing skip flag: %v", cap.args)
 	}
 }
 
 func TestSpawnBackgroundInjectAppended(t *testing.T) {
-	argv := stubBG(t, realBanner, realAgentsJSON)
+	cap := stubBG(t, realBanner, realAgentsJSON)
 	h := New().(harness.BackgroundLauncher)
-	if _, err := h.SpawnBackground("n", "base prompt", harness.LaunchOpts{Inject: "also check X"}); err != nil {
+	if _, err := h.SpawnBackground("/w", "n", "base prompt", harness.LaunchOpts{Inject: "also check X"}); err != nil {
 		t.Fatalf("SpawnBackground: %v", err)
 	}
-	joined := strings.Join(*argv, "\n")
+	joined := strings.Join(cap.args, "\n")
 	if !strings.Contains(joined, harness.InjectionMarker) || !strings.Contains(joined, "also check X") {
-		t.Errorf("spawn argv missing injection marker/text: %v", *argv)
+		t.Errorf("spawn argv missing injection marker/text: %v", cap.args)
 	}
 }
 
@@ -168,7 +189,7 @@ func TestSpawnBackgroundInjectAppended(t *testing.T) {
 func TestSpawnBackgroundShortIDNotInRegistry(t *testing.T) {
 	stubBG(t, "backgrounded · deadbeef · n\n", realAgentsJSON)
 	h := New().(harness.BackgroundLauncher)
-	if _, err := h.SpawnBackground("n", "p", harness.LaunchOpts{}); err == nil {
+	if _, err := h.SpawnBackground("/w", "n", "p", harness.LaunchOpts{}); err == nil {
 		t.Fatalf("SpawnBackground: want error when short id absent from registry")
 	}
 }
@@ -176,19 +197,22 @@ func TestSpawnBackgroundShortIDNotInRegistry(t *testing.T) {
 // ResumeBackground resumes the OLD id under --bg but, because --bg mints
 // a fresh id, must return the NEW captured agent (history inherited).
 func TestResumeBackgroundCapturesNewID(t *testing.T) {
-	argv := stubBG(t, realBanner, realAgentsJSON)
+	cap := stubBG(t, realBanner, realAgentsJSON)
 	h := New().(harness.BackgroundLauncher)
 	oldSID := "00000000-1111-4222-8333-444444444444"
-	agent, err := h.ResumeBackground(oldSID, harness.LaunchOpts{SkipPermissions: true})
+	agent, err := h.ResumeBackground("/repo/app", oldSID, harness.LaunchOpts{SkipPermissions: true})
 	if err != nil {
 		t.Fatalf("ResumeBackground: %v", err)
 	}
-	// argv resumes the OLD id under --bg ...
-	if !contains(*argv, "--bg") || !containsPair(*argv, "--resume", oldSID) {
-		t.Errorf("resume argv wrong: %v", *argv)
+	// argv resumes the OLD id under --bg, in the task's work_dir ...
+	if !contains(cap.args, "--bg") || !containsPair(cap.args, "--resume", oldSID) {
+		t.Errorf("resume argv wrong: %v", cap.args)
 	}
-	if !contains(*argv, "--dangerously-skip-permissions") {
-		t.Errorf("resume argv missing skip flag: %v", *argv)
+	if cap.workDir != "/repo/app" {
+		t.Errorf("resume cwd = %q, want /repo/app", cap.workDir)
+	}
+	if !contains(cap.args, "--dangerously-skip-permissions") {
+		t.Errorf("resume argv missing skip flag: %v", cap.args)
 	}
 	// ... but returns the NEW id minted by --bg (captured via banner + registry).
 	if agent.SessionID != "48d287d9-1ef0-4738-84b9-3110beb988c4" {
@@ -213,7 +237,7 @@ func TestBackgroundAgentsList(t *testing.T) {
 func TestBackgroundAgentsUsesAll(t *testing.T) {
 	var gotArgs []string
 	old := BGCommandRunner
-	BGCommandRunner = func(args []string) ([]byte, error) { gotArgs = args; return []byte("[]"), nil }
+	BGCommandRunner = func(workDir string, args []string) ([]byte, error) { gotArgs = args; return []byte("[]"), nil }
 	t.Cleanup(func() { BGCommandRunner = old })
 	if _, err := New().(harness.BackgroundLauncher).BackgroundAgents(); err != nil {
 		t.Fatalf("BackgroundAgents: %v", err)

--- a/internal/harness/claude/background_test.go
+++ b/internal/harness/claude/background_test.go
@@ -173,18 +173,26 @@ func TestSpawnBackgroundShortIDNotInRegistry(t *testing.T) {
 	}
 }
 
-func TestResumeBackgroundArgv(t *testing.T) {
+// ResumeBackground resumes the OLD id under --bg but, because --bg mints
+// a fresh id, must return the NEW captured agent (history inherited).
+func TestResumeBackgroundCapturesNewID(t *testing.T) {
 	argv := stubBG(t, realBanner, realAgentsJSON)
 	h := New().(harness.BackgroundLauncher)
-	sid := "48d287d9-1ef0-4738-84b9-3110beb988c4"
-	if err := h.ResumeBackground(sid, harness.LaunchOpts{SkipPermissions: true}); err != nil {
+	oldSID := "00000000-1111-4222-8333-444444444444"
+	agent, err := h.ResumeBackground(oldSID, harness.LaunchOpts{SkipPermissions: true})
+	if err != nil {
 		t.Fatalf("ResumeBackground: %v", err)
 	}
-	if !contains(*argv, "--bg") || !containsPair(*argv, "--resume", sid) {
+	// argv resumes the OLD id under --bg ...
+	if !contains(*argv, "--bg") || !containsPair(*argv, "--resume", oldSID) {
 		t.Errorf("resume argv wrong: %v", *argv)
 	}
 	if !contains(*argv, "--dangerously-skip-permissions") {
 		t.Errorf("resume argv missing skip flag: %v", *argv)
+	}
+	// ... but returns the NEW id minted by --bg (captured via banner + registry).
+	if agent.SessionID != "48d287d9-1ef0-4738-84b9-3110beb988c4" {
+		t.Errorf("ResumeBackground returned %q, want the newly-minted id", agent.SessionID)
 	}
 }
 
@@ -197,6 +205,21 @@ func TestBackgroundAgentsList(t *testing.T) {
 	}
 	if len(agents) != 2 {
 		t.Fatalf("BackgroundAgents: got %d, want 2", len(agents))
+	}
+}
+
+// BackgroundAgents must query with --all so exited/failed/completed
+// sessions are visible (needed to tell "removed" from "present, idle").
+func TestBackgroundAgentsUsesAll(t *testing.T) {
+	var gotArgs []string
+	old := BGCommandRunner
+	BGCommandRunner = func(args []string) ([]byte, error) { gotArgs = args; return []byte("[]"), nil }
+	t.Cleanup(func() { BGCommandRunner = old })
+	if _, err := New().(harness.BackgroundLauncher).BackgroundAgents(); err != nil {
+		t.Fatalf("BackgroundAgents: %v", err)
+	}
+	if !contains(gotArgs, "agents") || !contains(gotArgs, "--json") || !contains(gotArgs, "--all") {
+		t.Errorf("BackgroundAgents args = %v, want agents --json --all", gotArgs)
 	}
 }
 

--- a/internal/harness/claude/background_test.go
+++ b/internal/harness/claude/background_test.go
@@ -58,6 +58,24 @@ func TestParseBackgroundBanner(t *testing.T) {
 	}
 }
 
+// `claude agents --json --all` also returns interactive (non-background)
+// sessions. parseBackgroundAgents must drop them — flow's bg surfaces
+// (bg_status, [live] merge, resume detection) are about background agents
+// only, and counting an ordinary tab session would mislabel it.
+func TestParseBackgroundAgentsDropsInteractive(t *testing.T) {
+	const mixed = `[
+	  {"pid":1,"id":"aaaaaaaa","cwd":"/w","kind":"interactive","sessionId":"aaaaaaaa-0000-4000-8000-000000000000","name":"tab","status":"waiting"},
+	  {"pid":2,"id":"bbbbbbbb","cwd":"/w","kind":"background","sessionId":"bbbbbbbb-0000-4000-8000-000000000000","name":"bg","status":"busy","state":"working"}
+	]`
+	agents, err := parseBackgroundAgents([]byte(mixed))
+	if err != nil {
+		t.Fatalf("parseBackgroundAgents: %v", err)
+	}
+	if len(agents) != 1 || agents[0].ShortID != "bbbbbbbb" {
+		t.Errorf("got %+v, want only the background-kind entry", agents)
+	}
+}
+
 func TestParseBackgroundAgents(t *testing.T) {
 	agents, err := parseBackgroundAgents([]byte(realAgentsJSON))
 	if err != nil {

--- a/internal/harness/claude/background_test.go
+++ b/internal/harness/claude/background_test.go
@@ -1,0 +1,221 @@
+package claude
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"flow/internal/harness"
+)
+
+// realBanner mirrors the exact stdout `claude --bg --name <n> <prompt>`
+// prints (captured from the live CLI): the short id is wrapped in ANSI
+// color codes, the separator is U+00B7, and help lines follow that also
+// mention the short id (so the parser must read only the first line).
+const realBanner = "backgrounded · \x1b[36m48d287d9\x1b[39m · flow/bg-probe\n" +
+	"\x1b[2m  claude agents             list sessions\x1b[22m\n" +
+	"\x1b[2m  claude attach 48d287d9    open in this terminal\x1b[22m\n"
+
+// realAgentsJSON mirrors `claude agents --json` (captured live).
+const realAgentsJSON = `[
+  {"pid":7184,"id":"48d287d9","cwd":"/work/dir","kind":"background",
+   "startedAt":1781025646235,"sessionId":"48d287d9-1ef0-4738-84b9-3110beb988c4",
+   "name":"flow/bg-probe","status":"idle","state":"done"},
+  {"pid":85723,"id":"5cb25e62","cwd":"/other","kind":"background",
+   "startedAt":1780564604460,"sessionId":"5cb25e62-0f1f-40d9-9da6-72b2d36c990f",
+   "name":"Monitoring","status":"busy","state":"working"}
+]`
+
+func TestParseBackgroundBanner(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+		err  bool
+	}{
+		{"ansi+name", realBanner, "48d287d9", false},
+		{"no-ansi", "backgrounded · c10d7528 · some name\n", "c10d7528", false},
+		{"no-name", "backgrounded · \x1b[36m1923df79\x1b[39m\n", "1923df79", false},
+		{"no-banner", "some unrelated output\n", "", true},
+		{"empty", "", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseBackgroundBanner(tc.in)
+			if tc.err {
+				if err == nil {
+					t.Fatalf("parseBackgroundBanner(%q) = %q, want error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseBackgroundBanner(%q): %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("parseBackgroundBanner: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseBackgroundAgents(t *testing.T) {
+	agents, err := parseBackgroundAgents([]byte(realAgentsJSON))
+	if err != nil {
+		t.Fatalf("parseBackgroundAgents: %v", err)
+	}
+	want := []harness.BackgroundAgent{
+		{
+			ShortID:   "48d287d9",
+			SessionID: "48d287d9-1ef0-4738-84b9-3110beb988c4",
+			Name:      "flow/bg-probe",
+			Cwd:       "/work/dir",
+			PID:       7184,
+			Status:    "idle",
+			State:     "done",
+		},
+		{
+			ShortID:   "5cb25e62",
+			SessionID: "5cb25e62-0f1f-40d9-9da6-72b2d36c990f",
+			Name:      "Monitoring",
+			Cwd:       "/other",
+			PID:       85723,
+			Status:    "busy",
+			State:     "working",
+		},
+	}
+	if !reflect.DeepEqual(agents, want) {
+		t.Errorf("parseBackgroundAgents mismatch:\n got %+v\nwant %+v", agents, want)
+	}
+}
+
+// stubBG installs a BGCommandRunner that dispatches on args[0]/presence
+// of --bg: spawn/resume calls get the banner, `agents --json` gets the
+// JSON. Records the last spawn/resume argv for assertions.
+func stubBG(t *testing.T, banner, agentsJSON string) *[]string {
+	t.Helper()
+	var lastNonAgents []string
+	old := BGCommandRunner
+	BGCommandRunner = func(args []string) ([]byte, error) {
+		if len(args) >= 1 && args[0] == "agents" {
+			return []byte(agentsJSON), nil
+		}
+		lastNonAgents = args
+		return []byte(banner), nil
+	}
+	t.Cleanup(func() { BGCommandRunner = old })
+	return &lastNonAgents
+}
+
+func TestSpawnBackgroundCapturesSessionID(t *testing.T) {
+	argv := stubBG(t, realBanner, realAgentsJSON)
+	h := New().(harness.BackgroundLauncher)
+
+	agent, err := h.SpawnBackground("flow/bg-probe", "do the work", harness.LaunchOpts{})
+	if err != nil {
+		t.Fatalf("SpawnBackground: %v", err)
+	}
+	if agent.SessionID != "48d287d9-1ef0-4738-84b9-3110beb988c4" {
+		t.Errorf("SessionID: got %q, want full UUID", agent.SessionID)
+	}
+	if agent.Name != "flow/bg-probe" {
+		t.Errorf("Name: got %q", agent.Name)
+	}
+	if agent.Status != "idle" {
+		t.Errorf("Status: got %q, want idle", agent.Status)
+	}
+
+	// argv must carry --bg, --name <name>, and the prompt; no skip flag.
+	joined := strings.Join(*argv, "\x00")
+	if !strings.Contains(joined, "--bg") {
+		t.Errorf("spawn argv missing --bg: %v", *argv)
+	}
+	if !containsPair(*argv, "--name", "flow/bg-probe") {
+		t.Errorf("spawn argv missing --name flow/bg-probe: %v", *argv)
+	}
+	if !contains(*argv, "do the work") {
+		t.Errorf("spawn argv missing prompt: %v", *argv)
+	}
+	if contains(*argv, "--dangerously-skip-permissions") {
+		t.Errorf("spawn argv should NOT skip permissions when opts unset: %v", *argv)
+	}
+}
+
+func TestSpawnBackgroundSkipPermissions(t *testing.T) {
+	argv := stubBG(t, realBanner, realAgentsJSON)
+	h := New().(harness.BackgroundLauncher)
+	if _, err := h.SpawnBackground("n", "p", harness.LaunchOpts{SkipPermissions: true}); err != nil {
+		t.Fatalf("SpawnBackground: %v", err)
+	}
+	if !contains(*argv, "--dangerously-skip-permissions") {
+		t.Errorf("spawn argv missing skip flag: %v", *argv)
+	}
+}
+
+func TestSpawnBackgroundInjectAppended(t *testing.T) {
+	argv := stubBG(t, realBanner, realAgentsJSON)
+	h := New().(harness.BackgroundLauncher)
+	if _, err := h.SpawnBackground("n", "base prompt", harness.LaunchOpts{Inject: "also check X"}); err != nil {
+		t.Fatalf("SpawnBackground: %v", err)
+	}
+	joined := strings.Join(*argv, "\n")
+	if !strings.Contains(joined, harness.InjectionMarker) || !strings.Contains(joined, "also check X") {
+		t.Errorf("spawn argv missing injection marker/text: %v", *argv)
+	}
+}
+
+// If the captured short id isn't in the agents registry, capture failed
+// — surface an error rather than recording a phantom id.
+func TestSpawnBackgroundShortIDNotInRegistry(t *testing.T) {
+	stubBG(t, "backgrounded · deadbeef · n\n", realAgentsJSON)
+	h := New().(harness.BackgroundLauncher)
+	if _, err := h.SpawnBackground("n", "p", harness.LaunchOpts{}); err == nil {
+		t.Fatalf("SpawnBackground: want error when short id absent from registry")
+	}
+}
+
+func TestResumeBackgroundArgv(t *testing.T) {
+	argv := stubBG(t, realBanner, realAgentsJSON)
+	h := New().(harness.BackgroundLauncher)
+	sid := "48d287d9-1ef0-4738-84b9-3110beb988c4"
+	if err := h.ResumeBackground(sid, harness.LaunchOpts{SkipPermissions: true}); err != nil {
+		t.Fatalf("ResumeBackground: %v", err)
+	}
+	if !contains(*argv, "--bg") || !containsPair(*argv, "--resume", sid) {
+		t.Errorf("resume argv wrong: %v", *argv)
+	}
+	if !contains(*argv, "--dangerously-skip-permissions") {
+		t.Errorf("resume argv missing skip flag: %v", *argv)
+	}
+}
+
+func TestBackgroundAgentsList(t *testing.T) {
+	stubBG(t, realBanner, realAgentsJSON)
+	h := New().(harness.BackgroundLauncher)
+	agents, err := h.BackgroundAgents()
+	if err != nil {
+		t.Fatalf("BackgroundAgents: %v", err)
+	}
+	if len(agents) != 2 {
+		t.Fatalf("BackgroundAgents: got %d, want 2", len(agents))
+	}
+}
+
+// ---- tiny helpers ----
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsPair(ss []string, flag, val string) bool {
+	for i := 0; i+1 < len(ss); i++ {
+		if ss[i] == flag && ss[i+1] == val {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/harness/claude/transcript.go
+++ b/internal/harness/claude/transcript.go
@@ -55,7 +55,17 @@ func resolveTranscriptPath(home, cwd, sessionID string) (string, error) {
 	}
 	matches, _ := filepath.Glob(filepath.Join(projects, "*", sessionID+".jsonl"))
 	if len(matches) > 0 {
-		return matches[0], nil
+		// The same session id can appear under two project dirs (e.g. a
+		// plain `claude --resume <id>` from a different cwd writes a second
+		// copy). Prefer the most recently modified — the live transcript,
+		// not a stale one.
+		newest, newestMod := matches[0], int64(-1)
+		for _, m := range matches {
+			if fi, err := os.Stat(m); err == nil && fi.ModTime().UnixNano() > newestMod {
+				newest, newestMod = m, fi.ModTime().UnixNano()
+			}
+		}
+		return newest, nil
 	}
 	return "", fmt.Errorf(
 		"claude transcript not found: no %s.jsonl under %s (tried cwd-encoded path %s and a glob on the session id)",

--- a/internal/harness/claude/transcript.go
+++ b/internal/harness/claude/transcript.go
@@ -24,21 +24,43 @@ func (c *claude) RenderTranscript(cwd, sessionID string, compact bool, w io.Writ
 	if err != nil {
 		return fmt.Errorf("no home dir: %w", err)
 	}
-	encoded := EncodeCwd(cwd)
-	p := filepath.Join(home, ".claude", "projects", encoded, sessionID+".jsonl")
+	p, err := resolveTranscriptPath(home, cwd, sessionID)
+	if err != nil {
+		return err
+	}
 	f, err := os.Open(p)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf(
-				"claude transcript not found at %s (cwd=%q maps to project dir %q). "+
-					"the file might be under a different project dir if claude was started elsewhere",
-				p, cwd, encoded,
-			)
-		}
 		return fmt.Errorf("open claude transcript %s: %w", p, err)
 	}
 	defer f.Close()
 	return RenderJSONL(f, compact, w)
+}
+
+// resolveTranscriptPath locates a session's jsonl under
+// ~/.claude/projects. It first tries the deterministic cwd-encoded path
+// (~/.claude/projects/<EncodeCwd(cwd)>/<sid>.jsonl) — the fast, exact
+// hit for ordinary sessions. If that file is absent it falls back to a
+// glob on the globally-unique session id (~/.claude/projects/*/<sid>.jsonl).
+//
+// The glob fallback is what makes bg/worktree sessions resolvable: a
+// `claude --bg` session can auto-move into a git worktree and key its
+// jsonl under the PARENT repo's project dir rather than the worktree
+// cwd, so neither work_dir nor the agent's reported cwd reliably encodes
+// the path. Since the session id is unique, the glob is unambiguous.
+func resolveTranscriptPath(home, cwd, sessionID string) (string, error) {
+	projects := filepath.Join(home, ".claude", "projects")
+	det := filepath.Join(projects, EncodeCwd(cwd), sessionID+".jsonl")
+	if _, err := os.Stat(det); err == nil {
+		return det, nil
+	}
+	matches, _ := filepath.Glob(filepath.Join(projects, "*", sessionID+".jsonl"))
+	if len(matches) > 0 {
+		return matches[0], nil
+	}
+	return "", fmt.Errorf(
+		"claude transcript not found: no %s.jsonl under %s (tried cwd-encoded path %s and a glob on the session id)",
+		sessionID, projects, det,
+	)
 }
 
 // RenderJSONL renders a claude session jsonl byte-stream to w. Exposed

--- a/internal/harness/claude/transcript_test.go
+++ b/internal/harness/claude/transcript_test.go
@@ -2,6 +2,8 @@ package claude
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -125,5 +127,75 @@ func TestRendersEntriesWithoutTimestamp(t *testing.T) {
 
 	if !strings.Contains(out, "NO TIMESTAMP entry") {
 		t.Errorf("entry without timestamp dropped:\n%s", out)
+	}
+}
+
+// TestResolveTranscriptPathPrefersDeterministic: when the cwd-encoded
+// path exists, it wins — no glob needed.
+func TestResolveTranscriptPathPrefersDeterministic(t *testing.T) {
+	home := t.TempDir()
+	cwd := "/Users/x/code/app"
+	sid := "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+
+	det := filepath.Join(home, ".claude", "projects", EncodeCwd(cwd), sid+".jsonl")
+	if err := os.MkdirAll(filepath.Dir(det), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(det, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A decoy under a different project dir must NOT be chosen.
+	decoyDir := filepath.Join(home, ".claude", "projects", "-Users-x-other")
+	if err := os.MkdirAll(decoyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(decoyDir, sid+".jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveTranscriptPath(home, cwd, sid)
+	if err != nil {
+		t.Fatalf("resolveTranscriptPath: %v", err)
+	}
+	if got != det {
+		t.Errorf("got %q, want deterministic path %q", got, det)
+	}
+}
+
+// TestResolveTranscriptPathGlobFallback simulates the bg/worktree gotcha:
+// the session ran with cwd under a git worktree but its jsonl is keyed
+// under the PARENT repo's project dir. The cwd-encoded path doesn't
+// exist, so resolution must fall back to a glob on the globally-unique
+// session id.
+func TestResolveTranscriptPathGlobFallback(t *testing.T) {
+	home := t.TempDir()
+	worktreeCwd := "/Users/x/flow/.claude/worktrees/bg-spawn-backend"
+	sid := "48d287d9-1ef0-4738-84b9-3110beb988c4"
+
+	// jsonl lives under the parent-repo project dir, not the worktree's.
+	parentDir := filepath.Join(home, ".claude", "projects", "-Users-x-flow")
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	actual := filepath.Join(parentDir, sid+".jsonl")
+	if err := os.WriteFile(actual, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveTranscriptPath(home, worktreeCwd, sid)
+	if err != nil {
+		t.Fatalf("resolveTranscriptPath (glob fallback): %v", err)
+	}
+	if got != actual {
+		t.Errorf("got %q, want globbed path %q", got, actual)
+	}
+}
+
+// TestResolveTranscriptPathNotFound: neither deterministic nor glob hits.
+func TestResolveTranscriptPathNotFound(t *testing.T) {
+	home := t.TempDir()
+	_, err := resolveTranscriptPath(home, "/Users/x/code/app", "ffffffff-0000-4000-8000-000000000000")
+	if err == nil {
+		t.Fatalf("resolveTranscriptPath: want error when no jsonl exists")
 	}
 }

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -82,12 +82,15 @@ type BackgroundAgent struct {
 // captures the REAL id after spawn by querying the registry, so the
 // DB-authoritative binding contract holds without fighting the harness.
 type BackgroundLauncher interface {
-	// SpawnBackground starts a fresh background session running prompt,
-	// displayed as name. It blocks only until the session is registered
-	// (no polling), then resolves and returns the full session id (plus
-	// current status) by querying the agent registry. The returned
+	// SpawnBackground starts a fresh background session in workDir,
+	// running prompt, displayed as name. workDir is where the agent
+	// begins (and what its transcript/CLAUDE.md context is keyed to) —
+	// it must be the task's work_dir, not the cwd flow happened to run
+	// from. It blocks only until the session is registered (no polling),
+	// then resolves and returns the full session id (plus current
+	// status) by querying the agent registry. The returned
 	// BackgroundAgent.SessionID is what flow records on the task.
-	SpawnBackground(name, prompt string, opts LaunchOpts) (BackgroundAgent, error)
+	SpawnBackground(workDir, name, prompt string, opts LaunchOpts) (BackgroundAgent, error)
 
 	// ResumeBackground brings a no-longer-tracked background session's
 	// conversation back as a fresh background agent, seeded from the
@@ -96,9 +99,10 @@ type BackgroundLauncher interface {
 	// inherited, but `claude --bg --resume <id>` does not preserve the
 	// id — verified against the CLI and documented behavior). The
 	// returned BackgroundAgent carries the NEW id, which flow re-records
-	// on the task. opts.Inject, if set, is delivered as the first
-	// message after resume.
-	ResumeBackground(sessionID string, opts LaunchOpts) (BackgroundAgent, error)
+	// on the task. workDir is where the resumed agent begins (the task's
+	// work_dir). opts.Inject, if set, is delivered as the first message
+	// after resume.
+	ResumeBackground(workDir, sessionID string, opts LaunchOpts) (BackgroundAgent, error)
 
 	// BackgroundAgents returns the current background-agent registry
 	// (claude: `claude agents --json --all`, so exited / failed /

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -54,6 +54,52 @@ type LaunchOpts struct {
 	Inject string
 }
 
+// BackgroundAgent is one entry from a harness's background-agent
+// registry. For the claude adapter it is populated from
+// `claude agents --json`. SessionID is the full session id flow records
+// on the task; ShortID is the harness's display/handle id (claude: the
+// 8-char prefix of SessionID, shown in the Agent View and accepted by
+// `claude attach`/`logs`/`stop`).
+type BackgroundAgent struct {
+	ShortID   string
+	SessionID string
+	Name      string
+	Cwd       string
+	PID       int
+	Status    string // coarse liveness, e.g. "busy" / "idle"
+	State     string // finer state, e.g. "working" / "blocked" / "done"
+}
+
+// BackgroundLauncher is an OPTIONAL harness capability: hosting
+// terminal-free background sessions (claude's Agent View, via
+// `claude --bg`). flow selects this path when spawner.IsBackground() is
+// true ($FLOW_TERM=bg). A harness that does NOT implement it makes
+// `$FLOW_TERM=bg flow do <task>` fail cleanly — flow never silently
+// falls back to a terminal tab.
+//
+// Unlike the interactive path, flow does NOT pre-allocate the session id
+// here: a backgrounding harness mints (and manages) its own id. flow
+// captures the REAL id after spawn by querying the registry, so the
+// DB-authoritative binding contract holds without fighting the harness.
+type BackgroundLauncher interface {
+	// SpawnBackground starts a fresh background session running prompt,
+	// displayed as name. It blocks only until the session is registered
+	// (no polling), then resolves and returns the full session id (plus
+	// current status) by querying the agent registry. The returned
+	// BackgroundAgent.SessionID is what flow records on the task.
+	SpawnBackground(name, prompt string, opts LaunchOpts) (BackgroundAgent, error)
+
+	// ResumeBackground resumes an existing background session by full
+	// session id (transcript preserved, same id). opts.Inject, if set,
+	// is delivered as the first message after resume.
+	ResumeBackground(sessionID string, opts LaunchOpts) error
+
+	// BackgroundAgents returns the current background-agent registry.
+	// Used to decide spawn-vs-resume-vs-already-running and to surface
+	// live status in `flow show` / `flow list`.
+	BackgroundAgents() ([]BackgroundAgent, error)
+}
+
 // Harness is the contract every agent-CLI adapter implements.
 type Harness interface {
 	// Identity ---------------------------------------------------------

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -89,14 +89,24 @@ type BackgroundLauncher interface {
 	// BackgroundAgent.SessionID is what flow records on the task.
 	SpawnBackground(name, prompt string, opts LaunchOpts) (BackgroundAgent, error)
 
-	// ResumeBackground resumes an existing background session by full
-	// session id (transcript preserved, same id). opts.Inject, if set,
-	// is delivered as the first message after resume.
-	ResumeBackground(sessionID string, opts LaunchOpts) error
+	// ResumeBackground brings a no-longer-tracked background session's
+	// conversation back as a fresh background agent, seeded from the
+	// prior session's transcript. NOTE: a backgrounding harness manages
+	// its own id, so this MINTS A NEW session id (the prior history is
+	// inherited, but `claude --bg --resume <id>` does not preserve the
+	// id — verified against the CLI and documented behavior). The
+	// returned BackgroundAgent carries the NEW id, which flow re-records
+	// on the task. opts.Inject, if set, is delivered as the first
+	// message after resume.
+	ResumeBackground(sessionID string, opts LaunchOpts) (BackgroundAgent, error)
 
-	// BackgroundAgents returns the current background-agent registry.
-	// Used to decide spawn-vs-resume-vs-already-running and to surface
-	// live status in `flow show` / `flow list`.
+	// BackgroundAgents returns the current background-agent registry
+	// (claude: `claude agents --json --all`, so exited / failed /
+	// completed sessions are included, not just live ones). Used to
+	// decide spawn-vs-attach-vs-resume and to surface status in
+	// `flow show` / `flow list`. A registry entry with a zero PID is
+	// not currently running (its process exited) but is still
+	// recoverable by attaching in the Agent View.
 	BackgroundAgents() ([]BackgroundAgent, error)
 }
 

--- a/internal/spawner/spawner.go
+++ b/internal/spawner/spawner.go
@@ -50,6 +50,23 @@ const (
 // Used by tests; production code should leave it as "".
 var Override Backend
 
+// BackgroundOverride, if non-nil, forces IsBackground's result
+// regardless of $FLOW_TERM. Used by tests; production code leaves it nil.
+var BackgroundOverride *bool
+
+// IsBackground reports whether flow should spawn this session as a
+// terminal-free background agent ($FLOW_TERM=bg) rather than opening a
+// terminal tab. bg mode is NOT a terminal backend — it bypasses SpawnTab
+// entirely (see do.go's bg branch), so it lives in its own predicate
+// rather than as a Detect() case. The match is exact and case-sensitive,
+// mirroring Detect's $FLOW_TERM handling.
+func IsBackground() bool {
+	if BackgroundOverride != nil {
+		return *BackgroundOverride
+	}
+	return os.Getenv("FLOW_TERM") == "bg"
+}
+
 // Detect returns the backend that SpawnTab will use for the current
 // process environment. Exposed so callers (and tests) can inspect the
 // choice without spawning.

--- a/internal/spawner/spawner_test.go
+++ b/internal/spawner/spawner_test.go
@@ -11,6 +11,54 @@ import (
 	"testing"
 )
 
+// TestIsBackground verifies the bg-mode selector. $FLOW_TERM=bg means
+// "spawn as a terminal-free background agent" — distinct from the
+// terminal backends Detect() returns, so it lives in its own predicate
+// that do.go checks before any SpawnTab.
+func TestIsBackground(t *testing.T) {
+	cases := []struct {
+		flowTerm string
+		want     bool
+	}{
+		{"bg", true},
+		{"", false},
+		{"iterm", false},
+		{"BG", false}, // case-sensitive, mirrors Detect's exact match
+		{"background", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.flowTerm, func(t *testing.T) {
+			t.Setenv("FLOW_TERM", tc.flowTerm)
+			BackgroundOverride = nil
+			if got := IsBackground(); got != tc.want {
+				t.Errorf("IsBackground() with FLOW_TERM=%q: got %v, want %v",
+					tc.flowTerm, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBackgroundOverrideBeatsEnv confirms the test escape hatch: setting
+// BackgroundOverride pins IsBackground regardless of $FLOW_TERM, so tests
+// can force bg mode on or off without env mutation.
+func TestBackgroundOverrideBeatsEnv(t *testing.T) {
+	t.Cleanup(func() { BackgroundOverride = nil })
+
+	t.Setenv("FLOW_TERM", "iterm")
+	tru := true
+	BackgroundOverride = &tru
+	if !IsBackground() {
+		t.Errorf("BackgroundOverride=true: IsBackground()=false, want true")
+	}
+
+	t.Setenv("FLOW_TERM", "bg")
+	fls := false
+	BackgroundOverride = &fls
+	if IsBackground() {
+		t.Errorf("BackgroundOverride=false: IsBackground()=true, want false")
+	}
+}
+
 // TestDetectFromEnv verifies the TERM_PROGRAM → backend mapping. The
 // Override knob and the ZELLIJ / kitty / FLOW_TERM checks have higher
 // precedence and are checked separately below.


### PR DESCRIPTION
## What

A first-class `$FLOW_TERM=bg` spawn backend so users who live in Claude Code's **Agent View** (`claude agents`) can have `flow do` launch sessions as **terminal-free background agents** instead of opening a terminal tab.

## Why

A `claude` alias that injects `--bg` makes `claude` **ignore flow's pre-allocated `--session-id`** and mint its own. flow records a phantom id, and the next `flow do` re-`--resume`s a session that never existed. Rather than fight the alias, flow now spawns `claude --bg` *deliberately* (via Go `exec`, which never applies the user's interactive shell alias) and **captures the real, harness-minted session id** from the agent registry — restoring the DB-authoritative binding contract.

## How

- **`spawner.IsBackground()`** — `$FLOW_TERM=bg` selector (+ a test override). bg is its own predicate, *not* a `Detect()` terminal backend: it bypasses `SpawnTab` entirely.
- **`harness.BackgroundLauncher`** — new **optional** capability interface (`SpawnBackground` / `ResumeBackground` / `BackgroundAgents`). Only the claude adapter implements it; `$FLOW_TERM=bg` against a codex/gemini-pinned task fails **cleanly** — no silent tab fallback.
- **claude adapter** — `claude --bg --name "<project>/<task>" <prompt>`, parse the `backgrounded · <shortId> · <name>` banner, then resolve the full session id via **one** `claude agents --json --all` lookup (no polling — the banner only prints after the session is registered). The spawn runs in the task's **`work_dir`** (`cmd.Dir`), so the agent starts in the right repo.
- **`do.go`** — bg branch parallel to `--auto`: capability gate; spawn/resume protocol; record the captured real session id + harness.
- **`flow show`** — live `bg_status: <status> / <state> (pid …)`. **`flow list`** — bg agents with a live pid fold into the `[live]` marker.
- **transcript** — resolves a bg session's jsonl by globbing the globally-unique session id (`~/.claude/projects/*/<sid>.jsonl`), so it works even when a bg session relocates into a git worktree.

## Spawn / re-run / resume protocol

Re-running `flow do <task>` is idempotent and mirrors the Agent View:

| State | Action |
|---|---|
| No session yet (or `--fresh`) | Fresh `--bg` spawn; capture + record the real id |
| Session **live** in the registry (process up) | Don't spawn/resume — just report it's open in the Agent View |
| Session **not running** (stopped/failed/done) **or** removed | `claude --bg --resume <oldid>` forks a fresh process seeded from the saved transcript; capture + **re-record the new id** (history inherited) |

`claude --bg --resume` does **not** preserve the id (verified against the live CLI + [Agent View docs](https://code.claude.com/docs/en/agent-view)): `--bg` manages its own id. Plain `claude --resume` keeps the id but isn't a background agent, so it can't be used in bg mode. Hence flow re-records the new id — the task never points at a dead session.

## `--with` / `--with-file`

Work on bg spawn **and** resume — the instruction rides via `opts.Inject` and is appended behind the shared `[via flow do --with]` marker, exactly like the interactive path.

## Testing

TDD throughout, behind a `BGCommandRunner` seam fed banner/JSON **captured from the live CLI**; a package `TestMain` keeps the suite hermetic (no real claude; and `spawner.BackgroundOverride=false` so an ambient `$FLOW_TERM=bg` in the dev env doesn't leak into terminal-path tests). `make test` green, `go vet` clean.

**Verified end-to-end against the real binary:**
- fresh spawn captures the real id (no phantom), `bg_status` live in `flow show`, `[live]` in `flow list`, agent runs in `work_dir`
- re-run while live → "open in your Agent View" (no duplicate)
- stop / `claude rm` → re-run resumes: forks, re-records the new id, registers in the Agent View, **inherits the prior conversation** (old marker present in the resumed transcript)
- `--with` delivers on both spawn and resume (injection marker + obeyed instruction in the transcript)
- `flow transcript` resolves the jsonl (incl. the worktree-relocation case)
- non-claude harness → clean capability-gate error

## Out of scope (per brief)

- Owners (#71) — separate branch/PR.
- Pass-through of `--model` / `--effort` / `--permission-mode` to bg spawn (later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)