### PR TITLE
feat(done): pin close-out sweep to Sonnet, override via FLOW_SWEEP_MODEL

### DIFF
--- a/internal/harness/claude/claude.go
+++ b/internal/harness/claude/claude.go
@@ -176,12 +176,30 @@ func (c *claude) AutoRunArgv(sessionID, prompt string, opts harness.LaunchOpts) 
 	return argv
 }
 
+// sweepModel returns the model the headless close-out sweep runs on.
+// Reads the FLOW_SWEEP_MODEL env var; defaults to "sonnet". The sweep
+// is bounded, template-driven distillation (KB scoop + project update)
+// — it doesn't need a top-tier model, and pinning it keeps every task
+// closure off the user's interactive default (which may be a premium
+// tier like Opus). Mirrors the FLOW_STALE_DAYS env convention. The
+// "sonnet" alias is used rather than a dated model id so it survives
+// model-id churn.
+func sweepModel() string {
+	if m := strings.TrimSpace(os.Getenv("FLOW_SWEEP_MODEL")); m != "" {
+		return m
+	}
+	return "sonnet"
+}
+
 // runSkipPermissions is the default SkipPermissionsRunner — execs
-// `claude -p <prompt> --dangerously-skip-permissions`. Stdout/stderr
-// are discarded because the sweep prompt instructs claude to write
-// files silently with no chat output.
+// `claude -p <prompt> --model <sweepModel> --dangerously-skip-permissions`.
+// Stdout/stderr are discarded because the sweep prompt instructs claude
+// to write files silently with no chat output. The --model pin (default
+// "sonnet") keeps the close-out sweep off the user's interactive default;
+// override via FLOW_SWEEP_MODEL.
 func runSkipPermissions(prompt string) error {
-	cmd := exec.Command("claude", "-p", prompt, "--dangerously-skip-permissions")
+	cmd := exec.Command("claude", "-p", prompt,
+		"--model", sweepModel(), "--dangerously-skip-permissions")
 	cmd.Stdout = io.Discard
 	cmd.Stderr = io.Discard
 	return cmd.Run()

--- a/internal/harness/claude/claude_test.go
+++ b/internal/harness/claude/claude_test.go
@@ -245,3 +245,22 @@ func TestLiveSessions_PSError(t *testing.T) {
 		t.Errorf("expected error, got nil (live=%v)", live)
 	}
 }
+
+// TestSweepModel verifies close-out sweep model resolution: defaults to
+// "sonnet" and honors FLOW_SWEEP_MODEL (trimmed) when set.
+func TestSweepModel(t *testing.T) {
+	t.Setenv("FLOW_SWEEP_MODEL", "")
+	if got := sweepModel(); got != "sonnet" {
+		t.Errorf("default sweepModel() = %q, want %q", got, "sonnet")
+	}
+
+	t.Setenv("FLOW_SWEEP_MODEL", "opus")
+	if got := sweepModel(); got != "opus" {
+		t.Errorf("override sweepModel() = %q, want %q", got, "opus")
+	}
+
+	t.Setenv("FLOW_SWEEP_MODEL", "  claude-sonnet-5  ")
+	if got := sweepModel(); got != "claude-sonnet-5" {
+		t.Errorf("trimmed sweepModel() = %q, want %q", got, "claude-sonnet-5")
+	}
+}


### PR DESCRIPTION
## What

The `flow done` close-out sweep runs a headless `claude -p` pass that distills the task transcript into KB entries + (for project tasks) a project update. It currently inherits the user's interactive default model, so anyone whose default is a premium tier (Opus, etc.) pays top-tier rates on **every task closure** for what is bounded, template-driven distillation.

This pins the sweep to the `sonnet` alias by default, overridable via a new `FLOW_SWEEP_MODEL` env var.

## Details

- New `sweepModel()` helper in `internal/harness/claude/claude.go`: reads `FLOW_SWEEP_MODEL`, defaults to `"sonnet"`. Uses the alias (not a dated model id) so it survives model-id churn. Mirrors the existing `FLOW_STALE_DAYS` env convention.
- `runSkipPermissions` now passes `--model <sweepModel>` to `claude -p`.
- **Scope:** only the close-out sweep (`runSkipPermissions`) is affected. `AutoRunArgv` — the actual task work under `flow do --auto` — still uses the user's chosen model, since that's real work, not distillation.

## Testing

- `TestSweepModel` added: default `sonnet`, `FLOW_SWEEP_MODEL` override, whitespace trim.
- `make test` passes across all packages.
- Verified end-to-end locally: with the patch and no env var, a real close-out sweep transcript is 100% `claude-sonnet-*`.

## Backward compatibility

Existing users see the sweep move from their default model to Sonnet. Anyone who wants the old behavior (or a different tier) sets `FLOW_SWEEP_MODEL` to their preferred model/alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)