### PR TITLE
docs: v0.1.0-alpha.25 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [0.1.0-alpha.25] — 2026-07-14
+
 ### Changed
 
 - **Skill token footprint cut ~55% via progressive disclosure.** The flow
@@ -492,7 +494,8 @@ Initial public release.
   against `macos-latest` and `ubuntu-latest`.
 - **License.** MIT.
 
-[Unreleased]: https://github.com/Facets-cloud/flow/compare/v0.1.0-alpha.24...HEAD
+[Unreleased]: https://github.com/Facets-cloud/flow/compare/v0.1.0-alpha.25...HEAD
+[0.1.0-alpha.25]: https://github.com/Facets-cloud/flow/releases/tag/v0.1.0-alpha.25
 [0.1.0-alpha.24]: https://github.com/Facets-cloud/flow/releases/tag/v0.1.0-alpha.24
 [0.1.0-alpha.20]: https://github.com/Facets-cloud/flow/releases/tag/v0.1.0-alpha.20
 [0.1.0-alpha.19]: https://github.com/Facets-cloud/flow/releases/tag/v0.1.0-alpha.19


### PR DESCRIPTION
Moves the [Unreleased] "progressive-disclosure skill token cut" entry (from #88) under a dated `## [0.1.0-alpha.25]` heading and adds the footer release link. Pre-tag changelog bump, matching the alpha.24 cadence (#87).

🤖 Generated with [Claude Code](https://claude.com/claude-code)