### PR TITLE
Add Codex harness support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License">
 </p>
 
-> A complete task manager for Claude Code — and the working memory
+> A complete task manager for Claude Code and Codex — and the working memory
 > layer that turns every session from a brilliant new hire into the
 > engineer on your team.
 
@@ -140,15 +140,14 @@ now will know everything every prior weekly review surfaced.
 
 ## Install
 
-In any Claude Code session, paste this:
+In any Claude Code or Codex session, paste this:
 
 > Install flow from https://github.com/Facets-cloud/flow
 
-Claude reads the repo, downloads the binary, and runs `flow init` —
-which installs the flow skill into `~/.claude/skills/flow/SKILL.md`
-and registers a SessionStart hook so every future Claude session
-loads the skill automatically. Then say **"let's get to work"** and
-follow along.
+Your agent reads the repo, downloads the binary, and runs `flow init` —
+which installs the flow skill and SessionStart hook for the active harness
+so future sessions load the skill automatically. Then say **"let's get to
+work"** and follow along.
 
 <details>
 <summary>Manual install (curl + chmod + flow init)</summary>
@@ -168,12 +167,13 @@ xattr -d com.apple.quarantine /usr/local/bin/flow 2>/dev/null || true
 flow init
 ```
 
-`flow init` is the step that wires flow into Claude Code. It:
+`flow init` is the step that wires flow into your active agent harness. It:
 
 - Creates `~/.flow/` (database, kb, projects, tasks, playbooks)
-- Writes the flow skill to `~/.claude/skills/flow/SKILL.md`
-- Adds a SessionStart hook to `~/.claude/settings.json` so every new
-  Claude Code session auto-loads the skill
+- Writes the flow skill to `~/.claude/skills/flow/SKILL.md` or
+  `~/.codex/skills/flow/SKILL.md`
+- Adds a SessionStart hook in the matching harness configuration so every
+  new Claude Code or Codex session auto-loads the skill
 
 The `xattr` step removes Gatekeeper's quarantine attribute so macOS
 doesn't refuse to run the unsigned binary.
@@ -218,25 +218,22 @@ handles the rest.
   you left off, even after a week away.
 - **Playbooks for cadence work.** Weekly reviews, daily triage,
   on-call rotations — define once, run on demand.
-- **A Claude skill that speaks plain English.** "What should I
+- **An agent skill that speaks plain English.** "What should I
   work on", "resume auth", "save a note" — the skill turns intent
   into flow commands.
 
 ## How it works under the hood
 
-`flow do <task>` pre-allocates a session UUID, writes it to the
-task row, and spawns a tab in zellij (when `$ZELLIJ` is set), kitty
+`flow do <task>` selects the task's pinned harness, records its session
+identifier, and spawns a tab in zellij (when `$ZELLIJ` is set), kitty
 (when `$KITTY_WINDOW_ID` is set or `$TERM=xterm-kitty`), the backend
 named in `$FLOW_TERM` (when set), or Warp / iTerm2 / stock
 Terminal.app (auto-detected from `$TERM_PROGRAM`) — chosen in that
-priority order, with iTerm as the historical fallback — running
-`claude --session-id <uuid>` with `FLOW_TASK` / `FLOW_PROJECT` inlined.
-The jsonl file lands at the deterministic path
-`~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`, so future
-`flow do` calls run `claude --resume <uuid>` to continue the same
-conversation. A SessionStart hook re-injects the task brief,
-updates, and CLAUDE.md context on every resume; a UserPromptSubmit
-hook keeps the flow skill discoverable in ad-hoc Claude sessions.
+priority order, with iTerm as the historical fallback. Claude sessions use
+an allocated UUID; Codex sessions mint a real thread with `codex exec --json`
+before flow opens `codex resume <thread-id>`. Future `flow do` calls resume
+the recorded conversation. A SessionStart hook re-injects the task brief,
+updates, and repository context on every resume.
 
 When `flow do <task>` is run for a task whose session is already
 live in another tab, flow focuses that tab instead of spawning a
@@ -398,8 +395,7 @@ and reinstall the skill + hook.
 
 Today flow runs on **macOS (iTerm2, Warp, stock Terminal.app, kitty,
 zellij, or Claude Code background agents via `FLOW_TERM=bg`) + Claude
-Code only**. That's the stack we use, and that's what the session-spawn
-layer was built and tested against. The background-agent backend is
+Code and Codex**. The background-agent backend is
 platform-agnostic (no terminal, no AppleScript) but Claude-only. zellij
 and kitty work on Linux too as a side effect — both are
 cross-platform and flow's zellij / kitty backends don't depend on
@@ -408,7 +404,7 @@ any macOS APIs. Kitty needs `allow_remote_control yes` (or
 from inside the running kitty instance.
 
 The architecture is portable — session spawning is one small
-package — but other harnesses (Codex, Cursor, plain shell) and other
+package — but other harnesses (Cursor, plain shell) and other
 terminals (Linux + tmux/wezterm, Windows Terminal) need contributors
 who run those stacks daily and care enough to wire them in. If that's
 you, [a PR is very welcome](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -235,6 +235,12 @@ before flow opens `codex resume <thread-id>`. Future `flow do` calls resume
 the recorded conversation. A SessionStart hook re-injects the task brief,
 updates, and repository context on every resume.
 
+To start an unbootstrapped task in a different supported harness, choose it
+explicitly: `flow do <task> --harness codex` (or `--harness claude`). This
+only selects the first session. Once a task has a session, its harness remains
+pinned so flow can safely resume the same transcript instead of transferring
+an in-progress task.
+
 When `flow do <task>` is run for a task whose session is already
 live in another tab, flow focuses that tab instead of spawning a
 duplicate. The source tab prints "Already open: `<slug>` — switched

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -87,7 +87,7 @@ func Run(args []string) int {
 }
 
 func printUsage() {
-	fmt.Println(`flow — personal task and Claude session manager
+	fmt.Println(`flow — personal task and agent-session manager
 
 Setup:
   flow init
@@ -100,8 +100,8 @@ Create:
   flow add task    "<name>" [--slug <s>] [--project <slug>] [--work-dir <path>] [--mkdir] [--priority h|m|l] [--due <date>]
 
 Sessions:
-  flow do                <ref> [--fresh] [--dangerously-skip-permissions]
-  flow do --auto         <ref>                 (run headlessly in the background; self-completes via flow done)
+  flow do                <ref> [--harness claude|codex] [--fresh] [--dangerously-skip-permissions]
+  flow do --auto         <ref> [--harness claude|codex] (run headlessly in the background; self-completes via flow done)
   flow done              <ref>
   flow hook session-start                      (SessionStart hook handler — wire via ~/.claude/settings.json)
 
@@ -123,8 +123,8 @@ Edit / mutate:
                             [--waiting "<who or what>"] [--clear-waiting]
                             [--tag <t> ...] [--remove-tag <t> ...] [--clear-tags]
   flow update project <ref> [--priority h|m|l]
-  flow do        <ref> [--fresh] [--dangerously-skip-permissions] [--force]   (spawn a new tab; --force overrides the live-session guard)
-  flow do --here <ref> [--force]                                              (bind THIS Claude session to the task; --force overwrites a prior binding)
+  flow do        <ref> [--harness claude|codex] [--fresh] [--dangerously-skip-permissions] [--force]   (choose harness only for a new task session; --force overrides the live-session guard)
+  flow do --here <ref> [--force]                                              (bind THIS harness session to the task; --force overwrites a prior binding)
   flow archive   <ref>
   flow unarchive <ref>
 
@@ -137,7 +137,7 @@ Workdirs:
 Playbooks:
   flow add playbook   "<name>" --work-dir <path> [--slug <s>] [--project <slug>] [--mkdir]
   flow run playbook   <slug> [--dangerously-skip-permissions]   (spawn a new tab)
-  flow run playbook   <slug> --here                              (bind THIS Claude session to the new run; no new tab)
+  flow run playbook   <slug> --here                              (bind THIS harness session to the new run; no new tab)
   flow run playbook   <slug> --auto                              (run the playbook headlessly in the background)
   flow show playbook  <ref>
   flow list playbooks [--project <slug>] [--include-archived]

--- a/internal/app/auto.go
+++ b/internal/app/auto.go
@@ -123,18 +123,24 @@ var processAlive = func(pid int) bool {
 }
 
 // autoChildEnv builds the environment for the detached supervisor. It
-// inherits the parent's environment (so PATH finds claude and FLOW_ROOT
-// points at the same store) but strips CLAUDE_CODE_SESSION_ID — that
-// belongs to the dispatch session, not the headless run, and leaking it
-// would confuse reverse-lookups inside the autonomous session.
+// inherits the parent's environment (so PATH finds the selected harness and
+// FLOW_ROOT points at the same store) but strips every registered harness
+// session id. Those ids belong to the dispatch session, not the headless run,
+// and leaking one would confuse reverse-lookups inside the autonomous session.
 func autoChildEnv() []string {
 	in := os.Environ()
 	out := make([]string, 0, len(in))
 	for _, kv := range in {
-		if strings.HasPrefix(kv, "CLAUDE_CODE_SESSION_ID=") {
-			continue
+		isSessionEnv := false
+		for _, h := range allHarnesses() {
+			if strings.HasPrefix(kv, h.SessionIDEnvVar()+"=") {
+				isSessionEnv = true
+				break
+			}
 		}
-		out = append(out, kv)
+		if !isSessionEnv {
+			out = append(out, kv)
+		}
 	}
 	return out
 }

--- a/internal/app/do.go
+++ b/internal/app/do.go
@@ -100,9 +100,10 @@ func cmdDo(args []string) int {
 	}
 	fs := flagSet("do")
 	fresh := fs.Bool("fresh", false, "discard existing session and re-bootstrap")
+	harnessName := fs.String("harness", "", "harness for a new task session (one of: "+registeredHarnessNames()+")")
 	dangerSkip := fs.Bool("dangerously-skip-permissions", false, "skip per-tool approval prompts in the spawned harness")
-	force := fs.Bool("force", false, "open even if the task's Claude session is already running elsewhere")
-	here := fs.Bool("here", false, "bind THIS Claude session to the task (no new tab); requires running inside a Claude Code session")
+	force := fs.Bool("force", false, "open even if the task's harness session is already running elsewhere")
+	here := fs.Bool("here", false, "bind THIS harness session to the task (no new tab); requires a supported harness session")
 	auto := fs.Bool("auto", false, "run headlessly in the background (no tab, no human); the session self-completes via `flow done`. Implies --dangerously-skip-permissions")
 	withInstr := fs.String("with", "", "inject `<instruction>` as the first user message after the bootstrap/resume")
 	withFile := fs.String("with-file", "", "inject 'read instructions at <path>' (mutually exclusive with --with)")
@@ -127,6 +128,10 @@ func cmdDo(args []string) int {
 	}
 	if injectionText != "" && *here {
 		fmt.Fprintln(os.Stderr, "error: --with/--with-file cannot be used with --here (no session is spawned to inject into)")
+		return 2
+	}
+	if *harnessName != "" && *here {
+		fmt.Fprintln(os.Stderr, "error: --harness cannot be used with --here (the current session's harness is already fixed)")
 		return 2
 	}
 
@@ -183,10 +188,23 @@ func cmdDo(args []string) int {
 	// before, task.harness is set and binding; otherwise detect from
 	// the current process's ambient harness env (so `flow do` from
 	// inside codex picks codex), falling back to claude.
-	h, err := harnessForSpawn(task)
+	h, err := harnessForExplicitSpawn(task, *harnessName)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
+	}
+	// A task can be bound to the thread that is running this very flow
+	// command (for example after `flow do --here`). Starting `codex resume`
+	// for that thread opens a second writer and Codex rejects it during TUI
+	// bootstrap. `ps` cannot reliably see the host-owned Codex process, so
+	// detect this direct identity match before the best-effort live-process
+	// guard below. --fresh is the explicit escape hatch for a new thread.
+	ambient := ambientHarness()
+	if !*fresh && task.SessionID.Valid && task.SessionID.String != "" &&
+		ambient != nil && ambient.Name() == h.Name() &&
+		strings.EqualFold(task.SessionID.String, currentSessionID()) {
+		fmt.Printf("Already open: %s — this is the current session\n", task.Slug)
+		return 0
 	}
 
 	// Background-agent mode ($FLOW_TERM=bg): spawn a terminal-free
@@ -528,6 +546,32 @@ func cmdDo(args []string) int {
 		fmt.Printf("Resumed %s (session %s)\n", task.Slug, sessionID)
 	}
 	return 0
+}
+
+// harnessForExplicitSpawn applies `flow do --harness <name>` to an
+// unbootstrapped task. Harness is intentionally a first-session choice: once
+// a task has a session id, its stored harness owns its transcript and resume
+// path. Changing it here would silently transfer an in-flight task, so the
+// explicit `--harness` selector refuses instead of acting like --force.
+func harnessForExplicitSpawn(task *flowdb.Task, requested string) (harness.Harness, error) {
+	if requested == "" {
+		return harnessForSpawn(task)
+	}
+	if task != nil && task.SessionID.Valid && task.SessionID.String != "" {
+		current, err := harnessForTask(task)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf(
+			"task %q already has a %s session; --harness only selects the first session for an unbootstrapped task",
+			task.Slug, current.Name(),
+		)
+	}
+	h, err := harnessByName(requested)
+	if err != nil {
+		return nil, fmt.Errorf("invalid --harness %q (available: %s)", requested, registeredHarnessNames())
+	}
+	return h, nil
 }
 
 // backgroundLauncherFor returns the harness's BackgroundLauncher

--- a/internal/app/do_test.go
+++ b/internal/app/do_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flow/internal/flowdb"
 	"flow/internal/harness/claude"
+	"flow/internal/harness/codex"
 	"flow/internal/iterm"
 	"flow/internal/spawner"
 	"io"
@@ -36,6 +37,15 @@ func stubNewUUID(t *testing.T, sid string) {
 	old := claude.NewUUID
 	claude.NewUUID = func() (string, error) { return sid, nil }
 	t.Cleanup(func() { claude.NewUUID = old })
+}
+
+func stubCodexProbe(t *testing.T, sid string) {
+	t.Helper()
+	old := codex.ProbeRunner
+	codex.ProbeRunner = func() ([]byte, error) {
+		return []byte(`{"type":"thread.started","thread_id":"` + sid + `"}`), nil
+	}
+	t.Cleanup(func() { codex.ProbeRunner = old })
 }
 
 // stubITerm replaces iterm.Runner with a counter + captured-script
@@ -131,6 +141,13 @@ func TestCmdDoLiveSessionGuard(t *testing.T) {
 	setupFlowRoot(t)
 	seedTask(t, "live-task")
 
+	// This exercises the Claude-specific live-process guard. Clear the
+	// ambient harness inherited from the test process (which may be Codex)
+	// so harnessForSpawn selects Claude as intended.
+	for _, h := range allHarnesses() {
+		t.Setenv(h.SessionIDEnvVar(), "")
+	}
+
 	const pinnedSID = "abcdef12-3456-4789-8abc-def012345678"
 	// Pre-bind the task to the pinned session so the live check has
 	// something to match against. (Without bootstrapping via cmdDo —
@@ -169,6 +186,103 @@ func TestCmdDoLiveSessionGuard(t *testing.T) {
 	}
 	if *count != 1 {
 		t.Errorf("iterm spawn count after --force = %d, want 1", *count)
+	}
+}
+
+// TestCmdDoCurrentSessionGuard covers the case ps cannot see: a task was
+// bound with `do --here`, then `do <task>` is invoked from that same active
+// Codex thread. Resuming it would create a second writer and Codex refuses
+// the TUI bootstrap, so this must be an idempotent no-op.
+func TestCmdDoCurrentSessionGuard(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "current-codex-task")
+
+	const sid = "019ff4b1-6162-7263-974f-f5f1866ad0fe"
+	db := openFlowDB(t)
+	if _, err := db.Exec(
+		`UPDATE tasks SET session_id=?, session_started=?, harness='codex' WHERE slug='current-codex-task'`,
+		sid, flowdb.NowISO(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+
+	for _, h := range allHarnesses() {
+		t.Setenv(h.SessionIDEnvVar(), "")
+	}
+	t.Setenv("CODEX_THREAD_ID", sid)
+	spawns, _ := stubITerm(t)
+	out := captureStdout(t, func() {
+		if rc := cmdDo([]string{"current-codex-task"}); rc != 0 {
+			t.Errorf("cmdDo rc=%d, want 0", rc)
+		}
+	})
+	if !strings.Contains(out, "Already open: current-codex-task — this is the current session") {
+		t.Errorf("cmdDo output = %q", out)
+	}
+	if *spawns != 0 {
+		t.Errorf("spawn count = %d, want 0", *spawns)
+	}
+}
+
+func TestCmdDoExplicitHarnessSelectsCodexForNewTask(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "explicit-codex")
+	for _, h := range allHarnesses() {
+		t.Setenv(h.SessionIDEnvVar(), "")
+	}
+	// Exercise the important cross-harness case: Claude is ambient, but the
+	// user explicitly asks flow to open this *new* task in Codex.
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "658bf2be-5ae3-4842-a8a4-e0d0b785514d")
+	const sid = "019ff4b1-6162-7263-974f-f5f1866ad0fe"
+	stubCodexProbe(t, sid)
+	_, script := stubITerm(t)
+
+	if rc := cmdDo([]string{"explicit-codex", "--harness", "codex"}); rc != 0 {
+		t.Fatalf("cmdDo rc=%d", rc)
+	}
+	db := openFlowDB(t)
+	defer db.Close()
+	task, err := flowdb.GetTask(db, "explicit-codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.Harness.String != "codex" || task.SessionID.String != sid {
+		t.Errorf("task = harness=%q session=%q, want codex/%q", task.Harness.String, task.SessionID.String, sid)
+	}
+	if !strings.Contains(script(), "codex resume "+sid) {
+		t.Errorf("spawn script did not resume Codex: %q", script())
+	}
+}
+
+func TestCmdDoExplicitHarnessRefusesStartedTask(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "started-task")
+	db := openFlowDB(t)
+	if _, err := db.Exec(
+		`UPDATE tasks SET harness='claude', session_id=?, session_started=? WHERE slug='started-task'`,
+		"658bf2be-5ae3-4842-a8a4-e0d0b785514d", flowdb.NowISO(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+	_, _ = stubITerm(t)
+	stderr := captureStderr(t)
+	if rc := cmdDo([]string{"started-task", "--harness", "codex"}); rc == 0 {
+		t.Fatal("cmdDo succeeded, want explicit harness refusal")
+	}
+	if got := stderr(); !strings.Contains(got, "only selects the first session") {
+		t.Errorf("stderr = %q", got)
+	}
+}
+
+func TestCmdDoRejectsHarnessWithHere(t *testing.T) {
+	stderr := captureStderr(t)
+	if rc := cmdDo([]string{"task", "--here", "--harness", "codex"}); rc != 2 {
+		t.Errorf("cmdDo rc=%d, want 2", rc)
+	}
+	if got := stderr(); !strings.Contains(got, "cannot be used with --here") {
+		t.Errorf("stderr = %q", got)
 	}
 }
 

--- a/internal/app/harness.go
+++ b/internal/app/harness.go
@@ -8,6 +8,7 @@ import (
 	"flow/internal/flowdb"
 	"flow/internal/harness"
 	"flow/internal/harness/claude"
+	"flow/internal/harness/codex"
 	"flow/internal/spawner"
 )
 
@@ -17,7 +18,7 @@ import (
 func allHarnesses() []harness.Harness {
 	return []harness.Harness{
 		claude.New(),
-		// codex.New(),    // wired when the codex adapter lands
+		codex.New(),
 		// gemini.New(),   // wired when the gemini adapter lands
 	}
 }

--- a/internal/app/harness_test.go
+++ b/internal/app/harness_test.go
@@ -170,7 +170,7 @@ func TestCmdDoRefusesUnsupportedHarnessPin(t *testing.T) {
 
 	// Simulate a future build having pinned the task.
 	db := openFlowDB(t)
-	if _, err := db.Exec(`UPDATE tasks SET harness='codex' WHERE slug='future-pin'`); err != nil {
+	if _, err := db.Exec(`UPDATE tasks SET harness='gemini' WHERE slug='future-pin'`); err != nil {
 		t.Fatal(err)
 	}
 	db.Close()
@@ -181,7 +181,7 @@ func TestCmdDoRefusesUnsupportedHarnessPin(t *testing.T) {
 		t.Fatalf("cmdDo rc=%d, want non-zero (unsupported pin should refuse)", rc)
 	}
 	got := stderr()
-	if !strings.Contains(got, "codex") || !strings.Contains(got, "isn't supported") {
+	if !strings.Contains(got, "gemini") || !strings.Contains(got, "isn't supported") {
 		t.Errorf("stderr should name the unsupported harness; got:\n%s", got)
 	}
 
@@ -190,8 +190,8 @@ func TestCmdDoRefusesUnsupportedHarnessPin(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if task.Harness.String != "codex" {
-		t.Errorf("refusal should preserve the pin; got %q, want codex",
+	if task.Harness.String != "gemini" {
+		t.Errorf("refusal should preserve the pin; got %q, want gemini",
 			task.Harness.String)
 	}
 	if task.SessionID.Valid {

--- a/internal/app/harness_test.go
+++ b/internal/app/harness_test.go
@@ -30,6 +30,52 @@ func TestAmbientHarness(t *testing.T) {
 	if got.Name() != harness.NameClaude {
 		t.Errorf("ambientHarness = %v, want claude", got.Name())
 	}
+
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "")
+	t.Setenv("CODEX_THREAD_ID", "019ff4b1-6162-7263-974f-f5f1866ad0fe")
+	got = ambientHarness()
+	if got == nil {
+		t.Fatal("ambientHarness with $CODEX_THREAD_ID set = nil, want codex")
+	}
+	if got.Name() != harness.NameCodex {
+		t.Errorf("ambientHarness = %v, want codex", got.Name())
+	}
+}
+
+func TestHarnessForSpawnPrefersCodexAmbient(t *testing.T) {
+	for _, h := range allHarnesses() {
+		t.Setenv(h.SessionIDEnvVar(), "")
+	}
+	t.Setenv("CODEX_THREAD_ID", "019ff4b1-6162-7263-974f-f5f1866ad0fe")
+	h, err := harnessForSpawn(&flowdb.Task{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h.Name() != harness.NameCodex {
+		t.Errorf("harnessForSpawn ambient=%q, want codex", h.Name())
+	}
+}
+
+func TestCmdDoHereBindsCodexSession(t *testing.T) {
+	setupFlowRoot(t)
+	seedTask(t, "codex-here")
+	for _, h := range allHarnesses() {
+		t.Setenv(h.SessionIDEnvVar(), "")
+	}
+	const sid = "019ff4b1-6162-7263-974f-f5f1866ad0fe"
+	t.Setenv("CODEX_THREAD_ID", sid)
+	if rc := cmdDoHere("codex-here", false); rc != 0 {
+		t.Fatalf("cmdDoHere rc=%d", rc)
+	}
+	db := openFlowDB(t)
+	defer db.Close()
+	task, err := flowdb.GetTask(db, "codex-here")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.Harness.String != "codex" || task.SessionID.String != sid || task.Status != "in-progress" {
+		t.Errorf("bound task = %+v, want codex/%s/in-progress", task, sid)
+	}
 }
 
 // TestHarnessForTask covers the column → adapter lookup. NULL and

--- a/internal/app/hook.go
+++ b/internal/app/hook.go
@@ -117,12 +117,12 @@ func appendStaleVersionHint() string {
 }
 
 // lookupBoundTask returns the task whose session_id matches
-// $CLAUDE_CODE_SESSION_ID, or nil if no such task exists, the env var
+// the active harness's session-id environment variable, or nil if no such task exists, the env var
 // is unset, or the DB lookup fails. Hook code must never fail loud — a
 // hook error blocks the user's session — so all errors are swallowed
 // and treated as "unbound".
 func lookupBoundTask() *flowdb.Task {
-	sid := os.Getenv("CLAUDE_CODE_SESSION_ID")
+	sid := currentSessionID()
 	if sid == "" {
 		return nil
 	}

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -141,7 +141,7 @@ Create
   flow add owner    "<name>" --work-dir <path> --every <dur> [--slug <s>] [--project <slug>] [--mkdir]
 
 Sessions
-  flow do               <ref> [--fresh] [--dangerously-skip-permissions] [--force]
+  flow do               <ref> [--harness claude|codex] [--fresh] [--dangerously-skip-permissions] [--force]
                               [--with "<instruction>" | --with-file <path>]
   flow do --here        <ref> [--force]   (bind THIS harness session to the task — no new tab)
   flow do --auto        <ref> [--with "<instruction>" | --with-file <path>]
@@ -406,6 +406,13 @@ X", or a bare `flow do --auto X`.
 3. On "no task matching", ask the user to clarify or offer `flow add task`.
 4. Pass `--fresh` ONLY if the user explicitly asked ("start over", "fresh
    session"). Never on your own.
+5. **Harness selection:** if the user explicitly asks to open an
+   unbootstrapped task in another harness (for example, "open auth in
+   Codex" while speaking from Claude Code), pass `--harness codex`.
+   Without that flag, flow selects the active harness automatically. This is
+   a first-session choice only: never offer `--harness` for a task that
+   already has a session or is in progress, because its harness is pinned to
+   preserve its transcript and resume path.
 
 **Autonomous mode (`--auto`):** launches a detached headless run instead
 of a tab, returns immediately, does the work end-to-end and calls `flow
@@ -824,9 +831,11 @@ Y?", stop and use the tool.
 
 ## 9. The execution-session bootstrap contract
 
-When `flow do <task>` spawns a session, it selects the task's pinned harness
-or the active one (`CODEX_THREAD_ID` → Codex; otherwise Claude Code by
-default). Claude Code accepts a flow-minted UUID. Codex first mints a real
+When `flow do <task>` spawns a session, it selects the task's pinned harness,
+the explicit first-session `--harness <claude|codex>` choice, or the active
+harness (`CODEX_THREAD_ID` → Codex; otherwise Claude Code by default).
+`--harness` is rejected once a task already has a session. Claude Code accepts
+a flow-minted UUID. Codex first mints a real
 thread with `codex exec --json`, then flow opens `codex resume <thread-id>`.
 The chosen harness and session id are stored before the interactive tab opens,
 so there is no self-registration step. Subsequent `flow do <same-task>` calls

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: flow
 description: |
-  Personal task and Claude session manager. CLI binary is `flow` (assumed
+  Personal task and agent-session manager. CLI binary is `flow` (assumed
   on PATH) and stores metadata in ~/.flow/flow.db (SQLite). Use this skill when the
   user asks about their work, tasks, or projects in any natural phrasing —
   including but not limited to: "what's left", "what's remaining",
@@ -17,7 +17,7 @@ description: |
   on", "blocked on", "stuck until", "mark done", "archive", "weekly
   review", "clean up my tasks", or when the user invokes any
   `flow <subcommand>` directly. Also use whenever the user asks you to
-  bootstrap a new Claude session on a task or tell them about their
+  bootstrap a new Claude Code or Codex session on a task or tell them about their
   in-flight work.
 ---
 
@@ -26,16 +26,16 @@ description: |
 ## 1. What flow is
 
 `flow` is a small CLI (assumed on `$PATH`) that the user uses to track
-personal work and bootstrap per-task Claude sessions. Metadata (projects,
+personal work and bootstrap per-task agent sessions. Metadata (projects,
 tasks, workdirs, session IDs) lives in a single SQLite database at
 `~/.flow/flow.db`. Free-form plan content lives on disk as markdown
 "briefs" at `~/.flow/projects/<slug>/brief.md` and
 `~/.flow/tasks/<slug>/brief.md`. Progress notes accumulate as dated
 markdown files under each entity's `updates/` subdirectory. The user runs
-one long-lived Claude session per task in its own terminal tab, resumed via
+one long-lived Claude Code or Codex session per task in its own terminal tab, resumed via
 `flow do <task>`.
 
-You are speaking inside one of those Claude sessions (or the user's
+You are speaking inside one of those agent sessions (or the user's
 ambient "dispatch" session). Your job is to interpret the user's natural
 language requests and turn them into the exact `flow` commands and file
 edits they imply. You never edit `flow.db` directly. You never solve
@@ -63,7 +63,7 @@ first; let them choose what happens next.
 
 1. In 2–3 sentences, describe what you can do for the user with
    flow under the hood — capture work as briefs, log progress
-   notes, resume Claude sessions across days, track what they're
+   notes, resume agent sessions across days, track what they're
    waiting on. Frame it as your capabilities, not commands. The
    user does not need to learn flow's CLI.
 2. Use `AskUserQuestion` (header: "What now?") to offer the main
@@ -89,7 +89,7 @@ an intent, follow the matching recipe instead of re-asking via §1a.
   (mandatory — project's, user-supplied, or auto-created
   `~/.flow/tasks/<slug>/workspace/` for floating tasks), priority, status
   (`backlog`/`in-progress`/`done`), optional `project_slug`, optional
-  `waiting_on` note, `brief.md`. A task carries a Claude `session_id` once
+  `waiting_on` note, `brief.md`. A task carries a harness `session_id` once
   `flow do` has bootstrapped it.
 - **Playbooks** are reusable, runnable definitions (name, slug, work_dir,
   optional `project_slug`, `brief.md`). Each invocation creates a
@@ -143,7 +143,7 @@ Create
 Sessions
   flow do               <ref> [--fresh] [--dangerously-skip-permissions] [--force]
                               [--with "<instruction>" | --with-file <path>]
-  flow do --here        <ref> [--force]   (bind THIS Claude session to the task — no new tab)
+  flow do --here        <ref> [--force]   (bind THIS harness session to the task — no new tab)
   flow do --auto        <ref> [--with "<instruction>" | --with-file <path>]
                               (run headlessly in the background — no tab, no human; the
                                session does the work and self-completes via `flow done`.
@@ -153,7 +153,7 @@ Sessions
 Playbook runs
   flow run playbook <slug> [--with "<instr>" | --with-file <path>]
                                     spawn a fresh run session (new task with kind=playbook_run)
-  flow run playbook <slug> --here   bind THIS Claude session to the new run (no new tab)
+  flow run playbook <slug> --here   bind THIS harness session to the new run (no new tab)
   flow run playbook <slug> --auto   run the playbook headlessly in the background (no tab, no human)
   flow list runs [<playbook-slug>]  list playbook runs (filter by playbook optional)
 
@@ -168,7 +168,7 @@ Owners (autonomous ownership — see §4.17)
   (scheduled ticks run headlessly; `flow owner tick` is the on-demand / guided-first-run path)
 
 Read
-  flow show task    [<ref>]     (no arg → reverse-lookup via $CLAUDE_CODE_SESSION_ID)
+  flow show task    [<ref>]     (no arg → reverse-lookup via the active harness session id)
   flow show project [<ref>]     (no arg → project of the bound task)
   flow show playbook    [<ref>]
   flow transcript   [<ref>] [--compact]    (readable transcript from session jsonl)
@@ -348,7 +348,7 @@ else already bound.
 - **Yes, in a new tab** — §4.4 `flow do <slug>` (spawns a tab, flips to
   in-progress). Pick when work hasn't started.
 - **Continue here (bind this session)** — run **`flow do --here <slug>`**
-  now (binds `$CLAUDE_CODE_SESSION_ID`, flips to in-progress, no tab).
+  now (binds the active harness session id, flips to in-progress, no tab).
   Pick when the work already began in this session — the common case when
   §4.14 triggered intake from the SessionStart intercept.
 - **No, keep in backlog** — save and stop.
@@ -421,7 +421,7 @@ stop — do NOT poll, tail the log, or peek at its separate session.
 
 **After `flow do` succeeds** it already spawned the tab and exported env
 vars. Report "opened tab: <title>" and stop. Do NOT: run diagnostics
-(`pgrep`, `ls ~/.claude/...`, `osascript`) to verify the tab; spawn a tab
+(`pgrep`, `osascript`) to verify the tab; spawn a tab
 yourself; re-run `flow do` unless asked; or peek into the new session (you
 have no access). If `flow do` errored (rc≠0), relay it and stop — no
 workarounds.
@@ -510,7 +510,7 @@ passes", "ready to ship", "all good now", "we're good", "that did
 it".
 
 **Why closing matters — `flow done` is not just a status flip.** It runs
-a headless Claude **close-out sweep** over the task's transcript that
+a headless harness **close-out sweep** over the task's transcript that
 distills durable facts into the KB (`~/.flow/kb/`) and, for a
 project-attached task, writes a project update summarizing what got done
 and why. **If a task never closes, that distillation never happens** —
@@ -737,10 +737,9 @@ naming the tag.
 
 **Triggers:** "bind this session to <task>", "track this session under
 <task>", "attach this conversation to <task>". To bind THIS session so future
-`flow do <slug>` resumes here, run `flow do --here <slug>` (reads
-`$CLAUDE_CODE_SESSION_ID`, flips backlog→in-progress). The safety invariants,
-the cwd-mismatch refusal sub-recipe, and the anti-patterns (never guess the
-UUID, never `cd && --here` or `--force` to bypass a cwd mismatch) → read
+`flow do <slug>` resumes here, run `flow do --here <slug>` (reads the active
+harness's session id, flips backlog→in-progress). The safety invariants and
+anti-patterns → read
 **references/binding.md**.
 ### 4.17 Owners (autonomous ownership)
 
@@ -825,16 +824,13 @@ Y?", stop and use the tool.
 
 ## 9. The execution-session bootstrap contract
 
-When `flow do <task>` spawns a Claude session in a new terminal tab, it
-pre-allocates a UUID, writes it to `tasks.session_id` before spawning,
-and passes it to `claude --session-id <uuid>`. This makes the session's
-jsonl file appear at the deterministic path
-`~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`. There is no
-self-registration step — the DB is authoritative from the moment the
-tab opens.
-
-Subsequent `flow do <same-task>` calls read that UUID and spawn
-`claude --resume <uuid>` to continue the same conversation.
+When `flow do <task>` spawns a session, it selects the task's pinned harness
+or the active one (`CODEX_THREAD_ID` → Codex; otherwise Claude Code by
+default). Claude Code accepts a flow-minted UUID. Codex first mints a real
+thread with `codex exec --json`, then flow opens `codex resume <thread-id>`.
+The chosen harness and session id are stored before the interactive tab opens,
+so there is no self-registration step. Subsequent `flow do <same-task>` calls
+resume the recorded conversation with that same harness.
 
 **If you are the execution session spawned by `flow do`:**
 
@@ -938,10 +934,10 @@ priority, assignee, due-date, waiting, and tag flags — → read
 is owned by `flow do` / `flow do --here`.
 ## 10. How "what task am I on?" gets answered
 
-`tasks.session_id` is the single source of truth. Every Claude Code
-session has `$CLAUDE_CODE_SESSION_ID` in its env (Claude Code injects
-it); flow's commands reverse-lookup this value against
-`tasks.session_id` to find the bound task. Two implications:
+`tasks.session_id` is the single source of truth. Claude Code exposes
+`$CLAUDE_CODE_SESSION_ID`; Codex exposes `$CODEX_THREAD_ID`. Flow detects the
+one active harness and reverse-looks up its value against `tasks.session_id`
+to find the bound task. Two implications:
 
 - `flow show task` with no argument resolves the bound task via
   reverse-lookup. So does `flow show project` (it resolves the bound

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -442,6 +442,14 @@ Read **references/do-advanced.md** when any of these apply:
 - The user wants to fire a one-off instruction at a task without opening the
   tab: `--with "<instruction>"` or `--with-file <path>` (also works on
   `flow run playbook`).
+
+#### Transfer a task to the other harness
+
+**Triggers:** "move X to codex", "switch X to claude", "reopen X in the
+other harness" — for a task that ALREADY has a session (harness pinned, so
+`--harness` is rejected). Read **references/harness-transfer.md** and follow
+it: progress note → `flow transcript` handoff file → un-pin via the scoped
+sqlite UPDATE → `flow do --harness <h> --with-file <handoff>`.
 ### 4.5 Save a progress note
 
 **Triggers:** "save a note", "log progress", "write an update", "note

--- a/internal/app/skill/references/binding.md
+++ b/internal/app/skill/references/binding.md
@@ -1,130 +1,36 @@
 # Bind an in-flight session to a task
 
-> Loaded on demand from the flow skill's resident core (SKILL.md). This file holds the full workflow; the core keeps a one-line trigger pointing here.
+> Loaded on demand from the flow skill's resident core (SKILL.md).
 
-### 4.16 Bind an in-flight Claude session to a task
+### 4.16 Bind an in-flight harness session to a task
 
-**Triggers:** "bind this session to <task>", "track this session
-under <task>", "attach this conversation to <task>", "this session is
-for <task>". Also fires when the user manually creates a flow task
-while already deep in an ad-hoc Claude session and wants future
-`flow do <slug>` to resume *this* conversation rather than start a
-new one. The §4.2 "Continue here" option is the most common entry
-point.
+**Triggers:** "bind this session to <task>", "track this session under
+<task>", "attach this conversation to <task>", or "this session is for
+<task>".
 
-**Recipe:** if the target task already exists (or you just created
-it via §4.2), run:
+Run:
 
 ```
 flow do --here <slug>
 ```
 
-`flow do --here` reads the current session's UUID from
-`$CLAUDE_CODE_SESSION_ID` (Claude Code injects this into every
-session), validates it, and writes it to `tasks.session_id`. Side
-effects: status flips backlog → in-progress (the session-id
-invariant requires it). No terminal spawn happens; the binding is
-the only mutation.
+Flow detects the active harness automatically: Claude Code exposes
+`$CLAUDE_CODE_SESSION_ID`; Codex exposes `$CODEX_THREAD_ID`. It validates the
+identifier, writes it to `tasks.session_id`, pins `tasks.harness`, and moves
+the task to `in-progress`. No terminal tab is spawned.
 
-**Safety properties enforced by the binary** (you don't have to
-police these):
+**Safety properties:**
 
-- Refuses if `$CLAUDE_CODE_SESSION_ID` is unset (not a Claude Code
-  session) or not a v4 UUID.
-- Refuses if **THIS session** is already bound to a different task.
-  `--force` does NOT override this — session_id uniqueness is
-  structural. The user must release the prior binding first or
-  open the target in a new tab via `flow do <slug>`.
-- Refuses if **the target task** already has a different
-  session_id bound. `--force` overrides this case (and only this
-  case), but the user has been told it orphans the target's
-  prior session.
-- Refuses if **this Claude session's spawn directory ≠
-  `task.work_dir`**. Flow maintains the invariant *any task with
-  a session_id has work_dir equal to the cwd that session was
-  created at* — that's what makes `flow do <slug>` resumes find
-  the harness's on-disk transcript (the path is keyed by encoded
-  cwd). The check is honest: the binary stats the expected
-  transcript file on disk, not `os.Getwd()`. **`cd <work_dir>
-  && flow do --here` does NOT bypass this** — the chained `cd`
-  only changes the flow subprocess's cwd, not where the actual
-  Claude session jsonl was written. `--force` does NOT override
-  this gate — see the sub-recipe below.
-- No-op (idempotent) if the target is already bound to this same
-  session.
-- Refuses if the target is `done`. Reopen via
-  `flow update task <slug> --status in-progress` first; the
-  prior session_id is preserved across done, so `--here` becomes
-  unnecessary after reopen.
+- Refuses when no supported harness session is active, when both harness ids
+  are present, or when the active id is malformed.
+- Refuses if this session is already bound to another task. `--force` does
+  not override that invariant.
+- Refuses if the target has another session unless the user explicitly passes
+  `--force`; doing so replaces flow's tracked transcript association.
+- Refuses a done task; reopen it first. A same-session bind is idempotent.
+- Claude Code validates that its cwd-keyed transcript belongs to the task's
+  `work_dir`; a `cd` inside a tool command cannot bypass that check. Codex
+  transcripts are keyed only by thread id, so no cwd validation is needed.
 
-**Cwd-mismatch sub-recipe:**
-
-When `flow do --here <slug>` exits non-zero with stderr
-containing "the harness transcript isn't where work_dir says",
-the binary stat'd the expected transcript path on disk and it
-didn't exist — meaning **the Claude session you're currently in
-was started in a directory other than `task.work_dir`.** This is
-a fact about the running Claude process, not about your current
-Bash shell cwd. Whatever directory you `cd` into now does NOT
-change where the session jsonl was written. The binary's check
-detects this and refuses; trying to retry from a different cwd
-won't help.
-
-Surface the choice via `AskUserQuestion` — do **not** auto-retry,
-and **do not run `cd <work_dir> && flow do --here <slug>`** in
-the hope of getting past the check. That doesn't work and will
-hit the same refusal:
-
-```
-AskUserQuestion({
-  questions: [{
-    question: "This Claude session was started in a different directory than task `<slug>`'s work_dir (<work_dir>). The session's on-disk transcript isn't where future `flow do` resumes would look. What do you want to do?",
-    header: "Cwd mismatch",
-    options: [
-      { label: "Open in a new tab (Recommended)",  description: "Run `flow do <slug>` to spawn a fresh Claude session at the task's work_dir. THIS session stays unbound and keeps doing whatever it was doing. Best when you weren't really working on the task here." },
-      { label: "Point work_dir at THIS session's directory", description: "If you actually want this Claude session to own the task, update the task's work_dir to wherever this Claude was started (you'll need to figure that out — try the cwd of the shell that launched Claude). I'll then retry --here. Allowed even when a session is already bound, but the new work_dir must match where the harness transcript actually lives." }
-    ],
-    multiSelect: false
-  }]
-})
-```
-
-On "Open in a new tab" → run `flow do <slug>` (no `--here`).
-THIS session stays unbound; the task gets its own new session
-at work_dir.
-
-On "Point work_dir at THIS session's directory" → ask the user
-what cwd Claude was started in (they typed `claude` from
-somewhere — that's the path). Then run
-`flow update task <slug> --work-dir <real-cwd>`, then
-`flow do --here <slug>`. The work_dir update will succeed only
-if the harness transcript is actually at the named path
-(binary validates by stat). If the user picks the wrong path,
-the update errors with "harness transcript isn't there"; ask
-them to try again.
-
-**Why "cd then retry" is NOT listed as an option:** the binary
-verifies the on-disk transcript path, which is fixed at Claude
-session start. Bash subprocess cwd is irrelevant. `cd
-<work_dir> && flow do --here` will produce the same refusal as
-`flow do --here` from anywhere else — it's not a workaround.
-
-**Anti-patterns:**
-
-- **Do not invent or guess the session UUID.** The env var is the
-  only authoritative source.
-- **Do not bind without confirming the task slug.** If multiple
-  tasks could plausibly own this conversation, AskUserQuestion to
-  pick.
-- **Do not try `cd <work_dir> && flow do --here` to bypass a
-  cwd-mismatch refusal.** The check stats the on-disk transcript
-  path; chained-cd doesn't change where the jsonl is. The binary
-  will refuse identically.
-- **Do not try `--force` to bypass a cwd-mismatch refusal.**
-  `--force` overrides "already bound to a different session"
-  but NOT the cwd invariant. Pick one of the two sub-recipe
-  remedies instead.
-- **Do not run `--here` from a different tab to attach a session
-  in another tab.** The env var is per-process; `--here` always
-  attaches the *current* session. To attach a session in another
-  tab, switch to that tab and run `flow do --here` there.
+Never invent or guess a session id. `--here` always binds the current tab's
+session; to bind a different tab, switch to that tab first.

--- a/internal/app/skill/references/commands-advanced.md
+++ b/internal/app/skill/references/commands-advanced.md
@@ -12,7 +12,7 @@ yours), use:
 flow transcript <sibling-task-slug>
 ```
 
-This outputs a readable conversation transcript from that task's Claude
+This outputs a readable conversation transcript from that task's harness
 session — user messages, assistant messages, tool calls, and results.
 Use `--compact` to omit tool results and thinking blocks for a shorter
 overview. Pipe through `grep` or `head` if the full transcript is too

--- a/internal/app/skill/references/do-advanced.md
+++ b/internal/app/skill/references/do-advanced.md
@@ -5,7 +5,7 @@
 #### Special case: live-session guard
 
 `flow do` refuses to spawn when the task's `session_id` is already
-running in another Claude process — typically because the user has the
+running in another process of the task's harness — typically because the user has the
 task's tab open elsewhere and forgot. The error names the running
 session ID and points at `--force`. When you see it:
 
@@ -29,7 +29,7 @@ right Settings pane. When you see that error:
 
 1. **Trust the error verbatim.** It says "Terminal" because macOS
    attributes Accessibility to the responsible parent app, which is
-   Terminal.app — NOT Claude Code, NOT the flow binary. Do not advise
+   Terminal.app — NOT Claude Code, Codex, or the flow binary. Do not advise
    the user to toggle "Claude" or "flow"; that wastes their time.
 2. **Open the Accessibility pane for them**: run
    `open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"`.
@@ -45,7 +45,7 @@ right Settings pane. When you see that error:
 Macros for this: do not invent more candidate apps to toggle, do not
 suggest the user reinstall flow, do not attempt to grant Accessibility
 yourself. macOS guards Accessibility deliberately — there is no CLI to
-self-grant it, and Claude cannot bypass that.
+self-grant it, and an agent cannot bypass that.
 
 #### Surgical instructions: `--with` and `--with-file`
 

--- a/internal/app/skill/references/do-advanced.md
+++ b/internal/app/skill/references/do-advanced.md
@@ -29,7 +29,7 @@ right Settings pane. When you see that error:
 
 1. **Trust the error verbatim.** It says "Terminal" because macOS
    attributes Accessibility to the responsible parent app, which is
-	Terminal.app — NOT Claude Code or Codex, and NOT the flow binary. Do not advise
+   Terminal.app — NOT Claude Code or Codex, and NOT the flow binary. Do not advise
    the user to toggle "Claude" or "flow"; that wastes their time.
 2. **Open the Accessibility pane for them**: run
    `open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"`.

--- a/internal/app/skill/references/do-advanced.md
+++ b/internal/app/skill/references/do-advanced.md
@@ -29,7 +29,7 @@ right Settings pane. When you see that error:
 
 1. **Trust the error verbatim.** It says "Terminal" because macOS
    attributes Accessibility to the responsible parent app, which is
-   Terminal.app — NOT Claude Code, Codex, or the flow binary. Do not advise
+	Terminal.app — NOT Claude Code or Codex, and NOT the flow binary. Do not advise
    the user to toggle "Claude" or "flow"; that wastes their time.
 2. **Open the Accessibility pane for them**: run
    `open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"`.

--- a/internal/app/skill/references/harness-transfer.md
+++ b/internal/app/skill/references/harness-transfer.md
@@ -1,0 +1,78 @@
+# Transfer a task between harnesses
+
+> Loaded on demand from the flow skill's resident core (SKILL.md). This file
+> holds the full workflow; the core keeps a one-line trigger pointing here.
+
+## When this applies
+
+A task's harness is pinned by its **first** session: `flow do --harness`
+is a first-session choice only, and once `tasks.session_id` is set the
+binary rejects `--harness` (even with `--fresh`) to protect the
+transcript and resume path. So "move this task from Claude to Codex"
+(or the reverse) has no single CLI command. This recipe is the reliable
+manual transfer. Triggers: "move X to codex", "switch X to claude",
+"transfer this task to the other harness", "reopen X in codex" when X
+already has a session.
+
+**Before starting, confirm via AskUserQuestion** (header "Transfer?",
+"Yes, transfer to <harness>" / "No, wait") — the old session becomes
+unreachable through flow afterwards, and step 3 is a direct DB edit.
+
+## The recipe (old harness → new harness)
+
+1. **Save a progress note first** (§4.5) under
+   `tasks/<slug>/updates/`. Updates are harness-agnostic files and every
+   bootstrap reads them — this is flow's native cross-harness memory
+   layer. For a task with lots of in-flight state, a "where things
+   stand + next step" note is worth more to the new session than the
+   raw transcript.
+
+2. **Export the conversation.** `flow transcript <slug>` works for
+   either harness. Write it to a handoff file in the task dir, e.g.
+   `~/.flow/tasks/<slug>/handoff-YYYY-MM-DD.md` (it will surface under
+   `other:` in `flow show task`, so the new session can re-find it).
+   Use `--compact` if the full transcript is huge:
+
+   ```
+   flow transcript <slug> --compact > ~/.flow/tasks/<slug>/handoff-YYYY-MM-DD.md
+   ```
+
+3. **Un-pin the harness** — the one non-CLI step. Clear the binding in
+   `~/.flow/flow.db` (substitute `$FLOW_ROOT` if set):
+
+   ```
+   sqlite3 ~/.flow/flow.db \
+     "UPDATE tasks SET session_id=NULL, harness=NULL, status='backlog' WHERE slug='<slug>';"
+   ```
+
+   The `status='backlog'` flip is required — a CHECK constraint
+   (`status = 'backlog' OR session_id IS NOT NULL`) forbids a
+   non-backlog task without a session. Backlog is also semantically
+   right: the task is "unbootstrapped" again.
+
+4. **Respawn in the target harness with the context injected:**
+
+   ```
+   flow do <slug> --harness <claude|codex> --with-file ~/.flow/tasks/<slug>/handoff-YYYY-MM-DD.md
+   ```
+
+   The new session bootstraps normally (brief + updates), then gets
+   "read instructions at <path>" as its first user message, so it
+   starts having read the prior conversation. Add
+   `--dangerously-skip-permissions` per the user's session-mode choice
+   (§4.4 step 1 still applies).
+
+## Caveats (tell the user)
+
+- The old session becomes unreachable through flow: its transcript file
+  survives on disk, but `flow do` will only ever resume the new
+  binding. It also never gets a close-out sweep — the handoff file and
+  progress note are what carry its knowledge forward.
+- The transcript is text, not state. The new session re-reads what
+  happened but inherits no tool results or working memory beyond what
+  the transcript captures.
+- This is an exception to the "never hand-edit flow.db" rule, scoped to
+  exactly the step-3 UPDATE. Do not generalize it to other fields, and
+  prefer a future `flow move <slug> --harness <h>` if the binary grows
+  one — check `flow do --help` / `flow --help` for it before using this
+  recipe.

--- a/internal/app/skill/references/setup.md
+++ b/internal/app/skill/references/setup.md
@@ -34,13 +34,13 @@ basics in this order:
    `AskUserQuestion` (header: "Open it now?", options:
    "Open it now" / "Later, just save") to ask whether to run
    `flow do <slug>`. Briefly explain in the question: a dedicated
-   Claude session gets the brief, updates, and repo conventions
+   agent session gets the brief, updates, and repo conventions
    automatically. If "Open it now", proceed to §4.4. If "Later",
    stop here.
 
 4. **Mention the knowledge base.** "As we work together, I'll
    automatically note durable facts about you and your org in
-   `~/.flow/kb/`. These notes carry across sessions so future Claude
+   `~/.flow/kb/`. These notes carry across sessions so future agent
    conversations have context without you repeating yourself."
 
 5. **Point to daily use.** "From any session, just say 'what should I

--- a/internal/app/skill/references/upgrade.md
+++ b/internal/app/skill/references/upgrade.md
@@ -27,8 +27,8 @@ via `AskUserQuestion`.
    one (typically at `/usr/local/bin/flow`; confirm with
    `which flow` if unsure).
 4. Run `flow skill update` to refresh the embedded skill on disk and
-   re-wire both the SessionStart and UserPromptSubmit hooks in
-   `~/.claude/settings.json`. (The auto-upgrade path runs the same
+   re-wire the supported hooks in the active harness configuration
+   (`~/.claude/settings.json` or `~/.codex/hooks.json`). (The auto-upgrade path runs the same
    refresh on the next `flow` invocation, but explicit is better and
    surfaces any errors immediately.)
 5. Run `flow --version` again and confirm the version changed. If it

--- a/internal/harness/codex/codex.go
+++ b/internal/harness/codex/codex.go
@@ -1,0 +1,220 @@
+// Package codex implements harness.Harness for the Codex CLI.
+package codex
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"flow/internal/harness"
+	"flow/internal/spawner"
+)
+
+var (
+	// ProbeRunner mints a persisted Codex thread. Tests replace it to avoid
+	// invoking the CLI.
+	ProbeRunner = runProbe
+	PSRunner    = runPS
+)
+
+func New() harness.Harness { return &codex{} }
+
+type codex struct{}
+
+func (c *codex) Name() harness.Name      { return harness.NameCodex }
+func (c *codex) Binary() string          { return "codex" }
+func (c *codex) SessionIDEnvVar() string { return "CODEX_THREAD_ID" }
+
+// Codex thread ids are lowercase UUIDs. Codex currently creates UUIDv7
+// threads, while older saved threads may use other RFC-4122 versions.
+var sessionIDRe = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+func (c *codex) NewSessionID() (string, error) {
+	out, err := ProbeRunner()
+	if err != nil {
+		return "", fmt.Errorf("mint Codex session: %w", err)
+	}
+	return parseThreadID(out)
+}
+
+func (c *codex) ValidateSessionID(s string) error {
+	if !sessionIDRe.MatchString(s) {
+		return fmt.Errorf("not a valid lowercase Codex UUID: %q", s)
+	}
+	return nil
+}
+
+// Codex stores transcripts by globally unique thread id, rather than cwd.
+func (c *codex) ValidateSession(workDir, sessionID string) error { return nil }
+
+func (c *codex) LaunchCmd(sessionID, prompt string, opts harness.LaunchOpts) string {
+	if opts.Inject != "" {
+		prompt += "\n\n" + harness.InjectionMarker + "\n" + opts.Inject
+	}
+	cmd := "codex"
+	if opts.SkipPermissions {
+		cmd += " --dangerously-bypass-approvals-and-sandbox"
+	}
+	return cmd + " resume " + sessionID + " " + spawner.ShellQuote(prompt)
+}
+
+func (c *codex) ResumeCmd(sessionID string, opts harness.LaunchOpts) string {
+	cmd := "codex"
+	if opts.SkipPermissions {
+		cmd += " --dangerously-bypass-approvals-and-sandbox"
+	}
+	cmd += " resume " + sessionID
+	if opts.Inject != "" {
+		cmd += " " + spawner.ShellQuote(harness.InjectionMarker+"\n"+opts.Inject)
+	}
+	return cmd
+}
+
+func (c *codex) SkipPermissionsRun(prompt string) error {
+	cmd := exec.Command("codex", "exec", "--dangerously-bypass-approvals-and-sandbox", prompt)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	return cmd.Run()
+}
+
+func (c *codex) AutoRunArgv(sessionID, prompt string, opts harness.LaunchOpts) []string {
+	if opts.Inject != "" {
+		prompt += "\n\n" + harness.InjectionMarker + "\n" + opts.Inject
+	}
+	argv := []string{"codex", "exec", "resume"}
+	if opts.SkipPermissions {
+		argv = append(argv, "--dangerously-bypass-approvals-and-sandbox")
+	}
+	return append(argv, sessionID, prompt)
+}
+
+func runProbe() ([]byte, error) {
+	// This probe intentionally persists its thread: the interactive `codex
+	// resume` started immediately afterwards must resume this exact id.
+	return exec.Command(
+		"codex", "exec", "--json", "--sandbox", "read-only",
+		"Reply exactly with OK. Do not make any changes.",
+	).Output()
+}
+
+func parseThreadID(out []byte) (string, error) {
+	scanner := bufio.NewScanner(strings.NewReader(string(out)))
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	for scanner.Scan() {
+		var event struct {
+			Type     string `json:"type"`
+			ThreadID string `json:"thread_id"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			continue
+		}
+		if event.Type == "thread.started" {
+			if err := New().ValidateSessionID(event.ThreadID); err != nil {
+				return "", fmt.Errorf("Codex probe returned invalid thread id: %w", err)
+			}
+			return event.ThreadID, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("read Codex probe output: %w", err)
+	}
+	return "", fmt.Errorf("Codex probe output did not include a thread.started event")
+}
+
+var runningSessionRe = regexp.MustCompile(`\bresume\s+([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\b`)
+
+func (c *codex) LiveSessionIDs() (map[string]int, error) {
+	out, err := PSRunner()
+	if err != nil {
+		return nil, err
+	}
+	live := map[string]int{}
+	for _, line := range strings.Split(string(out), "\n") {
+		if !strings.Contains(strings.ToLower(line), "codex") {
+			continue
+		}
+		seen := map[string]bool{}
+		for _, m := range runningSessionRe.FindAllStringSubmatch(line, -1) {
+			id := strings.ToLower(m[1])
+			if !seen[id] {
+				live[id]++
+				seen[id] = true
+			}
+		}
+	}
+	return live, nil
+}
+
+func runPS() ([]byte, error) { return exec.Command("ps", "-axo", "pid,command").Output() }
+
+func (c *codex) SkillInstallPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("no home dir: %w", err)
+	}
+	return filepath.Join(home, ".codex", "skills", "flow", "SKILL.md"), nil
+}
+
+func (c *codex) SkillVersionPath() (string, error) {
+	p, err := c.SkillInstallPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(filepath.Dir(p), "VERSION"), nil
+}
+
+func (c *codex) InstallSkill(files fs.FS) error {
+	p, err := c.SkillInstallPath()
+	if err != nil {
+		return err
+	}
+	base := filepath.Dir(p)
+	return fs.WalkDir(files, ".", func(rel string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		content, err := fs.ReadFile(files, rel)
+		if err != nil {
+			return fmt.Errorf("read embedded %s: %w", rel, err)
+		}
+		target := filepath.Join(base, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("create %s: %w", filepath.Dir(target), err)
+		}
+		return os.WriteFile(target, content, 0o644)
+	})
+}
+
+func (c *codex) UninstallSkill() error {
+	p, err := c.SkillInstallPath()
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(filepath.Dir(p)); os.IsNotExist(err) {
+		return nil
+	}
+	return os.RemoveAll(filepath.Dir(p))
+}
+
+func (c *codex) InstallSessionStartHook(command string) (bool, error) {
+	return installHook("SessionStart", "startup|resume", command)
+}
+
+func (c *codex) UninstallSessionStartHook(command string) (bool, error) {
+	return uninstallHook("SessionStart", command)
+}
+
+// Codex currently exposes SessionStart but no per-prompt equivalent to
+// Claude's UserPromptSubmit event. Keep the interface operation a no-op.
+func (c *codex) InstallUserPromptSubmitHook(command string) (bool, error)   { return false, nil }
+func (c *codex) UninstallUserPromptSubmitHook(command string) (bool, error) { return false, nil }

--- a/internal/harness/codex/codex.go
+++ b/internal/harness/codex/codex.go
@@ -99,7 +99,7 @@ func runProbe() ([]byte, error) {
 	// This probe intentionally persists its thread: the interactive `codex
 	// resume` started immediately afterwards must resume this exact id.
 	return exec.Command(
-		"codex", "exec", "--json", "--sandbox", "read-only",
+		"codex", "exec", "--json", "--sandbox", "read-only", "--skip-git-repo-check",
 		"Reply exactly with OK. Do not make any changes.",
 	).Output()
 }

--- a/internal/harness/codex/codex_test.go
+++ b/internal/harness/codex/codex_test.go
@@ -1,0 +1,138 @@
+package codex
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"flow/internal/harness"
+)
+
+const testThreadID = "019ff4b1-6162-7263-974f-f5f1866ad0fe"
+
+func TestNewSessionIDParsesThreadStarted(t *testing.T) {
+	orig := ProbeRunner
+	t.Cleanup(func() { ProbeRunner = orig })
+	ProbeRunner = func() ([]byte, error) {
+		return []byte("noise\n{\"type\":\"thread.started\",\"thread_id\":\"" + testThreadID + "\"}\n"), nil
+	}
+	got, err := New().NewSessionID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != testThreadID {
+		t.Errorf("NewSessionID=%q, want %q", got, testThreadID)
+	}
+}
+
+func TestNewSessionIDRejectsMissingOrInvalidThread(t *testing.T) {
+	orig := ProbeRunner
+	t.Cleanup(func() { ProbeRunner = orig })
+	ProbeRunner = func() ([]byte, error) { return []byte(`{"type":"thread.started","thread_id":"nope"}`), nil }
+	if _, err := New().NewSessionID(); err == nil {
+		t.Error("NewSessionID accepted invalid thread id")
+	}
+	ProbeRunner = func() ([]byte, error) { return []byte(`{"type":"turn.started"}`), nil }
+	if _, err := New().NewSessionID(); err == nil {
+		t.Error("NewSessionID accepted output without thread.started")
+	}
+	ProbeRunner = func() ([]byte, error) { return nil, errors.New("not installed") }
+	if _, err := New().NewSessionID(); err == nil {
+		t.Error("NewSessionID swallowed probe error")
+	}
+}
+
+func TestCommands(t *testing.T) {
+	h := New()
+	if got, want := h.LaunchCmd(testThreadID, "work", harness.LaunchOpts{}), "codex resume "+testThreadID+" 'work'"; got != want {
+		t.Errorf("LaunchCmd=%q, want %q", got, want)
+	}
+	if got := h.LaunchCmd(testThreadID, "work", harness.LaunchOpts{SkipPermissions: true}); !strings.HasPrefix(got, "codex --dangerously-bypass-approvals-and-sandbox resume ") {
+		t.Errorf("LaunchCmd skip=%q", got)
+	}
+	if got := h.ResumeCmd(testThreadID, harness.LaunchOpts{Inject: "follow up"}); !strings.Contains(got, harness.InjectionMarker+"\nfollow up") {
+		t.Errorf("ResumeCmd missing injection: %q", got)
+	}
+	argv := h.AutoRunArgv(testThreadID, "work", harness.LaunchOpts{SkipPermissions: true})
+	want := []string{"codex", "exec", "resume", "--dangerously-bypass-approvals-and-sandbox", testThreadID, "work"}
+	if strings.Join(argv, "\x00") != strings.Join(want, "\x00") {
+		t.Errorf("AutoRunArgv=%q, want %q", argv, want)
+	}
+}
+
+func TestLiveSessionIDs(t *testing.T) {
+	orig := PSRunner
+	t.Cleanup(func() { PSRunner = orig })
+	PSRunner = func() ([]byte, error) {
+		return []byte("100 codex resume " + testThreadID + "\n101 codex exec resume " + testThreadID + "\n102 grep resume " + testThreadID), nil
+	}
+	live, err := New().LiveSessionIDs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if live[testThreadID] != 2 {
+		t.Errorf("live=%v, want two Codex processes", live)
+	}
+}
+
+func TestRenderJSONL(t *testing.T) {
+	input := strings.Join([]string{
+		`{"type":"session_meta","payload":{"id":"` + testThreadID + `"}}`,
+		`{"type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"hidden"}]}}`,
+		`{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}}`,
+		`{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}}`,
+		`{"type":"response_item","payload":{"type":"custom_tool_call","name":"functions.exec","input":"ls"}}`,
+		`{"type":"response_item","payload":{"type":"custom_tool_call_output","output":"files"}}`,
+	}, "\n")
+	var out bytes.Buffer
+	if err := RenderJSONL(strings.NewReader(input), false, &out); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	for _, want := range []string{"─── User ───\nhello", "─── Assistant ───\nhi", "─── Tool: functions.exec ───\nls", "─── Result ───\nfiles"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("render missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "hidden") {
+		t.Errorf("rendered developer instruction: %s", got)
+	}
+	out.Reset()
+	if err := RenderJSONL(strings.NewReader(input), true, &out); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "files") {
+		t.Errorf("compact render included tool result: %s", out.String())
+	}
+}
+
+func TestSkillAndSessionStartHook(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	h := New()
+	files := os.DirFS(t.TempDir())
+	if err := h.InstallSkill(files); err != nil {
+		t.Fatalf("InstallSkill empty fs: %v", err)
+	}
+	// An empty filesystem still establishes the destination path through
+	// the harness's path methods, while hooks must be written separately.
+	if added, err := h.InstallSessionStartHook("flow hook session-start"); err != nil || !added {
+		t.Fatalf("InstallSessionStartHook added=%v err=%v", added, err)
+	}
+	if added, err := h.InstallSessionStartHook("flow hook session-start"); err != nil || added {
+		t.Fatalf("idempotent install added=%v err=%v", added, err)
+	}
+	raw, err := os.ReadFile(filepath.Join(home, ".codex", "hooks.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), "startup|resume") || !strings.Contains(string(raw), "flow hook session-start") {
+		t.Errorf("unexpected hooks file: %s", raw)
+	}
+	if removed, err := h.UninstallSessionStartHook("flow hook session-start"); err != nil || !removed {
+		t.Fatalf("UninstallSessionStartHook removed=%v err=%v", removed, err)
+	}
+}

--- a/internal/harness/codex/hooks.go
+++ b/internal/harness/codex/hooks.go
@@ -1,0 +1,139 @@
+package codex
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func hooksPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("no home dir: %w", err)
+	}
+	return filepath.Join(home, ".codex", "hooks.json"), nil
+}
+
+func installHook(event, matcher, command string) (bool, error) {
+	path, err := hooksPath()
+	if err != nil {
+		return false, err
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, fmt.Errorf("read %s: %w", path, err)
+		}
+		raw = []byte("{}")
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return false, fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+		}
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(raw, &settings); err != nil {
+		return false, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if settings == nil {
+		settings = map[string]any{}
+	}
+	hooks, _ := settings["hooks"].(map[string]any)
+	if hooks == nil {
+		hooks = map[string]any{}
+	}
+	entries, _ := hooks[event].([]any)
+	for _, entry := range entries {
+		m, _ := entry.(map[string]any)
+		inner, _ := m["hooks"].([]any)
+		for _, h := range inner {
+			hm, _ := h.(map[string]any)
+			if cmd, _ := hm["command"].(string); cmd == command {
+				return false, nil
+			}
+		}
+	}
+	entry := map[string]any{"hooks": []any{map[string]any{"type": "command", "command": command}}}
+	if matcher != "" {
+		entry["matcher"] = matcher
+	}
+	hooks[event] = append(entries, entry)
+	settings["hooks"] = hooks
+	return writeSettings(path, settings)
+}
+
+func uninstallHook(event, command string) (bool, error) {
+	path, err := hooksPath()
+	if err != nil {
+		return false, err
+	}
+	raw, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(raw, &settings); err != nil {
+		return false, fmt.Errorf("parse %s: %w", path, err)
+	}
+	hooks, _ := settings["hooks"].(map[string]any)
+	entries, _ := hooks[event].([]any)
+	if len(entries) == 0 {
+		return false, nil
+	}
+	changed := false
+	kept := make([]any, 0, len(entries))
+	for _, entry := range entries {
+		m, ok := entry.(map[string]any)
+		if !ok {
+			kept = append(kept, entry)
+			continue
+		}
+		inner, _ := m["hooks"].([]any)
+		filtered := make([]any, 0, len(inner))
+		for _, h := range inner {
+			hm, ok := h.(map[string]any)
+			if ok && strings.TrimSpace(stringValue(hm["command"])) == command {
+				changed = true
+				continue
+			}
+			filtered = append(filtered, h)
+		}
+		if len(filtered) == 0 {
+			changed = true
+			continue
+		}
+		m["hooks"] = filtered
+		kept = append(kept, m)
+	}
+	if !changed {
+		return false, nil
+	}
+	if len(kept) == 0 {
+		delete(hooks, event)
+	} else {
+		hooks[event] = kept
+	}
+	if len(hooks) == 0 {
+		delete(settings, "hooks")
+	} else {
+		settings["hooks"] = hooks
+	}
+	return writeSettings(path, settings)
+}
+
+func stringValue(v any) string { s, _ := v.(string); return s }
+
+func writeSettings(path string, settings map[string]any) (bool, error) {
+	out, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return false, fmt.Errorf("marshal %s: %w", path, err)
+	}
+	out = append(out, '\n')
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		return false, fmt.Errorf("write %s: %w", path, err)
+	}
+	return true, nil
+}

--- a/internal/harness/codex/transcript.go
+++ b/internal/harness/codex/transcript.go
@@ -1,0 +1,161 @@
+package codex
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// RenderTranscript finds Codex's sid-keyed rollout JSONL and renders its
+// response items into the same human-readable shape used by other harnesses.
+func (c *codex) RenderTranscript(_ string, sessionID string, compact bool, w io.Writer) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("no home dir: %w", err)
+	}
+	p, err := resolveTranscriptPath(filepath.Join(home, ".codex", "sessions"), sessionID)
+	if err != nil {
+		return err
+	}
+	f, err := os.Open(p)
+	if err != nil {
+		return fmt.Errorf("open Codex transcript %s: %w", p, err)
+	}
+	defer f.Close()
+	return RenderJSONL(f, compact, w)
+}
+
+func resolveTranscriptPath(root, sessionID string) (string, error) {
+	var matches []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !d.IsDir() && strings.HasSuffix(path, "-"+sessionID+".jsonl") {
+			matches = append(matches, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("scan Codex sessions under %s: %w", root, err)
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("Codex transcript not found: no rollout ending in %s under %s", sessionID, root)
+	}
+	newest := matches[0]
+	newestMod := int64(-1)
+	for _, p := range matches {
+		if fi, err := os.Stat(p); err == nil && fi.ModTime().UnixNano() > newestMod {
+			newest, newestMod = p, fi.ModTime().UnixNano()
+		}
+	}
+	return newest, nil
+}
+
+// RenderJSONL renders persisted Codex response_item records. Session metadata,
+// turn context, and provider events are intentionally omitted: they do not add
+// conversational context for `flow transcript` or the close-out sweep.
+func RenderJSONL(r io.Reader, compact bool, w io.Writer) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	first := true
+	for scanner.Scan() {
+		var rec struct {
+			Type    string          `json:"type"`
+			Payload json.RawMessage `json:"payload"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &rec); err != nil || rec.Type != "response_item" {
+			continue
+		}
+		var item struct {
+			Type    string          `json:"type"`
+			Role    string          `json:"role"`
+			Content []contentBlock  `json:"content"`
+			Name    string          `json:"name"`
+			Input   json.RawMessage `json:"input"`
+			Output  json.RawMessage `json:"output"`
+		}
+		if err := json.Unmarshal(rec.Payload, &item); err != nil {
+			continue
+		}
+		var rendered bool
+		switch item.Type {
+		case "message":
+			if item.Role == "developer" {
+				continue
+			}
+			label := "─── User ───"
+			if item.Role == "assistant" {
+				label = "─── Assistant ───"
+			}
+			for _, block := range item.Content {
+				if block.Text == "" {
+					continue
+				}
+				if !first && !rendered {
+					fmt.Fprintln(w)
+				}
+				fmt.Fprintln(w, label)
+				fmt.Fprintln(w, block.Text)
+				rendered = true
+			}
+		case "custom_tool_call":
+			if !first {
+				fmt.Fprintln(w)
+			}
+			fmt.Fprintf(w, "─── Tool: %s ───\n", item.Name)
+			fmt.Fprintln(w, formatJSON(item.Input))
+			rendered = true
+		case "custom_tool_call_output":
+			if compact {
+				continue
+			}
+			if !first {
+				fmt.Fprintln(w)
+			}
+			fmt.Fprintln(w, "─── Result ───")
+			fmt.Fprintln(w, truncate(formatJSON(item.Output), 500))
+			rendered = true
+		}
+		if rendered {
+			first = false
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("read Codex session: %w", err)
+	}
+	return nil
+}
+
+type contentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+func formatJSON(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	var text string
+	if json.Unmarshal(raw, &text) == nil {
+		return text
+	}
+	var v any
+	if json.Unmarshal(raw, &v) == nil {
+		if pretty, err := json.Marshal(v); err == nil {
+			return string(pretty)
+		}
+	}
+	return string(raw)
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
+}

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -34,6 +34,7 @@ type Name string
 
 const (
 	NameClaude Name = "claude"
+	NameCodex  Name = "codex"
 )
 
 // InjectionMarker prefixes any first-user-message text injected via


### PR DESCRIPTION
## Summary

- add a Codex harness adapter for session minting, resuming, hooks, transcript rendering, and live-session detection
- select Codex from `CODEX_THREAD_ID` and preserve correct session ownership for hooks and autonomous runs
- document Codex setup and lifecycle alongside Claude Code
- document the harness-transfer recipe as a lazy-loaded skill reference (`references/harness-transfer.md`): moving an already-bootstrapped task between Claude and Codex via transcript handoff + un-pin, since `--harness` is first-session-only

## Why

Flow had a pluggable harness contract but only registered Claude, so Codex sessions could not be bound, resumed, or rendered.

## Validation

- `go test -count=1 ./...`
- `make build`
- targeted Codex adapter and app binding tests