### PR TITLE
feat(list): add name, due, and updated to JSON output

### DIFF
--- a/internal/app/list.go
+++ b/internal/app/list.go
@@ -304,9 +304,14 @@ func listTasksCmd(args []string) int {
 	for _, t := range tasks {
 		r := taskListRow{
 			Slug:     t.Slug,
+			Name:     t.Name,
 			Status:   t.Status,
 			Priority: t.Priority,
 			Archived: t.ArchivedAt.Valid,
+			Updated:  t.UpdatedAt,
+		}
+		if t.DueDate.Valid {
+			r.Due = t.DueDate.String
 		}
 		if t.ProjectSlug.Valid {
 			r.Project = t.ProjectSlug.String
@@ -454,10 +459,12 @@ func boolStr(b bool) string {
 // for `flow list tasks`. Field order matters for JSON output stability.
 type taskListRow struct {
 	Slug       string   `json:"slug"`
+	Name       string   `json:"name"`
 	Status     string   `json:"status"`
 	Priority   string   `json:"priority"`
 	Project    string   `json:"project,omitempty"`
 	AgeDays    int      `json:"age_days,omitempty"`
+	Due        string   `json:"due,omitempty"`
 	DueInDays  *int     `json:"due_in_days,omitempty"`
 	DueLabel   string   `json:"due_label,omitempty"`
 	Stale      bool     `json:"stale,omitempty"`
@@ -468,6 +475,7 @@ type taskListRow struct {
 	AutoRun    string   `json:"auto_run,omitempty"`
 	AutoRunPID int      `json:"auto_run_pid,omitempty"`
 	Archived   bool     `json:"archived,omitempty"`
+	Updated    string   `json:"updated,omitempty"`
 	Tags       []string `json:"tags,omitempty"`
 }
 
@@ -608,6 +616,7 @@ func listProjectsCmd(args []string) int {
 
 	type projectRow struct {
 		Slug       string `json:"slug"`
+		Name       string `json:"name"`
 		Priority   string `json:"priority"`
 		Status     string `json:"status"`
 		Total      int    `json:"total"`
@@ -615,6 +624,7 @@ func listProjectsCmd(args []string) int {
 		Backlog    int    `json:"backlog"`
 		Done       int    `json:"done"`
 		Archived   bool   `json:"archived,omitempty"`
+		Updated    string `json:"updated,omitempty"`
 	}
 
 	rows := make([]projectRow, 0, len(sortedProjects))
@@ -630,6 +640,7 @@ func listProjectsCmd(args []string) int {
 		}
 		rows = append(rows, projectRow{
 			Slug:       p.Slug,
+			Name:       p.Name,
 			Priority:   p.Priority,
 			Status:     statusW,
 			Total:      counts.total,
@@ -637,6 +648,7 @@ func listProjectsCmd(args []string) int {
 			Backlog:    counts.backlog,
 			Done:       counts.done,
 			Archived:   p.ArchivedAt.Valid,
+			Updated:    p.UpdatedAt,
 		})
 	}
 

--- a/internal/app/list_test.go
+++ b/internal/app/list_test.go
@@ -783,6 +783,30 @@ func TestCmdListTasksFormatJSON(t *testing.T) {
 	if rows[1].Project != "" {
 		t.Errorf("row 1 should be floating, got project=%q", rows[1].Project)
 	}
+	// Names are carried in JSON so consumers get legible titles, not slugs.
+	if rows[0].Name != "Alpha IP" || rows[1].Name != "Beta BL" {
+		t.Errorf("names = %q,%q, want \"Alpha IP\",\"Beta BL\"", rows[0].Name, rows[1].Name)
+	}
+}
+
+func TestCmdListTasksFormatJSONDueRaw(t *testing.T) {
+	root, db := showListEditDB(t)
+	insertTask(t, db, "due-t", "Has Due", "backlog", "high", filepath.Join(root, "x"), nil)
+	if _, err := db.Exec(`UPDATE tasks SET due_date = ? WHERE slug = ?`, "2026-12-31", "due-t"); err != nil {
+		t.Fatal(err)
+	}
+	out := captureStdout(t, func() {
+		if rc := cmdList([]string{"tasks", "--format", "json"}); rc != 0 {
+			t.Fatalf("rc=%d", rc)
+		}
+	})
+	var rows []taskListRow
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("invalid JSON: %v\nout=%q", err, out)
+	}
+	if len(rows) != 1 || rows[0].Due != "2026-12-31" {
+		t.Fatalf("want raw due 2026-12-31, got %+v", rows)
+	}
 }
 
 // TestCmdListTasksAutoColumn: `flow list tasks` has a dedicated, always-on
@@ -1011,8 +1035,8 @@ func TestCmdListProjectsFormatJSON(t *testing.T) {
 	if r["in_progress"].(float64) != 1 || r["backlog"].(float64) != 1 {
 		t.Errorf("breakdown wrong: %+v", r)
 	}
-	// `name` field was removed from JSON — confirm absence.
-	if _, ok := r["name"]; ok {
-		t.Errorf("name field should be absent from project JSON: %+v", r)
+	// `name` is included in JSON so the workspace layer gets legible titles.
+	if r["name"] != "P1" {
+		t.Errorf("name = %v, want P1", r["name"])
 	}
 }


### PR DESCRIPTION
## What

Enrich the machine-readable `flow list ... --format json` output so it is self-sufficient for scripts and integrations:

- **`flow list tasks --format json`** now includes:
  - `name` — the task title
  - `due` — the raw due date (alongside the existing humanized `due_label` / `due_in_days`)
  - `updated` — the last-updated timestamp
- **`flow list projects --format json`** now includes:
  - `name` — the project title (regained for parity with tasks)
  - `updated` — the last-updated timestamp

## Why

The JSON list output was missing the entity `name` and exact timestamps, forcing any consumer to make a second `flow show <slug>` call per row just to recover a legible title or a precise `updated`/`due` value. Carrying these in the list output removes that N+1 round-trip and makes `--format json` a complete, scriptable view.

Table and TSV output are unchanged.

## Tests

- `flow list tasks --format json` test asserts `name`; new test asserts the raw `due` value.
- `flow list projects --format json` test now asserts `name` is present.
- Full suite green (`go test ./...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)