### PR TITLE
Pop-only inbox API, self-send gate, assignee 'self' -> 'user'

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -138,19 +138,14 @@ Edit / mutate:
 
 Message bus (directed + broadcast, CLI-only — see flow skill §4.18):
   flow message <assignee>[/<task-slug>] "<body>" [--urgent]
-                                     (message a human — pending + escalation schedule until
-                                      answered — or the session bound to a task; alias: msg)
-  flow inbox [--as <assignee>] [--json]        (what's pending; --as self = the human even in a
-                                                bound session; --as = any assignee's queue)
-  flow inbox pop [--wait] [--timeout <s>] [--as <assignee>] [--json]
-                                     (atomically consume the oldest, one at a time; --wait blocks
-                                      until mail arrives — park a Monitor on it; safe with
-                                      concurrent consumers)
-  flow inbox ack [<id>]              (answer by hand; replying in the sending session acks automatically)
-  flow inbox due [--as <assignee>] [--json]   (escalation feed for YOUR notifier script: prints
-                                      due messages, advances their backoff; flow ships no UI)
-  flow inbox stats                   (wait-time metrics)
+                                     (message a human — "user" is the local human — or the
+                                      session bound to a task; never your own address; alias: msg)
   flow broadcast "<one-liner>"       (fan out to whoever watches this task/project/assignee; alias: post)
+  flow inbox [--as <assignee>] [--json]           (what's pending; --as user = the human's queue)
+  flow inbox pop [--wait] [--timeout <s>] [--as <assignee>] [--json]
+                                     (THE consumption API: atomically consume the oldest — answers,
+                                      delivers, clears; loop it freely; --wait blocks until mail)
+  flow inbox stats                   (wait-time metrics)
   flow watch <task|project|assignee> [--as <assignee>] | --list | --rm <target>
 
 Workdirs:

--- a/internal/app/broadcast.go
+++ b/internal/app/broadcast.go
@@ -106,7 +106,7 @@ func taskTopics(t *flowdb.Task) []string {
 	if t.ProjectSlug.Valid && t.ProjectSlug.String != "" {
 		topics = append(topics, t.ProjectSlug.String)
 	}
-	assignee := busSelf
+	assignee := busUser
 	if t.Assignee.Valid && t.Assignee.String != "" {
 		assignee = t.Assignee.String
 	}

--- a/internal/app/bus_test.go
+++ b/internal/app/bus_test.go
@@ -47,29 +47,13 @@ func TestMessageHumanLifecycle(t *testing.T) {
 	mkBusTask(t, db, "task-a", "sid-msg-1")
 
 	out := captureStdout(t, func() {
-		if rc := cmdMessage([]string{"self", "need release approval"}); rc != 0 {
+		if rc := cmdMessage([]string{"user", "need release approval"}); rc != 0 {
 			t.Fatalf("message rc != 0")
 		}
 	})
-	if !strings.Contains(out, "messaged self") {
+	if !strings.Contains(out, "messaged user") {
 		t.Errorf("send output: %s", out)
 	}
-
-	// Human-directed messages are due for notification immediately.
-	out = captureStdout(t, func() {
-		if rc := cmdInbox([]string{"due"}); rc != 0 {
-			t.Fatalf("due rc != 0 on due message")
-		}
-	})
-	if !strings.Contains(out, "need release approval") {
-		t.Errorf("due output: %s", out)
-	}
-	// due advanced the schedule: nothing due now, exit 1.
-	captureStdout(t, func() {
-		if rc := cmdInbox([]string{"due"}); rc != 1 {
-			t.Errorf("second due should exit 1")
-		}
-	})
 
 	// The user replying in the sender session acks + reports the wait.
 	out = captureStdout(t, func() {
@@ -90,21 +74,21 @@ func TestMessageHumanLifecycle(t *testing.T) {
 
 func TestInboxPopConsumesOneAtATime(t *testing.T) {
 	setupFlowRoot(t)
-	t.Setenv("CLAUDE_CODE_SESSION_ID", "") // consume as the human
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "sid-p") // messages come from a bound session
 	db := openFlowDB(t)
-	mkBusTask(t, db, "task-a", "")
+	mkBusTask(t, db, "task-p", "sid-p")
 
 	captureStdout(t, func() {
-		if rc := cmdMessage([]string{"self", "first"}); rc != 0 {
+		if rc := cmdMessage([]string{"user", "first"}); rc != 0 {
 			t.Fatal("msg1")
 		}
-		if rc := cmdMessage([]string{"self", "second"}); rc != 0 {
+		if rc := cmdMessage([]string{"user", "second"}); rc != 0 {
 			t.Fatal("msg2")
 		}
 	})
 
 	out := captureStdout(t, func() {
-		if rc := cmdInbox([]string{"pop"}); rc != 0 {
+		if rc := cmdInbox([]string{"pop", "--as", "user"}); rc != 0 {
 			t.Fatalf("pop rc != 0")
 		}
 	})
@@ -112,18 +96,18 @@ func TestInboxPopConsumesOneAtATime(t *testing.T) {
 		t.Errorf("pop should consume exactly the oldest: %s", out)
 	}
 	// Popping a human-directed message ACKS it.
-	s, _ := flowdb.GetBusStats(db, "self")
+	s, _ := flowdb.GetBusStats(db, "user")
 	if s.Acked != 1 || s.Pending != 1 {
 		t.Errorf("after one pop: %+v", s)
 	}
 	captureStdout(t, func() {
-		if rc := cmdInbox([]string{"pop"}); rc != 0 {
+		if rc := cmdInbox([]string{"pop", "--as", "user"}); rc != 0 {
 			t.Fatalf("pop2 rc != 0")
 		}
 	})
 	// Empty inbox: exit 1 (script/Monitor friendly).
 	captureStdout(t, func() {
-		if rc := cmdInbox([]string{"pop"}); rc != 1 {
+		if rc := cmdInbox([]string{"pop", "--as", "user"}); rc != 1 {
 			t.Errorf("empty pop should exit 1")
 		}
 	})
@@ -133,7 +117,7 @@ func TestMessageBodyCapAndAddressErrors(t *testing.T) {
 	setupFlowRoot(t)
 	long := strings.Repeat("x", busBodyMax+1)
 	out := captureStdout(t, func() {
-		if rc := cmdMessage([]string{"self", long}); rc != 2 {
+		if rc := cmdMessage([]string{"user", long}); rc != 2 {
 			t.Errorf("overlong body rc != 2")
 		}
 	})
@@ -141,7 +125,7 @@ func TestMessageBodyCapAndAddressErrors(t *testing.T) {
 		t.Errorf("cap message: %s", out)
 	}
 	out = captureStdout(t, func() {
-		if rc := cmdMessage([]string{"self/nope-not-a-task", "hi"}); rc != 2 {
+		if rc := cmdMessage([]string{"user/nope-not-a-task", "hi"}); rc != 2 {
 			t.Errorf("bad task address rc != 2")
 		}
 	})
@@ -170,9 +154,9 @@ func TestBroadcastFanoutToWatchers(t *testing.T) {
 	}
 
 	for _, w := range [][2]string{
-		{"self/task-c", "task-a"},
-		{"self", "task-a"},
-		{"self/task-a", "task-a"}, // self-watch: must be skipped on fan-out
+		{"user/task-c", "task-a"},
+		{"user", "task-a"},
+		{"user/task-a", "task-a"}, // self-watch: must be skipped on fan-out
 	} {
 		if err := flowdb.AddWatch(db, w[0], w[1]); err != nil {
 			t.Fatal(err)
@@ -190,7 +174,7 @@ func TestBroadcastFanoutToWatchers(t *testing.T) {
 	if len(rows) != 1 || rows[0].Kind != "broadcast" || rows[0].FromTaskSlug != "task-a" {
 		t.Errorf("task-c inbox = %+v", rows)
 	}
-	if human, _ := flowdb.PendingForHuman(db, "self"); len(human) != 1 {
+	if human, _ := flowdb.PendingForHuman(db, "user"); len(human) != 1 {
 		t.Errorf("human feed = %+v", human)
 	}
 	if self, _ := flowdb.PendingForTask(db, "task-a"); len(self) != 0 {
@@ -232,20 +216,52 @@ func TestInboxAsAssigneeAndJSON(t *testing.T) {
 		t.Logf("status field: %s", m.Status)
 	}
 
-	// due --as --json for a fresh message to shashwat.
+	// list --as --json for a fresh message to shashwat.
 	captureStdout(t, func() {
 		if rc := cmdMessage([]string{"shashwat", "second thing"}); rc != 0 {
 			t.Fatalf("message rc != 0")
 		}
 	})
 	out = captureStdout(t, func() {
-		if rc := cmdInbox([]string{"due", "--as", "shashwat", "--json"}); rc != 0 {
-			t.Fatalf("due --as --json rc != 0")
+		if rc := cmdInbox([]string{"--as", "shashwat", "--json"}); rc != 0 {
+			t.Fatalf("inbox --as --json rc != 0")
 		}
 	})
 	var arr []busMsgJSON
 	if err := json.Unmarshal([]byte(out), &arr); err != nil || len(arr) != 1 {
-		t.Fatalf("due json = %v, %v\nraw: %s", arr, err, out)
+		t.Fatalf("inbox json = %v, %v\nraw: %s", arr, err, out)
+	}
+}
+
+func TestSelfSendGates(t *testing.T) {
+	setupFlowRoot(t)
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "sid-g")
+	db := openFlowDB(t)
+	mkBusTask(t, db, "task-g", "sid-g")
+
+	// A bound session must not message its own inbox.
+	out := captureStdout(t, func() {
+		if rc := cmdMessage([]string{"user/task-g", "note to myself"}); rc != 2 {
+			t.Errorf("own-inbox send should rc=2")
+		}
+	})
+	if !strings.Contains(out, "own inbox") {
+		t.Errorf("gate message: %s", out)
+	}
+	// An unbound human must not message their own queue.
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "")
+	out = captureStdout(t, func() {
+		if rc := cmdMessage([]string{"user", "hi me"}); rc != 2 {
+			t.Errorf("own-queue send should rc=2")
+		}
+	})
+	if !strings.Contains(out, "yourself") {
+		t.Errorf("gate message: %s", out)
+	}
+	var n int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM bus_messages`).Scan(&n)
+	if n != 0 {
+		t.Errorf("gated sends inserted rows")
 	}
 }
 
@@ -256,11 +272,11 @@ func TestWatchAsSelfSubscribesHuman(t *testing.T) {
 	mkBusTask(t, db, "task-a", "sid-w")
 
 	captureStdout(t, func() {
-		if rc := cmdWatch([]string{"task-a", "--as", "self"}); rc != 0 {
+		if rc := cmdWatch([]string{"task-a", "--as", "user"}); rc != 0 {
 			t.Fatalf("watch --as self rc != 0")
 		}
 	})
-	ws, _ := flowdb.ListWatches(db, "self")
+	ws, _ := flowdb.ListWatches(db, "user")
 	if len(ws) != 1 || ws[0] != "task-a" {
 		t.Errorf("--as self should subscribe as self: %v", ws)
 	}
@@ -312,7 +328,7 @@ func TestHookStopNudgesPostOnlyWithWatchers(t *testing.T) {
 		t.Errorf("no-watcher stop hook should emit nothing, got: %s", out)
 	}
 
-	if err := flowdb.AddWatch(db, "self", "task-a"); err != nil {
+	if err := flowdb.AddWatch(db, "user", "task-a"); err != nil {
 		t.Fatal(err)
 	}
 	ctx := busHookContext(t, stopHookOnce(t, false))
@@ -344,8 +360,8 @@ func TestHooksInformButNeverConsume(t *testing.T) {
 
 	if err := flowdb.InsertBusMessage(db, &flowdb.BusMessage{
 		ID: "msg00001", CreatedAt: flowdb.NowISO(), Kind: "message",
-		FromAssignee: "self", FromTaskSlug: "task-a",
-		ToAssignee: "self", ToTaskSlug: "task-b", Body: "your PR is unblocked",
+		FromAssignee: "user", FromTaskSlug: "task-a",
+		ToAssignee: "user", ToTaskSlug: "task-b", Body: "your PR is unblocked",
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -382,7 +398,7 @@ func TestHookStopSilentDuringHookContinuation(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_SESSION_ID", "sid-a")
 	db := openFlowDB(t)
 	mkBusTask(t, db, "task-a", "sid-a")
-	if err := flowdb.AddWatch(db, "self", "task-a"); err != nil {
+	if err := flowdb.AddWatch(db, "user", "task-a"); err != nil {
 		t.Fatal(err)
 	}
 	// Even with every nudge condition met, stop_hook_active must win.
@@ -407,7 +423,7 @@ func TestMessageRejectsFlagAddressAndClosedTasks(t *testing.T) {
 
 	// Flag in the address slot must be a usage error, not a queue named '--urgent'.
 	out := captureStdout(t, func() {
-		if rc := cmdMessage([]string{"--urgent", "self", "release blocked"}); rc != 2 {
+		if rc := cmdMessage([]string{"--urgent", "user", "release blocked"}); rc != 2 {
 			t.Errorf("flag-first should rc=2")
 		}
 	})
@@ -425,7 +441,7 @@ func TestMessageRejectsFlagAddressAndClosedTasks(t *testing.T) {
 		t.Fatal(err)
 	}
 	out = captureStdout(t, func() {
-		if rc := cmdMessage([]string{"self/task-z", "too late"}); rc != 2 {
+		if rc := cmdMessage([]string{"user/task-z", "too late"}); rc != 2 {
 			t.Errorf("done task should rc=2")
 		}
 	})

--- a/internal/app/bushooks.go
+++ b/internal/app/bushooks.go
@@ -72,7 +72,7 @@ func busPromptSubmitContext() string {
 
 	var b strings.Builder
 	if s.SessionID != "" {
-		acked, _ := flowdb.AckHumanMessagesFromSession(db, s.SessionID, busSelf, "prompt")
+		acked, _ := flowdb.AckHumanMessagesFromSession(db, s.SessionID, busUser, "prompt")
 		for _, m := range acked {
 			b.WriteString(fmt.Sprintf(
 				" flow-bus: the user has just returned — your message [%s] (%q) was answered after %s. "+
@@ -89,7 +89,7 @@ func busPromptSubmitContext() string {
 // humanPendingNotice renders the inform-only "the USER has mail" line
 // ("" when their queue is empty).
 func humanPendingNotice(db *sql.DB) string {
-	n, err := flowdb.PendingCountForHuman(db, busSelf)
+	n, err := flowdb.PendingCountForHuman(db, busUser)
 	if err != nil || n == 0 {
 		return ""
 	}

--- a/internal/app/inbox.go
+++ b/internal/app/inbox.go
@@ -15,16 +15,15 @@ import (
 //
 //	flow inbox [--as <assignee>] [--json]
 //	flow inbox pop [--wait] [--timeout <s>] [--as <assignee>] [--json]
-//	flow inbox ack [<id>] [--as <assignee>]
-//	flow inbox due [--as <assignee>] [--json]
 //	flow inbox stats [--as <assignee>]
 //
-// Identity is implicit: a bound session consumes as self/<task-slug>
-// (its own mail); an unbound/human invocation consumes as self.
+// Identity is implicit: a bound session consumes as user/<task-slug>
+// (its own mail); an unbound/human invocation consumes as user.
 // Override: --as <assignee> targets a human queue directly — `--as
-// self` is the user's own inbox even inside a bound session (e.g. a
+// user` is the human's own inbox even inside a bound session (e.g. a
 // dedicated inbox-monitor task); any other assignee serves monitor/
-// transport workers draining that queue.
+// transport workers draining that queue. pop is the ONLY consumption
+// API: it answers, delivers, and clears — one verb, loop it freely.
 //
 // `pop --wait` blocks until a message exists, pops exactly one, and
 // exits 0 — built to be parked on by a Claude session's Monitor tool or
@@ -40,10 +39,6 @@ func cmdInbox(args []string) int {
 	switch sub {
 	case "pop":
 		return inboxPop(rest)
-	case "ack":
-		return inboxAck(rest)
-	case "due":
-		return inboxDue(rest)
 	case "stats":
 		return inboxStats(rest)
 	case "ls", "list":
@@ -86,7 +81,6 @@ type busMsgJSON struct {
 	Body      string   `json:"body"`
 	Urgent    bool     `json:"urgent"`
 	Status    string   `json:"status"`
-	Attempts  int      `json:"attempts"`
 	WaitedS   float64  `json:"waited_s,omitempty"`
 }
 
@@ -101,7 +95,7 @@ func toMsgJSON(m *flowdb.BusMessage) busMsgJSON {
 		From: addrJSON{Assignee: m.FromAssignee, TaskSlug: m.FromTaskSlug},
 		To:   addrJSON{Assignee: m.ToAssignee, TaskSlug: m.ToTaskSlug},
 		Body: m.Body, Urgent: m.Urgent, Status: m.Status,
-		Attempts: m.Attempts, WaitedS: m.WaitedS,
+		WaitedS: m.WaitedS,
 	}
 }
 
@@ -151,11 +145,7 @@ func inboxList(args []string) int {
 		} else if m.Urgent {
 			mark = "⚠"
 		}
-		extra := ""
-		if m.Kind == "message" && m.ToTaskSlug == "" {
-			extra = fmt.Sprintf("  (notified %dx)", m.Attempts)
-		}
-		fmt.Printf("%s [%s] %s%s  %s: %s\n", mark, m.ID, busAge(m.CreatedAt, now), extra, busFrom(m), m.Body)
+		fmt.Printf("%s [%s] %s  %s: %s\n", mark, m.ID, busAge(m.CreatedAt, now), busFrom(m), m.Body)
 	}
 	fmt.Printf("\nconsume one at a time: flow inbox pop\n")
 	return 0
@@ -259,96 +249,6 @@ func inboxPop(args []string) int {
 		}
 		time.Sleep(2 * time.Second)
 	}
-}
-
-func inboxAck(args []string) int {
-	fs := flagSet("inbox ack")
-	as := consumerFlags(fs)
-	if err := fs.Parse(args); err != nil {
-		return 2
-	}
-	db, err := openBusDB()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		return 1
-	}
-	defer db.Close()
-	if rest := fs.Args(); len(rest) == 1 {
-		m, err := flowdb.AckMessageByID(db, rest[0], "manual")
-		if err != nil || m == nil {
-			fmt.Println("nothing to ack")
-			return 0
-		}
-		fmt.Printf("acked [%s] after %s: %s\n", m.ID, fmtBusWait(m.WaitedS), m.Body)
-		return 0
-	}
-	s := resolveConsumer(*as)
-	assignee := s.Assignee
-	rows, _ := flowdb.PendingForHuman(db, assignee)
-	acked := 0
-	for _, r := range rows {
-		if r.Kind != "message" {
-			continue
-		}
-		if m, _ := flowdb.AckMessageByID(db, r.ID, "manual"); m != nil {
-			fmt.Printf("acked [%s] after %s: %s\n", m.ID, fmtBusWait(m.WaitedS), m.Body)
-			acked++
-		}
-	}
-	if acked == 0 {
-		fmt.Println("nothing to ack")
-	}
-	return 0
-}
-
-// inboxDue is the escalation primitive for user notifier scripts: it
-// prints human-directed messages whose notify deadline has passed and
-// advances each row's backoff. Poll it from cron/a loop and pipe into
-// whatever notification UX you want. Prints nothing (exit 1) when
-// nothing is due. Default output is tab-separated (id, attempts, age,
-// urgent, from, body); --json emits an array.
-func inboxDue(args []string) int {
-	fs := flagSet("inbox due")
-	as := consumerFlags(fs)
-	asJSON := fs.Bool("json", false, "emit due messages as a JSON array")
-	if err := fs.Parse(args); err != nil {
-		return 2
-	}
-	db, err := openBusDB()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		return 1
-	}
-	defer db.Close()
-	assignee := resolveConsumer(*as).Assignee
-	now := time.Now()
-	due, err := flowdb.DueBusMessages(db, assignee, now)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		return 1
-	}
-	if len(due) == 0 {
-		return 1
-	}
-	for _, m := range due {
-		_ = flowdb.BumpNotifyAttempt(db, m.ID, m.Attempts, now)
-	}
-	if *asJSON {
-		out := make([]busMsgJSON, len(due))
-		for i, m := range due {
-			out[i] = toMsgJSON(m)
-		}
-		return emitJSON(out)
-	}
-	for _, m := range due {
-		urgent := "0"
-		if m.Urgent {
-			urgent = "1"
-		}
-		fmt.Printf("%s\t%d\t%s\t%s\t%s\t%s\n",
-			m.ID, m.Attempts, busAge(m.CreatedAt, now), urgent, busFrom(m), m.Body)
-	}
-	return 0
 }
 
 func inboxStats(args []string) int {

--- a/internal/app/message.go
+++ b/internal/app/message.go
@@ -16,15 +16,14 @@ import (
 //
 //	flow message <assignee>[/<task-slug>] "<body>" [--urgent]
 //
-// A bare assignee (e.g. `self`) addresses the human: the message stays
-// pending, on an escalating notify schedule (`flow inbox due`), until
-// the user answers (their next reply in the sending session acks it,
-// or `flow inbox ack`/`pop`). `<assignee>/<task-slug>` addresses the
-// session bound to that task: delivered into its context via hooks or
-// `flow inbox pop`, no escalation.
+// A bare assignee (`user` = the local human) addresses a person: the
+// message stays pending until answered (their next reply in the sending
+// session acks it, or they `flow inbox pop`). `<assignee>/<task-slug>`
+// addresses the session bound to that task. A sender can never message
+// its own address.
 //
-// flow draws no attention itself — notification UX is user scripting
-// on top of `flow inbox due` (see skill references/messaging.md).
+// flow draws no attention itself — notification UX is the user's own
+// polling of `flow inbox` (see skill references/messaging.md).
 func cmdMessage(args []string) int {
 	if len(args) < 2 {
 		fmt.Fprintln(os.Stderr, `usage: flow message <assignee>[/<task-slug>] "<body>" [--urgent]`)
@@ -65,25 +64,29 @@ func cmdMessage(args []string) int {
 		return 2
 	}
 	s := currentBusSender()
+	if toSlug != "" && toSlug == s.TaskSlug {
+		fmt.Fprintf(os.Stderr, "error: %s/%s is THIS session's own inbox — you are the one who would pop it. Message `user` for the human, or another task's address.\n", toAssignee, toSlug)
+		return 2
+	}
+	if toSlug == "" && s.TaskSlug == "" && toAssignee == s.Assignee {
+		fmt.Fprintln(os.Stderr, "error: that is your own queue — you would be messaging yourself. Use a task update or note instead.")
+		return 2
+	}
 
 	m := &flowdb.BusMessage{
 		ID: newBusID(), CreatedAt: flowdb.NowISO(), Kind: "message",
 		FromAssignee: s.Assignee, FromTaskSlug: s.TaskSlug, SenderSessionID: s.SessionID,
 		ToAssignee: toAssignee, ToTaskSlug: toSlug, Body: body, Urgent: *urgent,
 	}
-	if toSlug == "" {
-		// Human-directed: due for notification immediately, then backoff.
-		m.NextNotifyAt = time.Now().UTC().Format(time.RFC3339)
-	}
 	if err := flowdb.InsertBusMessage(db, m); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
 	}
 	if toSlug == "" {
-		if toAssignee != busSelf {
+		if toAssignee != busUser {
 			fmt.Printf("note: no cross-user transport yet — %q will see this only on this machine\n", toAssignee)
 		}
-		fmt.Printf("messaged %s [%s] — pending until answered (their reply in this session, `flow inbox pop`, or `flow inbox ack`)\n",
+		fmt.Printf("messaged %s [%s] — pending until answered (their reply in this session, or `flow inbox pop`)\n",
 			toAssignee, m.ID)
 	} else {
 		fmt.Printf("messaged session %s/%s [%s] — delivered on its next activity or pop\n",
@@ -93,9 +96,12 @@ func cmdMessage(args []string) int {
 	return 0
 }
 
-// busSelf is the assignee name for the local user. Tasks with a NULL
-// assignee belong to self; multi-user addressing rides on tasks.assignee.
-const busSelf = "self"
+// busUser is the reserved assignee for the local human ("user" — the
+// person driving flow). Tasks with a NULL assignee belong to them;
+// multi-user addressing rides on tasks.assignee. Deliberately not
+// "self": that spelling confused agents into reading `message self` as
+// talking to themselves.
+const busUser = "user"
 
 const busBodyMax = 200
 
@@ -124,7 +130,7 @@ type busSender struct {
 
 func currentBusSender() busSender {
 	return busSender{
-		Assignee:  busSelf,
+		Assignee:  busUser,
 		TaskSlug:  lookupBoundTaskSlug(),
 		SessionID: currentSessionID(),
 	}
@@ -161,7 +167,7 @@ func parseBusAddress(db *sql.DB, addr string) (string, string, error) {
 		if err := deliverableTask(t); err != nil {
 			return "", "", err
 		}
-		return busSelf, addr, nil
+		return busUser, addr, nil
 	}
 	return addr, "", nil
 }

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -767,41 +767,33 @@ tag contract, the orchestrate-never-execute rule, the tick procedure, and the
 `flow add owner` / `flow owner start` commands → read **references/owners.md**.
 ### 4.18 Message bus (directed + broadcast)
 
-Sessions call for the user's attention or message each other over flow's
-bus. Two send verbs with opposite semantics — never blend them:
+Sessions message the human or each other over flow's bus. Two send verbs,
+one consumption verb:
 
-- `flow message <assignee>[/<task-slug>] "<body>"` — DIRECTED. Bare
-  assignee (e.g. `self`) messages the human: it stays pending on an
-  escalating notify schedule until they answer; use ONLY when blocked on
-  their decision, a needed permission, or a finished long task they're
-  waiting on — never routine progress, never when they're clearly active
-  in this session. `--urgent` for truly blocking matters.
-  `<assignee>/<task-slug>` messages that task's session (context
-  delivery, no interruption). Bodies short (≤200 chars, lead with the
-  ask; mention a task slug or update-file path for context). ONE
-  message per wait — it
-  escalates itself; NEVER re-send. The user's next reply in this session
-  acks it and a hook injects how long you waited (re-verify stale state
-  after long waits).
+- `flow message <assignee>[/<task-slug>] "<body>"` — DIRECTED. `user`
+  (bare) messages the local human: it stays pending until they answer;
+  use ONLY when blocked on their decision, a needed permission, or a
+  finished long task they're waiting on — never routine progress, never
+  when they're clearly active in this session. `--urgent` for truly
+  blocking matters. `<assignee>/<task-slug>` messages that task's
+  session. You can NEVER message your own address (flow rejects it).
+  Bodies short (≤200 chars, lead with the ask; mention a task slug for
+  context). ONE message per wait — NEVER re-send. The user's next reply
+  in this session acks it and a hook injects how long you waited
+  (re-verify stale state after long waits).
 - `flow broadcast "<one-liner>"` — BROADCAST. FYI to whoever watches
   this task/project/assignee; never interrupts anyone; you never pick
   recipients. If someone specific must act, message them too.
-- Consuming: `flow inbox` lists, `flow inbox pop` consumes one at a
-  time. At session start arm ONE persistent **Monitor** (preferred) —
-  the loop is required, Monitor streams stdout lines as events:
-  `Monitor(command: 'while true; do flow inbox pop --wait --timeout 300
-  --json || true; done', persistent: true)` — every message arrives as
-  a wake event, no re-arming ever (--json stays silent on timeouts).
-  Fallback without Monitor: background Bash `flow inbox pop --wait`,
-  single-shot — re-arm after every wake. That listener is the delivery
-  path (no per-tool-call hook).
-  `--as <assignee>` consumes a human queue instead (`--as self` = the
-  user's inbox, e.g. for a dedicated inbox-monitor task); `--json` for
-  programmatic output.
-  `flow watch <task|project|assignee>` subscribes you — watch whatever
-  you depend on and any task you create from this session.
-- flow ships NO notification UI: the user scripts their own on top of
-  `flow inbox due`. Never assume a message visually alerted anyone.
+- `flow inbox pop` is THE consumption API — it answers, delivers, and
+  clears in one atomic verb; loop it freely. At session start arm ONE
+  persistent **Monitor**: `Monitor(command: 'while true; do flow inbox
+  pop --wait --timeout 300 --json || true; done', persistent: true)` —
+  every message wakes you as an event, no re-arming (--json is silent
+  on timeouts). Background Bash single-shot `pop --wait` is the
+  fallback (re-arm per wake). `flow watch <task|project|assignee>`
+  subscribes you — watch what you depend on and tasks you create.
+- flow ships NO notification UI and hooks NEVER consume — they only
+  report pending counts. Never assume a message visually alerted anyone.
 
 Full workflow, address grammar, etiquette → read **references/messaging.md**.
 

--- a/internal/app/skill/references/messaging.md
+++ b/internal/app/skill/references/messaging.md
@@ -2,59 +2,60 @@
 
 flow's bus lets a bound session (a) call for the user's attention,
 (b) message another task's session, and (c) broadcast one-liner updates
-to subscribers. One SQLite-backed inbox in flow.db, one delivery path:
-a parked `flow inbox pop --wait` listener (instant), with hooks at
-prompt-submit / session-start informing you of pending counts (hooks
-NEVER consume — only pop consumes). The bus is CLI-only by design: flow
-stores, addresses, schedules escalation, and measures waits — it never
-draws attention itself. Notification UX is the user's own scripting on
-top of `flow inbox due`.
+to subscribers. One SQLite-backed store in flow.db; `flow inbox pop` is
+the ONLY consumption API — one atomic verb that answers, delivers, and
+clears. Hooks NEVER consume; they only report pending counts. flow
+ships no notification UI: the user polls their own queue however they
+like.
 
 ## Address grammar
 
 `<assignee>[/<task-slug>]`
 
-- `self` — the local user (tasks with no assignee belong to self).
+- `user` — the local human (tasks with no assignee belong to them).
 - `rohit`, `shashwat`, … — other assignees (as used in `tasks.assignee`).
   NOTE: no cross-machine transport yet — a message to another assignee
   queues locally with a warning; delivery lands with flow-workspace.
 - `<assignee>/<task-slug>` — the SESSION bound to that task.
-- A bare task slug is sugar for `self/<slug>`.
+- A bare task slug is sugar for `user/<slug>`.
+- You can NEVER message your own address — a session cannot mail its own
+  inbox, and the human cannot mail their own queue (flow rejects both;
+  use a task update or note instead). Done/archived tasks are also
+  rejected (undeliverable).
 
 ## Messaging the human
 
 ```
-flow message self "coinswitch-gcp-migration: prod release plan ready, needs approval"
-flow message self "state bucket perms broken, blocked on your GCP login" --urgent
+flow message user "coinswitch-gcp-migration: prod release plan ready, needs approval"
+flow message user "state bucket perms broken, blocked on your GCP login" --urgent
 ```
 
-The message stays pending on an escalating schedule (due immediately,
-then 1m, 2m, 4m, 8m, 16m, capped at 30m — surfaced via `flow inbox due`
-to whatever notifier the user scripted) until answered. Discipline:
+The message stays pending until answered. Discipline:
 
 - Message when blocked on the user's decision, a permission only they
   can grant, a long task finishing that they wait on, or something they
   must know NOW. Never routine progress; never when they are actively
   replying in this session.
-- ONE pending message per wait. The schedule escalates it — re-sending
-  is noise.
+- ONE pending message per wait; NEVER re-send.
 - Body ≤200 chars; lead with the ask; mention the task slug or an
   update-file path in the body when the recipient needs context.
 - Ack is automatic: the user's next prompt in this session acks it and a
   hook injects "answered after <duration>" — factor that elapsed time in
   (long waits mean stale state: re-verify before acting). They can also
-  answer via `flow inbox pop` / `flow inbox ack`.
+  answer via `flow inbox pop --as user`.
+- `--urgent` is a data flag for the user's own tooling; flow attaches no
+  behavior to it.
 
 ## Messaging a peer session
 
 ```
-flow message self/tekion-hub-network "state file moved, re-read before release"
+flow message user/tekion-hub-network "state file moved, re-read before release"
 ```
 
 Delivered instantly if the session has a listener parked (below); a
 listener-less session is told the pending COUNT at its next prompt /
-session start and pops explicitly. Hooks never consume mail. Include
-what the peer should DO with the information.
+session start and pops explicitly. Include what the peer should DO with
+the information.
 
 ## Broadcasting and watching
 
@@ -62,46 +63,41 @@ what the peer should DO with the information.
 flow broadcast "imports done, 3 drifts left"     # from a bound session
 flow watch coinswitch-gcp-migration               # subscribe to one task
 flow watch alpha-cp                               # a whole project
-flow watch shashwat                               # everything an assignee's tasks post
+flow watch shashwat                               # everything an assignee's tasks broadcast
 flow watch --list / --rm <target>                 # inspect / unsubscribe
-flow watch <target> --as self                     # subscribe the USER, not this session
+flow watch <target> --as user                     # subscribe the USER, not this session
 ```
 
 Semantics: the broadcaster NEVER picks recipients. At broadcast time
 the one-liner fans out as a message to every CURRENT watcher of the
 task's slug, its project, or its assignee (new watchers don't receive
-older broadcasts). Broadcasts never escalate; if someone specific must
-act, message them as well.
+older broadcasts; your own subscription to your own task is skipped).
+Broadcasts never escalate; if someone specific must act, message them
+as well.
 
 At turn end a Stop hook nudges you to broadcast when the task has
 watchers and your last broadcast is >30 min old — broadcast only if the
 turn produced something a watcher would care about; skip freely.
 Declined nudges back off exponentially (30m, 1h, 2h.. capped 4h) and a
 broadcast resets the cycle, so skipping is cheap. Stop never touches
-your inbox: mail arriving mid-turn reaches you via your armed Monitor
-within seconds, or as a pending-count notice at your next prompt.
+your inbox.
 
-## Consuming: inbox and pop
+## Consuming: pop, the one verb
 
 ```
 flow inbox [--json]            # list pending (identity-aware)
-flow inbox pop [--json]        # consume the oldest, exit 1 if empty
+flow inbox pop [--json]        # atomically consume the oldest, exit 1 if empty
 flow inbox pop --wait --timeout 3600
-flow inbox pop --wait --as self  # a session monitoring the USER's inbox
+flow inbox pop --wait --as user  # a session monitoring the USER's queue
 flow inbox pop --as shashwat   # drain another assignee's queue (transport/monitor workers)
 ```
 
 Identity is implicit: a bound session consumes its own task's mail; an
-unbound/human invocation consumes the user's. `--as <assignee>`
-targets a human queue directly: `--as self` forces the user's own
-inbox from inside a bound session — e.g. a dedicated flow task whose
-job is monitoring the user's inbox — and any other assignee serves
-monitor/transport workers draining that queue. Pops are atomic claims, so
-concurrent consumers of one inbox (your terminal + a monitor task)
-never double-pop. `--json` on inbox/pop/due emits machine-readable
-rows for scripting. Popping a human-directed message ACKS it (popping
-is answering); broadcasts are marked delivered. Rows are never deleted
-by popping — they transition status and roll off later by count.
+unbound/human invocation consumes the user's. `--as <assignee>` targets
+a human queue directly. Pops are atomic claims, so concurrent consumers
+of one queue never double-pop. Popping a human-directed message ACKS it
+(popping is answering); broadcasts are marked delivered. Rows are never
+deleted by popping — they transition status and roll off later by count.
 
 To be WOKEN by mail instead of discovering it on your next tool call,
 arm a listener. PREFERRED — one persistent **Monitor** wrapping pop in
@@ -119,27 +115,29 @@ whole session with NO re-arming. FALLBACK when Monitor is unavailable
 (e.g. non-Claude harnesses): a background Bash command
 (`run_in_background: true`) running `flow inbox pop --wait` — that is
 single-shot (blocks, pops one, exits 0 and wakes you; exit 1 =
-timeout), so RE-ARM it after every wake. Keep one listener per
-identity. Also subscribe to the tasks you depend on or spawn:
-`flow watch <slug>` for anything you're waiting on, coordinating with,
-or any task you create from this session.
+timeout), so RE-ARM it after every wake. Also subscribe to the tasks
+you depend on or spawn: `flow watch <slug>`.
 
-## For the user: scripting notification UX
+## For the user: notification UX is yours
 
-flow ships no UI. `flow inbox due` prints human-directed messages whose
-notify deadline passed (tab-separated: id, attempts, age, urgent, from,
-body) and advances each row's backoff. Poll it from cron, a launchd
-job, or a shell loop and pipe into any notifier (terminal-notifier,
-OSC escapes, ntfy, Slack, say). Empty = exit 1, prints nothing.
+flow never notifies. Poll your queue from cron, a launchd job, a shell
+loop, or a dedicated monitor task, and pipe into any notifier
+(terminal-notifier, OSC escapes, ntfy, Slack, say):
+
+    flow inbox --as user --json     # non-destructive peek
+    flow inbox pop --wait --as user --json   # blocking consumer
+
+Reminder cadence and dedup are your script's business — flow keeps only
+the queue.
 
 ## Utilities
 
 ```
-flow inbox ack [<id>]   # answer by hand (no-arg acks all pending human messages)
 flow inbox stats        # answered/pending counts, avg/median/worst wait
 ```
 
 Retention is automatic and row-count based: the newest 1000 rollable
 rows are kept (consumed rows of any kind, plus broadcasts of any
-status — an unread broadcast is an FYI, not a debt). Only pending
-directed messages never expire.
+status). Only pending directed messages never expire. Task close-out
+(`flow done` / `flow archive`) removes the task's undeliverable rows,
+its watches, and its nudge stamp.

--- a/internal/flowdb/bus.go
+++ b/internal/flowdb/bus.go
@@ -38,8 +38,6 @@ CREATE TABLE IF NOT EXISTS bus_messages (
     body               TEXT NOT NULL,
     urgent             INTEGER NOT NULL DEFAULT 0,
     status             TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','delivered','acked')),
-    attempts           INTEGER NOT NULL DEFAULT 0,
-    next_notify_at     TEXT,
     delivered_at       TEXT,
     acked_at           TEXT,
     waited_s           REAL,
@@ -79,15 +77,12 @@ type BusMessage struct {
 	Body            string
 	Urgent          bool
 	Status          string
-	Attempts        int
-	NextNotifyAt    string
 	WaitedS         float64
 }
 
 const busMsgCols = `id, created_at, kind, from_assignee, COALESCE(from_task_slug,''),
     COALESCE(sender_session_id,''), to_assignee, COALESCE(to_task_slug,''), body,
-    urgent, status, attempts, COALESCE(next_notify_at,''),
-    COALESCE(waited_s,0)`
+    urgent, status, COALESCE(waited_s,0)`
 
 func queryBusMsgs(db *sql.DB, where string, args ...any) ([]*BusMessage, error) {
 	// rowid tiebreak: created_at is second-granularity RFC3339, so
@@ -104,7 +99,7 @@ func queryBusMsgs(db *sql.DB, where string, args ...any) ([]*BusMessage, error) 
 		var urgent int
 		if err := rows.Scan(&m.ID, &m.CreatedAt, &m.Kind, &m.FromAssignee, &m.FromTaskSlug,
 			&m.SenderSessionID, &m.ToAssignee, &m.ToTaskSlug, &m.Body,
-			&urgent, &m.Status, &m.Attempts, &m.NextNotifyAt, &m.WaitedS); err != nil {
+			&urgent, &m.Status, &m.WaitedS); err != nil {
 			return nil, err
 		}
 		m.Urgent = urgent == 1
@@ -113,8 +108,7 @@ func queryBusMsgs(db *sql.DB, where string, args ...any) ([]*BusMessage, error) 
 	return out, rows.Err()
 }
 
-// InsertBusMessage inserts one message row. next_notify_at should be
-// set only for kind=message to a human (its escalation schedule).
+// InsertBusMessage inserts one message row (always status=pending).
 func InsertBusMessage(db *sql.DB, m *BusMessage) error {
 	urgent := 0
 	if m.Urgent {
@@ -122,11 +116,11 @@ func InsertBusMessage(db *sql.DB, m *BusMessage) error {
 	}
 	_, err := db.Exec(`INSERT INTO bus_messages
         (id, created_at, kind, from_assignee, from_task_slug, sender_session_id,
-         to_assignee, to_task_slug, body, urgent, status, attempts, next_notify_at)
-        VALUES (?,?,?,?,?,?,?,?,?,?,'pending',0,?)`,
+         to_assignee, to_task_slug, body, urgent, status)
+        VALUES (?,?,?,?,?,?,?,?,?,?,'pending')`,
 		m.ID, m.CreatedAt, m.Kind, m.FromAssignee, NullIfEmpty(m.FromTaskSlug),
 		NullIfEmpty(m.SenderSessionID), m.ToAssignee, NullIfEmpty(m.ToTaskSlug),
-		m.Body, urgent, NullIfEmpty(m.NextNotifyAt))
+		m.Body, urgent)
 	return err
 }
 
@@ -182,20 +176,6 @@ func AckHumanMessagesFromSession(db *sql.DB, sessionID, toAssignee, by string) (
 	return acked, nil
 }
 
-// AckMessageByID acks one message by id. Returns the row, or nil when
-// it doesn't exist, isn't pending, or was claimed concurrently.
-func AckMessageByID(db *sql.DB, id, by string) (*BusMessage, error) {
-	rows, err := queryBusMsgs(db, `id=? AND status='pending'`, id)
-	if err != nil || len(rows) == 0 {
-		return nil, err
-	}
-	claimed, err := ClaimAcked(db, rows[0], by)
-	if err != nil || !claimed {
-		return nil, err
-	}
-	return rows[0], nil
-}
-
 // ClaimAcked atomically transitions one message pending→acked,
 // recording the wait. Returns false when another consumer claimed it
 // first. Together with ClaimDelivered this makes concurrent consumers
@@ -218,120 +198,6 @@ func waitedSeconds(createdAt string, now time.Time) float64 {
 		return 0
 	}
 	return now.Sub(t).Seconds()
-}
-
-// DueBusMessages returns pending human-directed messages whose
-// next_notify_at has passed — the primitive user notifier scripts poll
-// (`flow inbox due`). Callers bump each returned row.
-func DueBusMessages(db *sql.DB, assignee string, now time.Time) ([]*BusMessage, error) {
-	return queryBusMsgs(db,
-		`kind='message' AND status='pending' AND to_task_slug IS NULL AND to_assignee=?
-         AND next_notify_at IS NOT NULL AND next_notify_at <= ?`,
-		assignee, now.UTC().Format(time.RFC3339))
-}
-
-// BumpNotifyAttempt records one escalation firing: attempts+1 and the
-// next backoff deadline. attempts counts firings so far, so the delay
-// after the first firing is the base: 1m, 2m, 4m, 8m, 16m, then capped
-// at 30m. The exponent is clamped BEFORE shifting so unbounded attempts
-// can never overflow past the cap.
-func BumpNotifyAttempt(db *sql.DB, id string, attempts int, now time.Time) error {
-	delay := 30 * time.Minute
-	if attempts >= 0 && attempts < 5 {
-		delay = time.Duration(60<<uint(attempts)) * time.Second
-	}
-	_, err := db.Exec(`UPDATE bus_messages SET attempts=?, next_notify_at=? WHERE id=?`,
-		attempts+1, now.Add(delay).UTC().Format(time.RFC3339), id)
-	return err
-}
-
-// PendingCountForTask returns how many undelivered rows await a task's
-// session — the inform-only primitive hooks use (hooks never consume).
-func PendingCountForTask(db *sql.DB, slug string) (int, error) {
-	var n int
-	err := db.QueryRow(`SELECT COUNT(*) FROM bus_messages WHERE status='pending' AND to_task_slug=?`, slug).Scan(&n)
-	return n, err
-}
-
-// PendingCountForHuman is the human-queue equivalent.
-func PendingCountForHuman(db *sql.DB, assignee string) (int, error) {
-	var n int
-	err := db.QueryRow(`SELECT COUNT(*) FROM bus_messages
-        WHERE status='pending' AND to_assignee=? AND to_task_slug IS NULL`, assignee).Scan(&n)
-	return n, err
-}
-
-// AddWatch subscribes `watcher` (address form: "self" for the human,
-// "self/<task-slug>" for a session) to `watched` (task slug, project
-// slug, or assignee).
-func AddWatch(db *sql.DB, watcher, watched string) error {
-	_, err := db.Exec(`INSERT OR IGNORE INTO bus_watches (watcher, watched, created_at)
-        VALUES (?,?,?)`, watcher, watched, NowISO())
-	return err
-}
-
-// RemoveWatch unsubscribes. Returns whether a row was removed.
-func RemoveWatch(db *sql.DB, watcher, watched string) (bool, error) {
-	res, err := db.Exec(`DELETE FROM bus_watches WHERE watcher=? AND watched=?`, watcher, watched)
-	if err != nil {
-		return false, err
-	}
-	n, _ := res.RowsAffected()
-	return n > 0, nil
-}
-
-// ListWatches returns the watch targets for one watcher.
-func ListWatches(db *sql.DB, watcher string) ([]string, error) {
-	rows, err := db.Query(`SELECT watched FROM bus_watches WHERE watcher=? ORDER BY watched`, watcher)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var out []string
-	for rows.Next() {
-		var w string
-		if err := rows.Scan(&w); err != nil {
-			return nil, err
-		}
-		out = append(out, w)
-	}
-	return out, rows.Err()
-}
-
-// WatchersOf returns the distinct watcher addresses subscribed to any
-// of the given topics (a post's task slug, project slug, assignee).
-func WatchersOf(db *sql.DB, topics []string) ([]string, error) {
-	if len(topics) == 0 {
-		return nil, nil
-	}
-	q := `SELECT DISTINCT watcher FROM bus_watches WHERE watched IN (?` +
-		repeatPlaceholder(len(topics)-1) + `)`
-	args := make([]any, len(topics))
-	for i, t := range topics {
-		args[i] = t
-	}
-	rows, err := db.Query(q, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var out []string
-	for rows.Next() {
-		var w string
-		if err := rows.Scan(&w); err != nil {
-			return nil, err
-		}
-		out = append(out, w)
-	}
-	return out, rows.Err()
-}
-
-func repeatPlaceholder(n int) string {
-	s := ""
-	for i := 0; i < n; i++ {
-		s += ",?"
-	}
-	return s
 }
 
 // GetNudgeState returns when the Stop hook last nudged a task to post
@@ -410,6 +276,95 @@ func GetBusStats(db *sql.DB, assignee string) (*BusStats, error) {
 	return s, nil
 }
 
+// PendingCountForTask returns how many undelivered rows await a task's
+// session — the inform-only primitive hooks use (hooks never consume).
+func PendingCountForTask(db *sql.DB, slug string) (int, error) {
+	var n int
+	err := db.QueryRow(`SELECT COUNT(*) FROM bus_messages WHERE status='pending' AND to_task_slug=?`, slug).Scan(&n)
+	return n, err
+}
+
+// PendingCountForHuman is the human-queue equivalent.
+func PendingCountForHuman(db *sql.DB, assignee string) (int, error) {
+	var n int
+	err := db.QueryRow(`SELECT COUNT(*) FROM bus_messages
+        WHERE status='pending' AND to_assignee=? AND to_task_slug IS NULL`, assignee).Scan(&n)
+	return n, err
+}
+
+// AddWatch subscribes `watcher` (address form: "user" for the human,
+// "user/<task-slug>" for a session) to `watched` (task slug, project
+// slug, or assignee).
+func AddWatch(db *sql.DB, watcher, watched string) error {
+	_, err := db.Exec(`INSERT OR IGNORE INTO bus_watches (watcher, watched, created_at)
+        VALUES (?,?,?)`, watcher, watched, NowISO())
+	return err
+}
+
+// RemoveWatch unsubscribes. Returns whether a row was removed.
+func RemoveWatch(db *sql.DB, watcher, watched string) (bool, error) {
+	res, err := db.Exec(`DELETE FROM bus_watches WHERE watcher=? AND watched=?`, watcher, watched)
+	if err != nil {
+		return false, err
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
+// ListWatches returns the watch targets for one watcher.
+func ListWatches(db *sql.DB, watcher string) ([]string, error) {
+	rows, err := db.Query(`SELECT watched FROM bus_watches WHERE watcher=? ORDER BY watched`, watcher)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var w string
+		if err := rows.Scan(&w); err != nil {
+			return nil, err
+		}
+		out = append(out, w)
+	}
+	return out, rows.Err()
+}
+
+// WatchersOf returns the distinct watcher addresses subscribed to any
+// of the given topics (a broadcast's task slug, project slug, assignee).
+func WatchersOf(db *sql.DB, topics []string) ([]string, error) {
+	if len(topics) == 0 {
+		return nil, nil
+	}
+	q := `SELECT DISTINCT watcher FROM bus_watches WHERE watched IN (?` +
+		repeatPlaceholder(len(topics)-1) + `)`
+	args := make([]any, len(topics))
+	for i, t := range topics {
+		args[i] = t
+	}
+	rows, err := db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var w string
+		if err := rows.Scan(&w); err != nil {
+			return nil, err
+		}
+		out = append(out, w)
+	}
+	return out, rows.Err()
+}
+
+func repeatPlaceholder(n int) string {
+	s := ""
+	for i := 0; i < n; i++ {
+		s += ",?"
+	}
+	return s
+}
+
 // CleanupTaskBus removes a closed task's bus footprint — called from
 // `flow done` and `flow archive`. Deleted: PENDING rows addressed TO
 // the task (undeliverable — no session will ever pop them; without this
@@ -482,52 +437,20 @@ func SweepBus(db *sql.DB, now time.Time) error {
 	return nil
 }
 
-// migrateBusKindBroadcast rebuilds bus_messages on databases created
-// when the broadcast kind was still spelled 'post' (the CHECK
-// constraint pins the old value, and SQLite cannot ALTER a CHECK).
-func migrateBusKindBroadcast(db *sql.DB) error {
-	var ddl string
-	err := db.QueryRow(`SELECT sql FROM sqlite_master WHERE type='table' AND name='bus_messages'`).Scan(&ddl)
-	if err == sql.ErrNoRows {
-		return nil
+// migrateBusSelfToUser renames the reserved assignee 'self' to 'user'
+// in existing rows (the old spelling confused agents into reading
+// "message self" as talking to themselves). Idempotent and cheap; runs
+// on every open.
+func migrateBusSelfToUser(db *sql.DB) error {
+	for _, q := range []string{
+		`UPDATE bus_messages SET to_assignee='user' WHERE to_assignee='self'`,
+		`UPDATE bus_messages SET from_assignee='user' WHERE from_assignee='self'`,
+		`UPDATE bus_watches SET watcher='user' WHERE watcher='self'`,
+		`UPDATE bus_watches SET watcher='user' || substr(watcher, 5) WHERE watcher LIKE 'self/%'`,
+	} {
+		if _, err := db.Exec(q); err != nil {
+			return err
+		}
 	}
-	if err != nil {
-		return err
-	}
-	if !strings.Contains(ddl, "'post'") {
-		return nil
-	}
-	tx, err := db.Begin()
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
-	if _, err := tx.Exec(`ALTER TABLE bus_messages RENAME TO bus_messages_old`); err != nil {
-		return err
-	}
-	if _, err := tx.Exec(busDDL); err != nil {
-		return err
-	}
-	if _, err := tx.Exec(`INSERT INTO bus_messages
-        (id, created_at, kind, from_assignee, from_task_slug, sender_session_id,
-         to_assignee, to_task_slug, body, urgent, status, attempts,
-         next_notify_at, delivered_at, acked_at, waited_s, acked_by)
-        SELECT id, created_at,
-        CASE WHEN kind='post' THEN 'broadcast' ELSE kind END,
-        from_assignee, from_task_slug, sender_session_id, to_assignee, to_task_slug,
-        body, urgent, status, attempts, next_notify_at, delivered_at,
-        acked_at, waited_s, acked_by FROM bus_messages_old`); err != nil {
-		return err
-	}
-	if _, err := tx.Exec(`DROP TABLE bus_messages_old`); err != nil {
-		return err
-	}
-	// RENAME kept the old table's indexes under their original names, so
-	// the busDDL above skipped creating them on the new table; now that
-	// the DROP freed the names, run it again so the new table is indexed
-	// within this same transaction.
-	if _, err := tx.Exec(busDDL); err != nil {
-		return err
-	}
-	return tx.Commit()
+	return nil
 }

--- a/internal/flowdb/bus_test.go
+++ b/internal/flowdb/bus_test.go
@@ -22,15 +22,14 @@ func TestBusMessageLifecycle(t *testing.T) {
 
 	m := &BusMessage{
 		ID: "aaaa0001", CreatedAt: NowISO(), Kind: "message",
-		FromAssignee: "self", FromTaskSlug: "task-a", SenderSessionID: "sid-1",
-		ToAssignee: "self", Body: "need approval", Urgent: true,
-		NextNotifyAt: time.Now().Add(-time.Second).UTC().Format(time.RFC3339),
+		FromAssignee: "user", FromTaskSlug: "task-a", SenderSessionID: "sid-1",
+		ToAssignee: "user", Body: "need approval", Urgent: true,
 	}
 	if err := InsertBusMessage(db, m); err != nil {
 		t.Fatalf("insert: %v", err)
 	}
 
-	pending, err := PendingForHuman(db, "self")
+	pending, err := PendingForHuman(db, "user")
 	if err != nil || len(pending) != 1 {
 		t.Fatalf("PendingForHuman = %v, %v; want 1 row", pending, err)
 	}
@@ -38,40 +37,14 @@ func TestBusMessageLifecycle(t *testing.T) {
 		t.Errorf("row roundtrip mismatch: %+v", pending[0])
 	}
 
-	due, err := DueBusMessages(db, "self", time.Now())
-	if err != nil || len(due) != 1 {
-		t.Fatalf("DueBusMessages = %v, %v; want 1", due, err)
-	}
-	now := time.Now()
-	if err := BumpNotifyAttempt(db, m.ID, 0, now); err != nil {
-		t.Fatalf("bump: %v", err)
-	}
-	if due, _ = DueBusMessages(db, "self", now); len(due) != 0 {
-		t.Errorf("after bump, message should not be due yet")
-	}
-	// Off-by-one guard: the first re-notify lands at base 1m, not 2m.
-	if due, _ = DueBusMessages(db, "self", now.Add(61*time.Second)); len(due) != 1 {
-		t.Errorf("first backoff step should be 1m")
-	}
-	// Overflow guard: absurd attempts still cap at 30m, never negative.
-	if err := BumpNotifyAttempt(db, m.ID, 1000000, now); err != nil {
-		t.Fatalf("bump big: %v", err)
-	}
-	if due, _ = DueBusMessages(db, "self", now.Add(29*time.Minute)); len(due) != 0 {
-		t.Errorf("capped delay should not be due before 30m")
-	}
-	if due, _ = DueBusMessages(db, "self", now.Add(31*time.Minute)); len(due) != 1 {
-		t.Errorf("capped delay must be due after 30m (overflow would push it to never/always)")
-	}
-
-	acked, err := AckHumanMessagesFromSession(db, "sid-1", "self", "prompt")
+	acked, err := AckHumanMessagesFromSession(db, "sid-1", "user", "prompt")
 	if err != nil || len(acked) != 1 {
 		t.Fatalf("AckHumanMessagesFromSession = %v, %v; want 1", acked, err)
 	}
-	if pending, _ = PendingForHuman(db, "self"); len(pending) != 0 {
+	if pending, _ = PendingForHuman(db, "user"); len(pending) != 0 {
 		t.Errorf("acked message still pending")
 	}
-	s, err := GetBusStats(db, "self")
+	s, err := GetBusStats(db, "user")
 	if err != nil || s.Acked != 1 || s.Pending != 0 {
 		t.Errorf("stats = %+v, %v; want acked=1 pending=0", s, err)
 	}
@@ -81,8 +54,8 @@ func TestBusTaskInboxDeliver(t *testing.T) {
 	db := openBusTestDB(t)
 	if err := InsertBusMessage(db, &BusMessage{
 		ID: "bbbb0001", CreatedAt: NowISO(), Kind: "broadcast",
-		FromAssignee: "self", FromTaskSlug: "task-a",
-		ToAssignee: "self", ToTaskSlug: "task-b", Body: "fyi done",
+		FromAssignee: "user", FromTaskSlug: "task-a",
+		ToAssignee: "user", ToTaskSlug: "task-b", Body: "fyi done",
 	}); err != nil {
 		t.Fatalf("insert: %v", err)
 	}
@@ -106,26 +79,26 @@ func TestBusTaskInboxDeliver(t *testing.T) {
 func TestBusWatches(t *testing.T) {
 	db := openBusTestDB(t)
 	for _, w := range [][2]string{
-		{"self/task-b", "task-a"},
-		{"self", "proj-x"},
-		{"self/task-c", "someone-else"},
+		{"user/task-b", "task-a"},
+		{"user", "proj-x"},
+		{"user/task-c", "someone-else"},
 	} {
 		if err := AddWatch(db, w[0], w[1]); err != nil {
 			t.Fatalf("AddWatch(%v): %v", w, err)
 		}
 	}
-	if err := AddWatch(db, "self/task-b", "task-a"); err != nil { // dup: no-op
+	if err := AddWatch(db, "user/task-b", "task-a"); err != nil { // dup: no-op
 		t.Fatalf("dup AddWatch: %v", err)
 	}
-	got, err := WatchersOf(db, []string{"task-a", "proj-x", "self"})
+	got, err := WatchersOf(db, []string{"task-a", "proj-x", "user"})
 	if err != nil || len(got) != 2 {
 		t.Fatalf("WatchersOf = %v, %v; want 2 watchers", got, err)
 	}
-	ws, _ := ListWatches(db, "self/task-b")
+	ws, _ := ListWatches(db, "user/task-b")
 	if len(ws) != 1 || ws[0] != "task-a" {
 		t.Errorf("ListWatches = %v", ws)
 	}
-	removed, err := RemoveWatch(db, "self/task-b", "task-a")
+	removed, err := RemoveWatch(db, "user/task-b", "task-a")
 	if err != nil || !removed {
 		t.Errorf("RemoveWatch = %v, %v", removed, err)
 	}
@@ -135,14 +108,14 @@ func TestCleanupTaskBus(t *testing.T) {
 	db := openBusTestDB(t)
 	// Rows the cleanup must remove:
 	_ = InsertBusMessage(db, &BusMessage{ID: "to000001", CreatedAt: NowISO(), Kind: "message",
-		FromAssignee: "self", ToAssignee: "self", ToTaskSlug: "task-x", Body: "undeliverable"})
-	_ = AddWatch(db, "self/task-x", "other-task")
-	_ = AddWatch(db, "self", "task-x")
+		FromAssignee: "user", ToAssignee: "user", ToTaskSlug: "task-x", Body: "undeliverable"})
+	_ = AddWatch(db, "user/task-x", "other-task")
+	_ = AddWatch(db, "user", "task-x")
 	_ = RecordNudge(db, "task-x")
 	// Rows the cleanup must keep:
 	_ = InsertBusMessage(db, &BusMessage{ID: "fr000001", CreatedAt: NowISO(), Kind: "message",
-		FromAssignee: "self", FromTaskSlug: "task-x", ToAssignee: "self", Body: "still asks the human"})
-	_ = AddWatch(db, "self/task-y", "unrelated")
+		FromAssignee: "user", FromTaskSlug: "task-x", ToAssignee: "user", Body: "still asks the human"})
+	_ = AddWatch(db, "user/task-y", "unrelated")
 
 	if err := CleanupTaskBus(db, "task-x"); err != nil {
 		t.Fatalf("cleanup: %v", err)
@@ -150,7 +123,7 @@ func TestCleanupTaskBus(t *testing.T) {
 	if rows, _ := PendingForTask(db, "task-x"); len(rows) != 0 {
 		t.Errorf("undeliverable inbox rows survived")
 	}
-	if ws, _ := ListWatches(db, "self/task-x"); len(ws) != 0 {
+	if ws, _ := ListWatches(db, "user/task-x"); len(ws) != 0 {
 		t.Errorf("watches BY closed task survived: %v", ws)
 	}
 	if got, _ := WatchersOf(db, []string{"task-x"}); len(got) != 0 {
@@ -160,10 +133,10 @@ func TestCleanupTaskBus(t *testing.T) {
 		t.Errorf("nudge stamp survived")
 	}
 	// Pending question to the human must survive close-out.
-	if rows, _ := PendingForHuman(db, "self"); len(rows) != 1 || rows[0].ID != "fr000001" {
+	if rows, _ := PendingForHuman(db, "user"); len(rows) != 1 || rows[0].ID != "fr000001" {
 		t.Errorf("human-directed pending message did not survive: %v", rows)
 	}
-	if ws, _ := ListWatches(db, "self/task-y"); len(ws) != 1 {
+	if ws, _ := ListWatches(db, "user/task-y"); len(ws) != 1 {
 		t.Errorf("unrelated watch was deleted")
 	}
 }
@@ -175,19 +148,19 @@ func TestBusSweepRollsConsumedByCount(t *testing.T) {
 		id := NowISO() + string(rune('a'+i))
 		_ = InsertBusMessage(db, &BusMessage{
 			ID: id, CreatedAt: NowISO(), Kind: "message",
-			FromAssignee: "self", ToAssignee: "self", Body: "old"})
+			FromAssignee: "user", ToAssignee: "user", Body: "old"})
 		if _, err := db.Exec(`UPDATE bus_messages SET status='acked' WHERE id=?`, id); err != nil {
 			t.Fatal(err)
 		}
 	}
 	_ = InsertBusMessage(db, &BusMessage{
 		ID: "pend0001", CreatedAt: NowISO(), Kind: "message",
-		FromAssignee: "self", ToAssignee: "self", Body: "pending forever"})
+		FromAssignee: "user", ToAssignee: "user", Body: "pending forever"})
 	// A pending BROADCAST is rollable (FYI, not a debt) — unlike the
 	// pending directed message above.
 	_ = InsertBusMessage(db, &BusMessage{
 		ID: "bcst0001", CreatedAt: NowISO(), Kind: "broadcast",
-		FromAssignee: "self", ToAssignee: "self", Body: "unread fyi"})
+		FromAssignee: "user", ToAssignee: "user", Body: "unread fyi"})
 
 	if err := SweepBus(db, time.Now()); err != nil {
 		t.Fatalf("sweep: %v", err)
@@ -218,9 +191,9 @@ func TestAckScopedToRepliersOwnQueue(t *testing.T) {
 	db := openBusTestDB(t)
 	_ = InsertBusMessage(db, &BusMessage{
 		ID: "cccc0001", CreatedAt: NowISO(), Kind: "message",
-		FromAssignee: "self", SenderSessionID: "sid-x",
+		FromAssignee: "user", SenderSessionID: "sid-x",
 		ToAssignee: "shashwat", Body: "queued for someone else"})
-	acked, err := AckHumanMessagesFromSession(db, "sid-x", "self", "prompt")
+	acked, err := AckHumanMessagesFromSession(db, "sid-x", "user", "prompt")
 	if err != nil || len(acked) != 0 {
 		t.Fatalf("self reply acked another assignee's message: %v, %v", acked, err)
 	}

--- a/internal/flowdb/db.go
+++ b/internal/flowdb/db.go
@@ -255,9 +255,9 @@ func OpenDB(path string) (*sql.DB, error) {
 		db.Close()
 		return nil, fmt.Errorf("apply bus schema: %w", err)
 	}
-	if err := migrateBusKindBroadcast(db); err != nil {
+	if err := migrateBusSelfToUser(db); err != nil {
 		db.Close()
-		return nil, fmt.Errorf("migrate bus kind: %w", err)
+		return nil, fmt.Errorf("migrate bus assignee: %w", err)
 	}
 	// bus_nudges.attempts arrived after the table shipped; backfill it
 	// on databases created in between.


### PR DESCRIPTION
Follow-up simplification to #93 per design review:

- **`flow inbox pop` is the only consumption API.** `ack` and `due` subcommands removed, escalation machinery (notify schedule, backoff, attempts) deleted — reminder cadence is the user's notifier script's business (loop/cron `flow inbox --as user --json`). Ack-on-reply and wait metrics are unchanged (hook behavior, not API).
- **Self-send gate:** no sender can message its own address (session → own inbox, human → own queue) — that's always a confused agent.
- **Reserved assignee renamed `self` → `user`:** agents misread `message self` as talking to themselves. Existing rows migrate idempotently on open. The one-shot post→broadcast kind migration is deleted (no released DB needed it).
- Docs/skill rewritten; suite green; live DB migrated and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFGNJQo5xNBBrT7rZMuUTu