### PR TITLE
fix(bg): raise agents-query timeout so bg spawn capture doesn't get killed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [0.1.0-alpha.20] — 2026-06-10
+
+### Fixed
+
+- **`$FLOW_TERM=bg` spawn could fail to capture the session id.** The
+  `claude agents --json --all` lookup that resolves a freshly-spawned bg
+  session's id had a 5s timeout, but immediately after `claude --bg` the
+  daemon is busy registering the new agent and the query routinely takes
+  ~10s — so the spawn errored (`signal: killed`) and rolled back, leaving
+  an orphaned agent. The backstop timeout is now 30s (it only guards
+  against a genuinely stalled daemon, not normal post-spawn latency).
+  Fixes bg spawn introduced in alpha.19.
+
 ## [0.1.0-alpha.19] — 2026-06-10
 
 ### Added
@@ -374,7 +387,8 @@ Initial public release.
   against `macos-latest` and `ubuntu-latest`.
 - **License.** MIT.
 
-[Unreleased]: https://github.com/Facets-cloud/flow/compare/v0.1.0-alpha.19...HEAD
+[Unreleased]: https://github.com/Facets-cloud/flow/compare/v0.1.0-alpha.20...HEAD
+[0.1.0-alpha.20]: https://github.com/Facets-cloud/flow/releases/tag/v0.1.0-alpha.20
 [0.1.0-alpha.19]: https://github.com/Facets-cloud/flow/releases/tag/v0.1.0-alpha.19
 [0.1.0-alpha.18]: https://github.com/Facets-cloud/flow/releases/tag/v0.1.0-alpha.18
 [0.1.0-alpha.17]: https://github.com/Facets-cloud/flow/releases/tag/v0.1.0-alpha.17

--- a/internal/harness/claude/background.go
+++ b/internal/harness/claude/background.go
@@ -28,12 +28,15 @@ import (
 var BGCommandRunner = runBGCommand
 
 func runBGCommand(workDir string, args []string) ([]byte, error) {
-	// The read-only `agents` query runs on the hot path (flow show/list),
-	// so cap it: a stalled claude daemon must never hang those commands.
-	// Spawn/resume have no timeout — they return promptly after the
-	// session registers, and a slow spawn shouldn't be cut off.
+	// The read-only `agents` query is bounded so a stalled claude daemon
+	// can't hang flow show/list forever — but the cap is generous: this
+	// same query is how SpawnBackground/ResumeBackground capture the
+	// minted session id, and immediately after a `--bg` launch the daemon
+	// is busy registering the new agent, so the query routinely takes
+	// ~10s (measured). The timeout is a backstop against a true hang, not
+	// a tight latency bound; too-tight a value kills legitimate captures.
 	if len(args) >= 1 && args[0] == "agents" {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		cmd := exec.CommandContext(ctx, "claude", args...)
 		if workDir != "" {


### PR DESCRIPTION
alpha.19 shipped a 5s timeout on the `claude agents --json --all` query, but that same query captures a freshly-spawned bg session's id — and immediately after `claude --bg` the daemon takes ~10s to answer (measured), so the spawn failed (`signal: killed`) and rolled back, orphaning the agent. Raised the backstop to 30s. Verified live: bg spawn now captures the id and records it. Cutting v0.1.0-alpha.20 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)