### PR TITLE
feat: UserPromptSubmit hook — bound-session drift/close-out anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+
+- **UserPromptSubmit hook — bound-session drift/close-out anchor.** In a
+  Claude session bound to a flow task, `flow hook user-prompt-submit`
+  injects a tiny (~45-token) per-prompt anchor naming the task and
+  re-running the skill's lifecycle-transition checks: if the prompt is
+  unrelated work it offers a new task (§4.11), and if the prompt signals
+  the task is finished it offers to close it out (§4.7). Unbound sessions
+  are a pure no-op. This is distinct from — and not a revival of — the
+  per-prompt *unbound* skill nudge retired in v0.1.0-alpha.7: that one
+  duplicated the SessionStart hint, whereas drift and close-out are
+  per-prompt signals SessionStart structurally cannot catch. Both
+  `flow skill install` and the auto-upgrade path now install the hook
+  (leaving any unrelated user-defined hooks in the same event untouched).
+
 ## [0.1.0-alpha.22] — 2026-06-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,6 @@ flow/
 
 ## Things to watch out for
 
-- `hookCommand` in `internal/app/skill.go` is the exact string matched in `~/.claude/settings.json`. Changing it orphans existing installations.
+- `hookCommand` (SessionStart) and `userPromptSubmitHookCommand` (UserPromptSubmit) in `internal/app/skill.go` are the exact strings matched in `~/.claude/settings.json`. Changing either orphans existing installations.
 - `do.go` uses `openConcurrentDB` with `busy_timeout(30000)` and `_txlock=immediate` for safe concurrent access.
 - Tests override `$HOME` — any code that calls `os.UserHomeDir()` will see the test's temp dir, not the real home.

--- a/docs/superpowers/specs/2026-07-06-bound-session-drift-hook-design.md
+++ b/docs/superpowers/specs/2026-07-06-bound-session-drift-hook-design.md
@@ -1,0 +1,112 @@
+# Reintroduce the UserPromptSubmit hook as a bound-session drift/close-out anchor
+
+**Date:** 2026-07-06
+**Status:** Implemented (branch `feat/bound-session-drift-hook`)
+
+## Summary
+
+Reintroduce the `flow hook user-prompt-submit` handler (retired in PR #24)
+as a **bound-session** anchor. In sessions bound to a flow task, it injects
+a ~50-token `additionalContext` payload on each prompt that re-runs two
+existing skill checks against that prompt:
+
+- **§4.11 scope-creep** — if the prompt is unrelated work, offer a new task.
+- **§4.7 close-out** — if the prompt signals the task is finished, offer to
+  mark it done.
+
+Unbound sessions are a pure no-op (exit 0, no output).
+
+## Why this is not reviving #24's mistake
+
+PR #24 retired the hook because it fired in **unbound** sessions, injecting
+~200 words nudging Claude to *bind* a task — redundant with the SessionStart
+hook (which already fires on startup + resume), so pure token cost.
+
+This is the mirror image:
+
+- Fires **only when bound** — the branch #24 killed was the unbound one.
+- Payload is ~50 tokens, not ~200 words.
+- Non-redundant with SessionStart: drift and done-signals are **per-prompt**
+  phenomena that a session-start-only hook structurally cannot catch.
+
+The binding is discovered deterministically and for free via
+`lookupBoundTaskSlug()` (reverse-lookup on `$CLAUDE_CODE_SESSION_ID` against
+`tasks.session_id`) — no LLM cost. The semantic "is this drift / is this
+done?" judgment stays with Claude via §4.11 / §4.7; the hook only supplies
+the anchor.
+
+## Behavior
+
+`flow hook user-prompt-submit`:
+
+| Session state | Action |
+|---|---|
+| Unbound (`lookupBoundTaskSlug()` == "") | No-op: exit 0, emit nothing. |
+| Bound | Emit the anchor payload below as `UserPromptSubmit` `additionalContext`. |
+
+**Anchor payload (bound only):**
+
+> flow session → task **{name}** (`{slug}`). Per §4.11/§4.7: if this prompt
+> is unrelated work, offer a new task; if it signals the task is finished,
+> offer to close it out. Else proceed silently.
+
+The trailing "Else proceed silently" is load-bearing: it stops the hook from
+turning every prompt into a nagging offer.
+
+All errors in the handler are swallowed and treated as "unbound" — a hook
+must never fail loud, since a hook error blocks the user's session.
+
+## Code changes
+
+1. **`internal/app/hook.go`** — replace the no-op `cmdHookUserPromptSubmit`
+   with the bound-branch logic. Add `lookupBoundTask() *flowdb.Task` (returns
+   the task or nil) so the payload can name the task; refactor
+   `lookupBoundTaskSlug` to call it.
+2. **`internal/harness/harness.go`** — add
+   `InstallUserPromptSubmitHook(command string) (added bool, err error)` to
+   the `Harness` interface (sibling of the existing `Uninstall`).
+3. **`internal/harness/claude/claude.go`** — implement it via
+   `installHook("UserPromptSubmit", "", command)` (empty matcher, as the
+   pre-#24 code used).
+4. **`internal/app/skill.go`** — reverse the #24 plumbing: `skillInstall` and
+   `maybeAutoUpgradeSkill` call `InstallUserPromptSubmitHook` instead of
+   `Uninstall`; restore the "installed UserPromptSubmit hook" console
+   messaging. `flow skill uninstall` keeps calling `Uninstall`. Update the
+   stale doc comment on `userPromptSubmitHookCommand` (no longer "legacy").
+   The command string `flow hook user-prompt-submit` is unchanged — stable, so
+   any surviving stale entry becomes live again rather than orphaned.
+5. **`internal/app/skill/SKILL.md`** — short note in/near §4.11 that a
+   per-prompt hook reinforces the drift + close-out checks in bound sessions
+   (skill is source of truth). Rebuild so `flow skill update` ships it.
+6. **`CLAUDE.md`** — the "Things to watch out for" note flags `hookCommand`;
+   add the `user-prompt-submit` command string alongside it.
+7. **`CHANGELOG.md`** — "Added" entry framed as the bound-session drift/
+   close-out anchor, explicitly distinct from the retired unbound nudge.
+
+## Tests (reverse #24's pins)
+
+- **`hook_test.go`** — replace `TestHookUserPromptSubmitIsNoOp` with:
+  - bound session emits an anchor containing the task name, slug, `§4.11`,
+    `§4.7`;
+  - unbound session is a clean no-op (empty stdout, rc 0).
+  Bound-session tests seed a task via the real temp SQLite DB and set
+  `CLAUDE_CODE_SESSION_ID` to its `session_id` (same pattern as existing
+  SessionStart bound tests).
+- **`skill_test.go`** —
+  - flip `TestSkillInstallWritesSessionStartHook` back to asserting **both**
+    hooks install;
+  - restore both-hook idempotency (`install --force` twice → one entry each);
+  - `TestSkillInstallRemovesStaleUserPromptSubmit` is now obsolete (we want
+    the entry) — remove it;
+  - repurpose `TestSkillInstallPreservesUnrelatedHooks` to prove install
+    **adds** flow's UPS entry while leaving a user's own UPS hook + a
+    PreToolUse hook + a top-level key untouched;
+  - flip the uninstall test back to asserting both hooks are stripped.
+
+## Out of scope (YAGNI)
+
+- No hook-side keyword/heuristic drift detection — semantic judgment stays
+  with Claude.
+- No throttle/cadence state — every bound prompt fires; the ~50-token payload
+  makes that cheap enough.
+- No codex/gemini harness work — only `claude` exists on `main`.

--- a/internal/app/hook.go
+++ b/internal/app/hook.go
@@ -15,8 +15,10 @@ import (
 //     sessions never re-read briefs and updates that may have been
 //     edited since the previous session.
 //
-//   - user-prompt-submit: kept as a permanent no-op for forward
-//     compatibility with stale settings.json entries.
+//   - user-prompt-submit: wired as a Claude Code UserPromptSubmit hook.
+//     In bound sessions it injects a tiny per-prompt anchor that re-runs
+//     the skill's drift (§4.11) and close-out (§4.7) checks; unbound
+//     sessions are a no-op.
 func cmdHook(args []string) int {
 	if len(args) == 0 {
 		fmt.Fprintln(os.Stderr, "error: hook requires a subcommand (session-start|user-prompt-submit)")
@@ -114,30 +116,39 @@ func appendStaleVersionHint() string {
 	)
 }
 
-// lookupBoundTaskSlug returns the slug of the task whose session_id
-// matches $CLAUDE_CODE_SESSION_ID, or "" if no such task exists, the
-// env var is unset, or the DB lookup fails. Hook code must never
-// fail loud — a hook error blocks the user's session — so all errors
-// are swallowed and treated as "unbound".
-func lookupBoundTaskSlug() string {
+// lookupBoundTask returns the task whose session_id matches
+// $CLAUDE_CODE_SESSION_ID, or nil if no such task exists, the env var
+// is unset, or the DB lookup fails. Hook code must never fail loud — a
+// hook error blocks the user's session — so all errors are swallowed
+// and treated as "unbound".
+func lookupBoundTask() *flowdb.Task {
 	sid := os.Getenv("CLAUDE_CODE_SESSION_ID")
 	if sid == "" {
-		return ""
+		return nil
 	}
 	dbPath, err := flowDBPath()
 	if err != nil {
-		return ""
+		return nil
 	}
 	db, err := flowdb.OpenDB(dbPath)
 	if err != nil {
-		return ""
+		return nil
 	}
 	defer db.Close()
 	t, err := flowdb.TaskBySessionID(db, sid)
 	if err != nil {
-		return ""
+		return nil
 	}
-	return t.Slug
+	return t
+}
+
+// lookupBoundTaskSlug returns the slug of the bound task, or "" if the
+// session is unbound. Thin wrapper over lookupBoundTask.
+func lookupBoundTaskSlug() string {
+	if t := lookupBoundTask(); t != nil {
+		return t.Slug
+	}
+	return ""
 }
 
 // emitAmbientSkillHint is the unbound-session branch of the
@@ -206,15 +217,37 @@ func emitHookContext(event, ctx string) int {
 	return 0
 }
 
-// cmdHookUserPromptSubmit is a permanent no-op kept only for forward
-// compatibility with stale `~/.claude/settings.json` entries.
-// `flow skill install` (and the auto-upgrade path) now actively
-// remove any UserPromptSubmit entry from settings.json, so this code
-// path should not be hit on upgraded installs.
+// cmdHookUserPromptSubmit implements `flow hook user-prompt-submit`,
+// wired as a Claude Code UserPromptSubmit hook that fires on every user
+// prompt but does work only in bound sessions.
+//
+// In a session bound to a flow task it injects a tiny (~45-token)
+// anchor that re-runs the skill's lifecycle-transition checks against
+// the current prompt — drift (§4.11 → offer a new task) and close-out
+// (§4.7 → offer to mark done) — so those passive disciplines don't
+// decay over a long session the way a SessionStart-only reminder does.
+// Unbound sessions are a pure no-op: the "go bind a task" nudge lives
+// in SessionStart, and repeating it per prompt was retired in
+// v0.1.0-alpha.7 for its token cost.
+//
+// The semantic judgment is Claude's — the hook only supplies which task
+// the session is bound to (a free, deterministic DB lookup); whether
+// the prompt has drifted or signals completion is Claude's call.
 func cmdHookUserPromptSubmit(args []string) int {
 	fs := flagSet("hook user-prompt-submit")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	return 0
+	t := lookupBoundTask()
+	if t == nil {
+		// Unbound — no-op, emit nothing.
+		return 0
+	}
+	anchor := fmt.Sprintf(
+		"flow session → task %q (%s). Per §4.11/§4.7: if this prompt is "+
+			"unrelated work, offer a new task; if it signals the task is done, "+
+			"offer to close it out. Else proceed silently.",
+		t.Name, t.Slug,
+	)
+	return emitHookContext("UserPromptSubmit", anchor)
 }

--- a/internal/app/hook_test.go
+++ b/internal/app/hook_test.go
@@ -121,12 +121,66 @@ func TestHookSessionStartRequiresSkillInvocation(t *testing.T) {
 	}
 }
 
-// TestHookUserPromptSubmitIsNoOp pins the v0.1.0-alpha.7 contract:
-// the UserPromptSubmit hook is a permanent no-op — exits 0 with no
-// stdout regardless of session state. Kept around only for forward
-// compatibility with stale settings.json entries on older installs.
-// `flow skill install` actively removes the entry on upgrade.
-func TestHookUserPromptSubmitIsNoOp(t *testing.T) {
+// TestHookUserPromptSubmitBoundEmitsAnchor pins the bound-session
+// contract: when the current $CLAUDE_CODE_SESSION_ID belongs to a task,
+// the hook injects a UserPromptSubmit anchor naming the task and citing
+// the drift (§4.11) and close-out (§4.7) checks.
+func TestHookUserPromptSubmitBoundEmitsAnchor(t *testing.T) {
+	setupFlowRoot(t)
+
+	// Seed a task whose name and slug differ, so the anchor is asserted
+	// to carry both.
+	if rc := cmdAdd([]string{"task", "Redesign Billing Page"}); rc != 0 {
+		t.Fatalf("seed task rc=%d", rc)
+	}
+	const sid = "deadbeef-1234-4567-8abc-def012345678"
+	db := openFlowDB(t)
+	if _, err := db.Exec(
+		`UPDATE tasks SET session_id=?, status='in-progress', session_started=? WHERE slug='redesign-billing-page'`,
+		sid, flowdb.NowISO(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_CODE_SESSION_ID", sid)
+
+	out := captureStdout(t, func() {
+		if rc := cmdHookUserPromptSubmit(nil); rc != 0 {
+			t.Fatalf("rc=%d", rc)
+		}
+	})
+	var parsed struct {
+		HookSpecificOutput struct {
+			HookEventName     string `json:"hookEventName"`
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("parse hook output: %v\nraw: %s", err, out)
+	}
+	if parsed.HookSpecificOutput.HookEventName != "UserPromptSubmit" {
+		t.Errorf("hookEventName = %q, want UserPromptSubmit", parsed.HookSpecificOutput.HookEventName)
+	}
+	ctx := parsed.HookSpecificOutput.AdditionalContext
+	for _, want := range []string{
+		"Redesign Billing Page", // task name
+		"redesign-billing-page", // slug
+		"§4.11",
+		"§4.7",
+		"new task",
+		"close it out",
+	} {
+		if !strings.Contains(ctx, want) {
+			t.Errorf("anchor missing %q; got:\n%s", want, ctx)
+		}
+	}
+}
+
+// TestHookUserPromptSubmitUnboundIsNoOp pins the unbound contract: with
+// no task carrying $CLAUDE_CODE_SESSION_ID (var unset, or set but
+// unmatched), the hook exits 0 with no stdout. The "go bind a task"
+// nudge lives in SessionStart, not per prompt.
+func TestHookUserPromptSubmitUnboundIsNoOp(t *testing.T) {
+	setupFlowRoot(t)
 	for _, sid := range []string{"", "deadbeef-1234-4567-8abc-def012345678"} {
 		t.Setenv("CLAUDE_CODE_SESSION_ID", sid)
 		out := captureStdout(t, func() {

--- a/internal/app/skill.go
+++ b/internal/app/skill.go
@@ -17,10 +17,10 @@ var embeddedSkill []byte
 // orphan existing installations.
 const hookCommand = "flow hook session-start"
 
-// userPromptSubmitHookCommand is the legacy UserPromptSubmit hook
-// string. flow no longer installs this hook (removed in
-// v0.1.0-alpha.7), but every install/upgrade actively uninstalls
-// stale entries so existing-user setups converge to a clean state.
+// userPromptSubmitHookCommand is the exact string settings.json records
+// as the UserPromptSubmit hook handler. In bound sessions the command
+// injects a tiny drift/close-out anchor; unbound sessions no-op. Stable
+// — changing it would orphan existing installations.
 const userPromptSubmitHookCommand = "flow hook user-prompt-submit"
 
 // readSkillVersion returns the version string recorded in the
@@ -89,10 +89,7 @@ func maybeAutoUpgradeSkill() {
 	}
 	_ = writeSkillVersion(Version)
 	_, _ = h.InstallSessionStartHook(hookCommand)
-	// UserPromptSubmit hook was removed in v0.1.0-alpha.7 — the
-	// per-prompt token cost wasn't worth the marginal value. Actively
-	// uninstall any stale entry left behind by older binaries.
-	_, _ = h.UninstallUserPromptSubmitHook(userPromptSubmitHookCommand)
+	_, _ = h.InstallUserPromptSubmitHook(userPromptSubmitHookCommand)
 	fmt.Fprintf(os.Stderr, "flow: upgraded skill to %s\n", Version)
 }
 
@@ -161,14 +158,13 @@ func skillInstall(args []string, forceDefault bool) int {
 	} else {
 		fmt.Println("SessionStart hook already installed — leaving as is")
 	}
-	// UserPromptSubmit hook was removed in v0.1.0-alpha.7. Actively
-	// uninstall any stale entry left behind by older binaries so a
-	// fresh `flow skill install` (or `update`) leaves a clean config.
-	if removed, err := h.UninstallUserPromptSubmitHook(userPromptSubmitHookCommand); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: could not remove stale UserPromptSubmit hook: %v\n", err)
+	if added, err := h.InstallUserPromptSubmitHook(userPromptSubmitHookCommand); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not install UserPromptSubmit hook: %v\n", err)
 		return 0
-	} else if removed {
-		fmt.Println("removed stale UserPromptSubmit hook (no longer used)")
+	} else if added {
+		fmt.Println("installed UserPromptSubmit hook (nudges drift/close-out on bound-session prompts)")
+	} else {
+		fmt.Println("UserPromptSubmit hook already installed — leaving as is")
 	}
 	return 0
 }

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -1118,6 +1118,12 @@ prose "want me to...?" question). Its purpose is to keep a task's
 transcript and update log focused, instead of letting unrelated work
 pile up under whichever task happens to own the current terminal tab.
 
+In a bound session a `UserPromptSubmit` hook re-injects a one-line
+anchor on every prompt (naming the bound task and citing §4.11/§4.7),
+so this check — and the §4.7 close-out check — stay live over a long
+session instead of decaying. The hook only re-anchors; the judgment
+below is still yours.
+
 **When to consider firing:**
 
 Fire when the *work itself* (not a single question) has clearly moved

--- a/internal/app/skill_test.go
+++ b/internal/app/skill_test.go
@@ -158,10 +158,10 @@ func TestSkillUninstallIdempotent(t *testing.T) {
 	}
 }
 
-// TestSkillInstallWritesSessionStartHook verifies install wires up the
-// SessionStart hook into ~/.claude/settings.json. The UserPromptSubmit
-// hook was retired in v0.1.0-alpha.7 — install MUST NOT add it.
-func TestSkillInstallWritesSessionStartHook(t *testing.T) {
+// TestSkillInstallWritesBothHooks verifies install wires up BOTH the
+// SessionStart hook and the UserPromptSubmit drift/close-out hook into
+// ~/.claude/settings.json.
+func TestSkillInstallWritesBothHooks(t *testing.T) {
 	home := withTempHome(t)
 	if rc := cmdSkill([]string{"install"}); rc != 0 {
 		t.Fatalf("install rc=%d", rc)
@@ -174,15 +174,14 @@ func TestSkillInstallWritesSessionStartHook(t *testing.T) {
 	if !hookEventReferencesCommand(hooks, "SessionStart", "flow hook session-start") {
 		t.Errorf("SessionStart hook missing or wrong command: %#v", hooks["SessionStart"])
 	}
-	// UserPromptSubmit must not be installed by fresh install.
-	if hookEventReferencesCommand(hooks, "UserPromptSubmit", "flow hook user-prompt-submit") {
-		t.Errorf("install should NOT add UserPromptSubmit hook; got %#v", hooks["UserPromptSubmit"])
+	if !hookEventReferencesCommand(hooks, "UserPromptSubmit", "flow hook user-prompt-submit") {
+		t.Errorf("UserPromptSubmit hook missing or wrong command: %#v", hooks["UserPromptSubmit"])
 	}
 }
 
 // TestSkillInstallIsIdempotent verifies a second install --force does
-// not duplicate the SessionStart entry. Past regressions append
-// duplicates silently; pin against that.
+// not duplicate either hook entry. Past regressions append duplicates
+// silently; pin against that.
 func TestSkillInstallIsIdempotent(t *testing.T) {
 	home := withTempHome(t)
 	if rc := cmdSkill([]string{"install"}); rc != 0 {
@@ -193,51 +192,19 @@ func TestSkillInstallIsIdempotent(t *testing.T) {
 	}
 	settings := readSettings(t, filepath.Join(home, ".claude", "settings.json"))
 	hooks, _ := settings["hooks"].(map[string]any)
-	entries, _ := hooks["SessionStart"].([]any)
-	if got := countMatchingHookEntries(entries, expectedCommand("SessionStart")); got != 1 {
-		t.Errorf("SessionStart: got %d matching entries, want 1", got)
-	}
-}
-
-// TestSkillInstallRemovesStaleUserPromptSubmit verifies the upgrade
-// path: an existing settings.json with a UserPromptSubmit hook entry
-// (legacy install from <= v0.1.0-alpha.6) gets that entry removed by
-// `flow skill install --force`, even on a fresh skill install.
-func TestSkillInstallRemovesStaleUserPromptSubmit(t *testing.T) {
-	home := withTempHome(t)
-	settingsPath := filepath.Join(home, ".claude", "settings.json")
-	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	stale := `{
-  "hooks": {
-    "UserPromptSubmit": [
-      {"hooks": [{"type": "command", "command": "flow hook user-prompt-submit"}]}
-    ]
-  }
-}`
-	if err := os.WriteFile(settingsPath, []byte(stale), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	if rc := cmdSkill([]string{"install"}); rc != 0 {
-		t.Fatalf("install rc=%d", rc)
-	}
-	settings := readSettings(t, settingsPath)
-	hooks, _ := settings["hooks"].(map[string]any)
-	if hookEventReferencesCommand(hooks, "UserPromptSubmit", "flow hook user-prompt-submit") {
-		t.Errorf("install should remove stale UserPromptSubmit hook; got %#v", hooks["UserPromptSubmit"])
-	}
-	// SessionStart should still get installed normally.
-	if !hookEventReferencesCommand(hooks, "SessionStart", "flow hook session-start") {
-		t.Errorf("SessionStart hook missing after install: %#v", hooks["SessionStart"])
+	for _, event := range []string{"SessionStart", "UserPromptSubmit"} {
+		entries, _ := hooks[event].([]any)
+		if got := countMatchingHookEntries(entries, expectedCommand(event)); got != 1 {
+			t.Errorf("%s: got %d matching entries, want 1", event, got)
+		}
 	}
 }
 
 // TestSkillInstallPreservesUnrelatedHooks pins the safety property:
-// removing flow's UserPromptSubmit hook MUST NOT touch other commands
-// the user has wired under UserPromptSubmit (e.g. their own scripts),
-// and MUST NOT touch other event keys (SessionEnd, PreToolUse, etc.).
+// installing flow's UserPromptSubmit hook MUST add flow's entry while
+// leaving other commands the user has wired under UserPromptSubmit
+// (their own scripts) AND other event keys (PreToolUse, etc.) and
+// top-level keys untouched.
 func TestSkillInstallPreservesUnrelatedHooks(t *testing.T) {
 	home := withTempHome(t)
 	settingsPath := filepath.Join(home, ".claude", "settings.json")
@@ -247,7 +214,6 @@ func TestSkillInstallPreservesUnrelatedHooks(t *testing.T) {
 	mixed := `{
   "hooks": {
     "UserPromptSubmit": [
-      {"hooks": [{"type": "command", "command": "flow hook user-prompt-submit"}]},
       {"hooks": [{"type": "command", "command": "my-custom-tool --watch"}]}
     ],
     "PreToolUse": [
@@ -265,10 +231,10 @@ func TestSkillInstallPreservesUnrelatedHooks(t *testing.T) {
 	}
 	settings := readSettings(t, settingsPath)
 
-	// flow's UPS entry gone; user's UPS entry preserved.
+	// flow's UPS entry added; user's UPS entry preserved.
 	hooks, _ := settings["hooks"].(map[string]any)
-	if hookEventReferencesCommand(hooks, "UserPromptSubmit", "flow hook user-prompt-submit") {
-		t.Errorf("flow UPS hook should be removed; got %#v", hooks["UserPromptSubmit"])
+	if !hookEventReferencesCommand(hooks, "UserPromptSubmit", "flow hook user-prompt-submit") {
+		t.Errorf("flow UPS hook should be added; got %#v", hooks["UserPromptSubmit"])
 	}
 	if !hookEventReferencesCommand(hooks, "UserPromptSubmit", "my-custom-tool --watch") {
 		t.Errorf("user's UPS hook MUST be preserved; got %#v", hooks["UserPromptSubmit"])
@@ -285,11 +251,10 @@ func TestSkillInstallPreservesUnrelatedHooks(t *testing.T) {
 	}
 }
 
-// TestSkillUninstallRemovesSessionStartHook verifies uninstall strips
-// the SessionStart entry. (The UserPromptSubmit hook is no longer
-// installed, so its absence after uninstall is verified by the
-// install-side tests.)
-func TestSkillUninstallRemovesSessionStartHook(t *testing.T) {
+// TestSkillUninstallRemovesBothHooks verifies uninstall strips both the
+// SessionStart and UserPromptSubmit entries, leaving an empty (or
+// absent) hooks map.
+func TestSkillUninstallRemovesBothHooks(t *testing.T) {
 	home := withTempHome(t)
 	if rc := cmdSkill([]string{"install"}); rc != 0 {
 		t.Fatalf("install rc=%d", rc)

--- a/internal/harness/claude/claude.go
+++ b/internal/harness/claude/claude.go
@@ -335,6 +335,11 @@ func (c *claude) UninstallSessionStartHook(command string) (bool, error) {
 	return uninstallHook("SessionStart", command)
 }
 
+func (c *claude) InstallUserPromptSubmitHook(command string) (bool, error) {
+	// UserPromptSubmit takes no matcher — the event fires on every prompt.
+	return installHook("UserPromptSubmit", "", command)
+}
+
 func (c *claude) UninstallUserPromptSubmitHook(command string) (bool, error) {
 	return uninstallHook("UserPromptSubmit", command)
 }

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -265,9 +265,14 @@ type Harness interface {
 	// inner command matches `command`.
 	UninstallSessionStartHook(command string) (removed bool, err error)
 
-	// UninstallUserPromptSubmitHook removes any stale
-	// UserPromptSubmit entry matching `command`. flow used to wire
-	// this hook in older releases; the cleanup is kept so upgraded
-	// installs converge to a clean config.
+	// InstallUserPromptSubmitHook idempotently registers `command` as a
+	// UserPromptSubmit hook (no matcher). Fires on every user prompt;
+	// the command itself no-ops in unbound sessions and injects a tiny
+	// drift/close-out anchor in bound ones. Returns (added=true) iff the
+	// on-disk hook config was actually modified.
+	InstallUserPromptSubmitHook(command string) (added bool, err error)
+
+	// UninstallUserPromptSubmitHook removes any UserPromptSubmit entry
+	// matching `command`. Used by `flow skill uninstall`.
 	UninstallUserPromptSubmitHook(command string) (removed bool, err error)
 }


### PR DESCRIPTION
## What

Reintroduces `flow hook user-prompt-submit` as a **bound-session drift/close-out anchor**. In a Claude session bound to a flow task, each prompt gets a tiny (~45-token) injected anchor:

> flow session → task "Redesign Billing Page" (redesign-billing-page). Per §4.11/§4.7: if this prompt is unrelated work, offer a new task; if it signals the task is done, offer to close it out. Else proceed silently.

Unbound sessions emit nothing (rc 0, zero token cost).

## Why this isn't reviving #24

PR #24 retired the old hook because it fired in **unbound** sessions, injecting ~200 words nudging Claude to *bind* a task — redundant with the SessionStart hook. This is the mirror image: it fires **only when bound**, and drift (§4.11) and close-out (§4.7) are **per-prompt** signals that a SessionStart-only hook structurally cannot catch. Binding is a free, deterministic reverse-lookup on `$CLAUDE_CODE_SESSION_ID`; the semantic judgment stays with Claude.

## Changes

- **`hook.go`** — bound-branch logic in `cmdHookUserPromptSubmit` + `lookupBoundTask()`
- **`harness.go` / `claude.go`** — new `InstallUserPromptSubmitHook` (empty matcher)
- **`skill.go`** — `skill install` + auto-upgrade now *install* the hook (reversing #24's active-uninstall); `skill uninstall` still removes it
- **`SKILL.md` §4.11** — note the per-prompt reinforcement (rebuilt; embedded)
- **`CLAUDE.md` / `CHANGELOG.md`** — watch-out for the second stable command string; Added entry
- **Tests** — bound emits anchor / unbound no-op; install writes both hooks; both-hook idempotency; preserve-unrelated-hooks now proves install *adds* flow's entry while leaving user hooks untouched
- **Design spec** — `docs/superpowers/specs/2026-07-06-bound-session-drift-hook-design.md`

## Verification

- `go test ./...` — all packages pass
- Real binary: unbound (empty + unmatched sid) → silent rc 0; bound → exact anchor payload above

🤖 Generated with [Claude Code](https://claude.com/claude-code)