### PR TITLE
fix: flow message silently stored a flag as the body

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -139,7 +139,9 @@ Edit / mutate:
 Message bus (directed + broadcast, CLI-only — see flow skill §4.18):
   flow message <assignee>[/<task-slug>] "<body>" [--urgent]
                                      (message a human — pending + escalation schedule until
-                                      answered — or the session bound to a task; alias: msg)
+                                      answered — or the session bound to a task; alias: msg.
+                                      Flags may come in any order; the body is positional or
+                                      --body "<text>". Only --urgent/--body are flags.)
   flow inbox [--as <assignee>] [--json]        (what's pending; --as self = the human even in a
                                                 bound session; --as = any assignee's queue)
   flow inbox pop [--wait] [--timeout <s>] [--as <assignee>] [--json]

--- a/internal/app/bus_test.go
+++ b/internal/app/bus_test.go
@@ -405,19 +405,35 @@ func TestMessageRejectsFlagAddressAndClosedTasks(t *testing.T) {
 	db := openFlowDB(t)
 	mkBusTask(t, db, "task-z", "sid-z")
 
-	// Flag in the address slot must be a usage error, not a queue named '--urgent'.
-	out := captureStdout(t, func() {
-		if rc := cmdMessage([]string{"--urgent", "self", "release blocked"}); rc != 2 {
-			t.Errorf("flag-first should rc=2")
+	// A KNOWN flag before the address is now fine (order-independent): the
+	// first positional is the address, --urgent is recognized as a flag.
+	captureStdout(t, func() {
+		if rc := cmdMessage([]string{"--urgent", "self", "release blocked"}); rc != 0 {
+			t.Errorf("known flag before address should send, rc=%d", rc)
 		}
 	})
-	if !strings.Contains(out, "usage:") {
-		t.Errorf("expected usage error: %s", out)
+	var urgent int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM bus_messages WHERE urgent=1 AND body='release blocked'`).Scan(&urgent)
+	if urgent != 1 {
+		t.Errorf("flag-first urgent message not stored correctly")
 	}
-	var n int
-	_ = db.QueryRow(`SELECT COUNT(*) FROM bus_messages`).Scan(&n)
-	if n != 0 {
-		t.Errorf("bogus queue row was inserted")
+
+	// An UNKNOWN flag is a usage error (never a bogus '--bogus' queue) and
+	// inserts nothing — this is what stops garbage from reaching the bus.
+	var before int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM bus_messages`).Scan(&before)
+	out := captureStdout(t, func() {
+		if rc := cmdMessage([]string{"--bogus", "self", "x"}); rc != 2 {
+			t.Errorf("unknown flag should rc=2")
+		}
+	})
+	if !strings.Contains(out, "unknown flag") {
+		t.Errorf("expected unknown-flag error: %s", out)
+	}
+	var after int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM bus_messages`).Scan(&after)
+	if after != before {
+		t.Errorf("unknown-flag send inserted a row")
 	}
 
 	// Done/archived tasks are undeliverable addresses.
@@ -431,5 +447,60 @@ func TestMessageRejectsFlagAddressAndClosedTasks(t *testing.T) {
 	})
 	if !strings.Contains(out, "done") {
 		t.Errorf("expected done-task error: %s", out)
+	}
+}
+
+// A flag written before the body (the natural order, and the --body agents
+// invent) must never become the literal body. Regression for the silent
+// "body stored as --urgent / --body" corruption.
+func TestMessageParsingToleratesFlagOrderAndBodyFlag(t *testing.T) {
+	setupFlowRoot(t)
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "sid-src")
+	db := openFlowDB(t)
+	mkBusTask(t, db, "src", "sid-src")
+	mkBusTask(t, db, "tgt", "sid-tgt")
+
+	send := func(args ...string) int {
+		var rc int
+		_ = captureStdout(t, func() { rc = cmdMessage(args) })
+		return rc
+	}
+
+	if rc := send("tgt", "--urgent", "flag first body"); rc != 0 {
+		t.Fatalf("flag-first rc=%d", rc)
+	}
+	if rc := send("tgt", "--body", "named flag body"); rc != 0 {
+		t.Fatalf("--body rc=%d", rc)
+	}
+	if rc := send("tgt", "positional body", "--urgent"); rc != 0 {
+		t.Fatalf("positional rc=%d", rc)
+	}
+
+	got := map[string]bool{}
+	rows, _ := flowdb.PendingForTask(db, "tgt")
+	for _, m := range rows {
+		got[m.Body] = m.Urgent
+		if strings.HasPrefix(m.Body, "-") {
+			t.Fatalf("a flag leaked into the body: %q", m.Body)
+		}
+	}
+	if u, ok := got["flag first body"]; !ok || !u {
+		t.Fatalf("flag-first body/urgent wrong: %+v", got)
+	}
+	if _, ok := got["named flag body"]; !ok {
+		t.Fatalf("--body not stored: %+v", got)
+	}
+	if u, ok := got["positional body"]; !ok || !u {
+		t.Fatalf("positional body/urgent wrong: %+v", got)
+	}
+
+	// unknown flag errors and stores nothing new
+	before, _ := flowdb.PendingForTask(db, "tgt")
+	if rc := send("tgt", "--nope", "x"); rc == 0 {
+		t.Fatalf("unknown flag should error, not send")
+	}
+	after, _ := flowdb.PendingForTask(db, "tgt")
+	if len(after) != len(before) {
+		t.Fatalf("unknown-flag send stored a message")
 	}
 }

--- a/internal/app/message.go
+++ b/internal/app/message.go
@@ -15,6 +15,11 @@ import (
 // cmdMessage implements the directed half of the message bus:
 //
 //	flow message <assignee>[/<task-slug>] "<body>" [--urgent]
+//	flow message <assignee> --body "<body>" [--urgent]   (equivalent)
+//
+// Flags are order-independent and the body may be given positionally or
+// via --body/-m/--message; unknown flags are rejected rather than being
+// silently swallowed into the body.
 //
 // A bare assignee (e.g. `self`) addresses the human: the message stays
 // pending, on an escalating notify schedule (`flow inbox due`), until
@@ -26,24 +31,64 @@ import (
 // flow draws no attention itself — notification UX is user scripting
 // on top of `flow inbox due` (see skill references/messaging.md).
 func cmdMessage(args []string) int {
-	if len(args) < 2 {
-		fmt.Fprintln(os.Stderr, `usage: flow message <assignee>[/<task-slug>] "<body>" [--urgent]`)
+	// Tolerant, order-independent parsing so the natural ways agents write
+	// this all work: `... <addr> "body" --urgent`, `... <addr> --urgent
+	// "body"`, and the named `... <addr> --body "body"` (agents invent
+	// --body constantly). Previously the body was a blind positional, so a
+	// flag written before it became the literal body ("--urgent") and the
+	// real text was silently dropped. Unknown flags now error instead.
+	usage := `usage: flow message <assignee>[/<task-slug>] "<body>" [--urgent]   (body also accepts --body "<text>")`
+	var urgent, haveBody, rest bool
+	var bodyFlag string
+	var pos []string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case rest:
+			pos = append(pos, a)
+		case a == "--":
+			rest = true
+		case a == "--urgent" || a == "-urgent":
+			urgent = true
+		case a == "--body" || a == "-body" || a == "--message" || a == "-m" || a == "-b":
+			if i+1 >= len(args) {
+				fmt.Fprintln(os.Stderr, "error: --body needs a value")
+				return 2
+			}
+			bodyFlag, haveBody, i = args[i+1], true, i+1
+		case strings.HasPrefix(a, "--body="):
+			bodyFlag, haveBody = a[len("--body="):], true
+		case strings.HasPrefix(a, "--message="):
+			bodyFlag, haveBody = a[len("--message="):], true
+		case a != "-" && strings.HasPrefix(a, "-"):
+			fmt.Fprintf(os.Stderr, "error: unknown flag %q — the body is positional or use --body \"...\"; only --urgent is a flag\n%s\n", a, usage)
+			return 2
+		default:
+			pos = append(pos, a)
+		}
+	}
+	if len(pos) == 0 {
+		fmt.Fprintln(os.Stderr, usage)
 		return 2
 	}
-	addr, body := args[0], strings.TrimSpace(args[1])
-	if strings.HasPrefix(addr, "-") {
-		// A flag in the address slot would otherwise become a bogus
-		// assignee queue nobody ever reads. Positionals come first.
-		fmt.Fprintln(os.Stderr, `usage: flow message <assignee>[/<task-slug>] "<body>" [--urgent] (address and body before flags)`)
-		return 2
-	}
-	fs := flagSet("message")
-	urgent := fs.Bool("urgent", false, "mark as urgent (notifier scripts may escalate harder)")
-	if err := fs.Parse(args[2:]); err != nil {
-		return 2
+	addr := pos[0]
+	var body string
+	switch {
+	case haveBody:
+		body = strings.TrimSpace(bodyFlag)
+		if len(pos) > 1 {
+			fmt.Fprintln(os.Stderr, "error: body given twice (a positional and --body) — use one")
+			return 2
+		}
+	case len(pos) >= 2:
+		body = strings.TrimSpace(pos[1])
+		if len(pos) > 2 {
+			fmt.Fprintln(os.Stderr, `error: too many arguments — quote the whole body: flow message <addr> "your message" [--urgent]`)
+			return 2
+		}
 	}
 	if body == "" {
-		fmt.Fprintln(os.Stderr, "error: empty message body")
+		fmt.Fprintln(os.Stderr, "error: empty message body\n"+usage)
 		return 2
 	}
 	if len(body) > busBodyMax {
@@ -69,7 +114,7 @@ func cmdMessage(args []string) int {
 	m := &flowdb.BusMessage{
 		ID: newBusID(), CreatedAt: flowdb.NowISO(), Kind: "message",
 		FromAssignee: s.Assignee, FromTaskSlug: s.TaskSlug, SenderSessionID: s.SessionID,
-		ToAssignee: toAssignee, ToTaskSlug: toSlug, Body: body, Urgent: *urgent,
+		ToAssignee: toAssignee, ToTaskSlug: toSlug, Body: body, Urgent: urgent,
 	}
 	if toSlug == "" {
 		// Human-directed: due for notification immediately, then backoff.

--- a/internal/app/skill/SKILL.md
+++ b/internal/app/skill/SKILL.md
@@ -775,7 +775,9 @@ bus. Two send verbs with opposite semantics — never blend them:
   escalating notify schedule until they answer; use ONLY when blocked on
   their decision, a needed permission, or a finished long task they're
   waiting on — never routine progress, never when they're clearly active
-  in this session. `--urgent` for truly blocking matters.
+  in this session. `--urgent` for truly blocking matters. The body is
+  positional or `--body "<text>"`; flags may come in any order (only
+  `--urgent`/`--body` are flags — an unknown flag is rejected, not sent).
   `<assignee>/<task-slug>` messages that task's session (context
   delivery, no interruption). Bodies short (≤200 chars, lead with the
   ask; mention a task slug or update-file path for context). ONE


### PR DESCRIPTION
## The bug

`flow message` took the body as a blind positional (`args[1]`) with no flag-guard, and Go's `flag.Parse` stops at the first positional. So any flag written **before** the body became the literal body, and the real text (and `--urgent`) were silently dropped:

```
flow message tgt --urgent "real body"   → body stored = "--urgent"   (text lost, not urgent)
flow message tgt --body   "real body"   → body stored = "--body"     (text lost)
flow message tgt "real body" --urgent   → body = "real body", urgent=1   ✓ (only this exact order worked)
```

Agents hit this constantly — they write the flag first (natural CLI order) or invent a `--body` flag — so real messages were being corrupted and delivered as literal `--urgent` / `--body`, with no error.

## The fix

Rewrite the arg parser to be order-independent and give the body a real name:

- `--urgent` recognised anywhere in the args
- a real `--body` / `-m` / `--message` flag for the text (plus `--body=…`)
- `--` to end flag parsing (so a body may start with `-`)
- **unknown flags now error** instead of silently becoming the body

All three natural forms now work:

```
flow message tgt "body" --urgent
flow message tgt --urgent "body"
flow message tgt --body "body"
```

## Tests

- New `TestMessageParsingToleratesFlagOrderAndBodyFlag` covers flag-first, `--body`, positional, and the unknown-flag rejection (nothing stored).
- Updated `TestMessageRejectsFlagAddressAndClosedTasks`: a *known* flag before the address is now valid (address = first positional); the real protection is that *unknown* flags error. Closed/done-task rejection unchanged.
- Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)